### PR TITLE
Preserve pane when splitting by moving last tab

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -89,7 +89,10 @@ final class SplitViewController {
                     orientation: orientation,
                     first: .pane(paneState),
                     second: .pane(newPane),
-                    dividerPosition: 1.0,  // Start at edge (will animate to 0.5)
+                    // Keep the model at its steady-state ratio. The view layer can still animate
+                    // from an edge via animationOrigin, but the model should never represent a
+                    // fully-collapsed pane (which can get stuck under view reparenting timing).
+                    dividerPosition: 0.5,
                     animationOrigin: .fromSecond  // New pane slides in from right/bottom
                 )
 
@@ -144,21 +147,21 @@ final class SplitViewController {
                 // Start with divider at the edge so there's no flash before animation
                 let splitState: SplitState
                 if insertFirst {
-                    // New pane goes first (left or top) - starts at 0, animates to 0.5
+                    // New pane goes first (left or top).
                     splitState = SplitState(
                         orientation: orientation,
                         first: .pane(newPane),
                         second: .pane(paneState),
-                        dividerPosition: 0.0,
+                        dividerPosition: 0.5,
                         animationOrigin: .fromFirst
                     )
                 } else {
-                    // New pane goes second (right or bottom) - starts at 1, animates to 0.5
+                    // New pane goes second (right or bottom).
                     splitState = SplitState(
                         orientation: orientation,
                         first: .pane(paneState),
                         second: .pane(newPane),
-                        dividerPosition: 1.0,
+                        dividerPosition: 0.5,
                         animationOrigin: .fromSecond
                     )
                 }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -142,6 +142,7 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
                 size: size,
                 pane: pane,
                 controller: controller,
+                bonsplitController: bonsplitController,
                 activeDropZone: $activeDropZone,
                 dropLifecycle: $dropLifecycle
             ))
@@ -198,6 +199,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
     let size: CGSize
     let pane: PaneState
     let controller: SplitViewController
+    let bonsplitController: BonsplitController
     @Binding var activeDropZone: DropZone?
     @Binding var dropLifecycle: PaneDropLifecycle
 

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -363,7 +363,11 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 // (window resizes, view reparenting, pane↔split structural updates), the model's
                 // dividerPosition should remain stable; syncPosition() will keep the view aligned.
                 guard wasDragging else {
-                    Task { @MainActor in
+                    let statePosition = self.splitState.dividerPosition
+                    DispatchQueue.main.async {
+                        // NSSplitView may resize subviews in a way that drifts away from our
+                        // normalized dividerPosition. Re-assert the model ratio.
+                        self.syncPosition(statePosition, in: splitView)
                         self.onGeometryChange?(false)
                     }
                     return


### PR DESCRIPTION
When splitting a pane by moving its last tab (drag-to-edge / programmatic), keep the original pane alive by inserting a placeholder tab instead of leaving it tabless. This prevents empty-pane edge cases and keeps the split closable via tab close.