### PR TITLE
Avoid split collapse by keeping arranged subviews stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ playground.xcworkspace
 
 # Archives
 *.xcarchive
+
+# Local build output
+build/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alasdair Monk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -17,6 +17,11 @@ final class SplitViewController {
     /// Source pane of the dragging tab
     var dragSourcePaneId: PaneID?
 
+    /// During drop, SwiftUI may keep the source tab view alive briefly (default removal animation)
+    /// even after we've updated the model. Hide it explicitly so it disappears immediately.
+    var dragHiddenSourceTabId: UUID?
+    var dragHiddenSourcePaneId: PaneID?
+
     /// Current frame of the entire split view container
     var containerFrame: CGRect = .zero
 

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -89,7 +89,10 @@ final class SplitViewController {
                     orientation: orientation,
                     first: .pane(paneState),
                     second: .pane(newPane),
-                    dividerPosition: 1.0,  // Start at edge (will animate to 0.5)
+                    // Keep the model at its steady-state ratio. The view layer can still animate
+                    // from an edge via animationOrigin, but the model should never represent a
+                    // fully-collapsed pane (which can get stuck under view reparenting timing).
+                    dividerPosition: 0.5,
                     animationOrigin: .fromSecond  // New pane slides in from right/bottom
                 )
 
@@ -144,21 +147,21 @@ final class SplitViewController {
                 // Start with divider at the edge so there's no flash before animation
                 let splitState: SplitState
                 if insertFirst {
-                    // New pane goes first (left or top) - starts at 0, animates to 0.5
+                    // New pane goes first (left or top).
                     splitState = SplitState(
                         orientation: orientation,
                         first: .pane(newPane),
                         second: .pane(paneState),
-                        dividerPosition: 0.0,
+                        dividerPosition: 0.5,
                         animationOrigin: .fromFirst
                     )
                 } else {
-                    // New pane goes second (right or bottom) - starts at 1, animates to 0.5
+                    // New pane goes second (right or bottom).
                     splitState = SplitState(
                         orientation: orientation,
                         first: .pane(paneState),
                         second: .pane(newPane),
-                        dividerPosition: 1.0,
+                        dividerPosition: 0.5,
                         animationOrigin: .fromSecond
                     )
                 }

--- a/Sources/Bonsplit/Internal/Models/PaneState.swift
+++ b/Sources/Bonsplit/Internal/Models/PaneState.swift
@@ -69,9 +69,14 @@ final class PaneState: Identifiable {
 
     /// Move a tab within this pane
     func moveTab(from sourceIndex: Int, to destinationIndex: Int) {
-        guard sourceIndex != destinationIndex,
-              tabs.indices.contains(sourceIndex),
+        guard tabs.indices.contains(sourceIndex),
               destinationIndex >= 0, destinationIndex <= tabs.count else { return }
+
+        // Treat dropping "on itself" or "after itself" as a no-op.
+        // This avoids remove/insert churn that can cause brief visual artifacts during drag/drop.
+        if destinationIndex == sourceIndex || destinationIndex == sourceIndex + 1 {
+            return
+        }
 
         let tab = tabs.remove(at: sourceIndex)
         let adjustedIndex = destinationIndex > sourceIndex ? destinationIndex - 1 : destinationIndex

--- a/Sources/Bonsplit/Internal/Models/PaneState.swift
+++ b/Sources/Bonsplit/Internal/Models/PaneState.swift
@@ -52,12 +52,13 @@ final class PaneState: Identifiable {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return nil }
         let tab = tabs.remove(at: index)
 
-        // If we removed the selected tab, select an adjacent one
+        // If we removed the selected tab, keep the index stable when possible:
+        // prefer selecting the tab that moved into the removed tab's slot (the "next" tab),
+        // and only fall back to selecting the previous tab when we removed the last tab.
         if selectedTabId == tabId {
-            if index > 0 {
-                selectedTabId = tabs[index - 1].id
-            } else if !tabs.isEmpty {
-                selectedTabId = tabs[0].id
+            if !tabs.isEmpty {
+                let newIndex = min(index, max(0, tabs.count - 1))
+                selectedTabId = tabs[newIndex].id
             } else {
                 selectedTabId = nil
             }

--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -18,21 +18,27 @@ struct TabItem: Identifiable, Hashable, Codable {
     let id: UUID
     var title: String
     var icon: String?
+    var iconImageData: Data?
     var isDirty: Bool
     var showsNotificationBadge: Bool
+    var isLoading: Bool
 
     init(
         id: UUID = UUID(),
         title: String,
         icon: String? = "doc.text",
+        iconImageData: Data? = nil,
         isDirty: Bool = false,
-        showsNotificationBadge: Bool = false
+        showsNotificationBadge: Bool = false,
+        isLoading: Bool = false
     ) {
         self.id = id
         self.title = title
         self.icon = icon
+        self.iconImageData = iconImageData
         self.isDirty = isDirty
         self.showsNotificationBadge = showsNotificationBadge
+        self.isLoading = isLoading
     }
 
     func hash(into hasher: inout Hasher) {
@@ -47,8 +53,10 @@ struct TabItem: Identifiable, Hashable, Codable {
         case id
         case title
         case icon
+        case iconImageData
         case isDirty
         case showsNotificationBadge
+        case isLoading
     }
 
     init(from decoder: Decoder) throws {
@@ -56,8 +64,10 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.id = try c.decode(UUID.self, forKey: .id)
         self.title = try c.decode(String.self, forKey: .title)
         self.icon = try c.decodeIfPresent(String.self, forKey: .icon)
+        self.iconImageData = try c.decodeIfPresent(Data.self, forKey: .iconImageData)
         self.isDirty = try c.decodeIfPresent(Bool.self, forKey: .isDirty) ?? false
         self.showsNotificationBadge = try c.decodeIfPresent(Bool.self, forKey: .showsNotificationBadge) ?? false
+        self.isLoading = try c.decodeIfPresent(Bool.self, forKey: .isLoading) ?? false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -65,8 +75,10 @@ struct TabItem: Identifiable, Hashable, Codable {
         try c.encode(id, forKey: .id)
         try c.encode(title, forKey: .title)
         try c.encodeIfPresent(icon, forKey: .icon)
+        try c.encodeIfPresent(iconImageData, forKey: .iconImageData)
         try c.encode(isDirty, forKey: .isDirty)
         try c.encode(showsNotificationBadge, forKey: .showsNotificationBadge)
+        try c.encode(isLoading, forKey: .isLoading)
     }
 }
 

--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -19,17 +19,20 @@ struct TabItem: Identifiable, Hashable, Codable {
     var title: String
     var icon: String?
     var isDirty: Bool
+    var showsNotificationBadge: Bool
 
     init(
         id: UUID = UUID(),
         title: String,
         icon: String? = "doc.text",
-        isDirty: Bool = false
+        isDirty: Bool = false,
+        showsNotificationBadge: Bool = false
     ) {
         self.id = id
         self.title = title
         self.icon = icon
         self.isDirty = isDirty
+        self.showsNotificationBadge = showsNotificationBadge
     }
 
     func hash(into hasher: inout Hasher) {
@@ -38,6 +41,32 @@ struct TabItem: Identifiable, Hashable, Codable {
 
     static func == (lhs: TabItem, rhs: TabItem) -> Bool {
         lhs.id == rhs.id
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case icon
+        case isDirty
+        case showsNotificationBadge
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(UUID.self, forKey: .id)
+        self.title = try c.decode(String.self, forKey: .title)
+        self.icon = try c.decodeIfPresent(String.self, forKey: .icon)
+        self.isDirty = try c.decodeIfPresent(Bool.self, forKey: .isDirty) ?? false
+        self.showsNotificationBadge = try c.decodeIfPresent(Bool.self, forKey: .showsNotificationBadge) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(title, forKey: .title)
+        try c.encodeIfPresent(icon, forKey: .icon)
+        try c.encode(isDirty, forKey: .isDirty)
+        try c.encode(showsNotificationBadge, forKey: .showsNotificationBadge)
     }
 }
 

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -55,6 +55,10 @@ enum TabBarColors {
         Color(nsColor: .labelColor).opacity(0.6)
     }
 
+    static var notificationBadge: Color {
+        Color(nsColor: .systemBlue)
+    }
+
     // MARK: - Shadows
 
     static var tabShadow: Color {

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -10,10 +10,10 @@ enum TabBarMetrics {
     // MARK: - Individual Tabs
 
     static let tabHeight: CGFloat = 30
-    static let tabMinWidth: CGFloat = 140
+    static let tabMinWidth: CGFloat = 48
     static let tabMaxWidth: CGFloat = 220
     static let tabCornerRadius: CGFloat = 0
-    static let tabHorizontalPadding: CGFloat = 12
+    static let tabHorizontalPadding: CGFloat = 6
     static let tabSpacing: CGFloat = 0
     static let activeIndicatorHeight: CGFloat = 2
 

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -24,6 +24,7 @@ enum TabBarMetrics {
     static let closeButtonSize: CGFloat = 16
     static let closeIconSize: CGFloat = 9
     static let dirtyIndicatorSize: CGFloat = 8
+    static let notificationBadgeSize: CGFloat = 6
     static let contentSpacing: CGFloat = 6
 
     // MARK: - Drop Indicator

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -20,7 +20,7 @@ enum TabBarMetrics {
     // MARK: - Tab Content
 
     static let iconSize: CGFloat = 14
-    static let titleFontSize: CGFloat = 12
+    static let titleFontSize: CGFloat = 11
     static let closeButtonSize: CGFloat = 16
     static let closeIconSize: CGFloat = 9
     static let dirtyIndicatorSize: CGFloat = 8

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -142,6 +142,7 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
                 size: size,
                 pane: pane,
                 controller: controller,
+                bonsplitController: bonsplitController,
                 activeDropZone: $activeDropZone,
                 dropLifecycle: $dropLifecycle
             ))
@@ -198,6 +199,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
     let size: CGSize
     let pane: PaneState
     let controller: SplitViewController
+    let bonsplitController: BonsplitController
     @Binding var activeDropZone: DropZone?
     @Binding var dropLifecycle: PaneDropLifecycle
 

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -24,16 +24,27 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.isVertical = splitState.orientation == .horizontal
         splitView.dividerStyle = .thin
         splitView.delegate = context.coordinator
+        // Bonsplit is often embedded in transparent/vibrant window backgrounds. Ensure the
+        // split view itself is not fully transparent so divider regions don't "show through"
+        // to whatever is behind the split hierarchy.
+        splitView.wantsLayer = true
+        splitView.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
 
         // Keep arranged subviews stable (always 2) to avoid transient "collapse" flashes when
         // replacing pane<->split content. We swap the hosted content within these containers.
         let firstContainer = NSView()
+        firstContainer.wantsLayer = true
+        firstContainer.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        firstContainer.layer?.masksToBounds = true
         let firstController = makeHostingController(for: splitState.first)
         installHostingController(firstController, into: firstContainer)
         splitView.addArrangedSubview(firstContainer)
         context.coordinator.firstHostingController = firstController
 
         let secondContainer = NSView()
+        secondContainer.wantsLayer = true
+        secondContainer.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        secondContainer.layer?.masksToBounds = true
         let secondController = makeHostingController(for: splitState.second)
         installHostingController(secondController, into: secondContainer)
         splitView.addArrangedSubview(secondContainer)

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -363,7 +363,11 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 // (window resizes, view reparenting, pane↔split structural updates), the model's
                 // dividerPosition should remain stable; syncPosition() will keep the view aligned.
                 guard wasDragging else {
-                    Task { @MainActor in
+                    let statePosition = self.splitState.dividerPosition
+                    DispatchQueue.main.async {
+                        // NSSplitView may resize subviews in a way that drifts away from our
+                        // normalized dividerPosition. Re-assert the model ratio.
+                        self.syncPosition(statePosition, in: splitView)
                         self.onGeometryChange?(false)
                     }
                     return

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -29,6 +29,10 @@ struct TabBarView: View {
         isFocused || splitViewController.dragSourcePaneId == pane.id
     }
 
+    private var tabBarSaturation: Double {
+        shouldShowFullSaturation ? 1.0 : 0.0
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             // Scrollable tabs with fade overlays
@@ -87,12 +91,12 @@ struct TabBarView: View {
             // Split buttons
             if showSplitButtons {
                 splitButtons
+                    .saturation(tabBarSaturation)
             }
         }
         .frame(height: TabBarMetrics.barHeight)
         .contentShape(Rectangle())
         .background(tabBarBackground)
-        .saturation(shouldShowFullSaturation ? 1.0 : 0)
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
         .onChange(of: splitViewController.draggingTab) { _, newValue in
             if newValue == nil {
@@ -109,6 +113,7 @@ struct TabBarView: View {
         TabItemView(
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
+            saturation: tabBarSaturation,
             onSelect: {
                 // Tab selection must be instant. Animating this transaction causes the pane
                 // content (often swapped via opacity) to crossfade, which is undesirable for
@@ -140,6 +145,7 @@ struct TabBarView: View {
         .overlay(alignment: .leading) {
             if dropTargetIndex == index {
                 dropIndicator
+                    .saturation(tabBarSaturation)
             }
         }
     }
@@ -184,6 +190,7 @@ struct TabBarView: View {
             .overlay(alignment: .leading) {
                 if dropTargetIndex == pane.tabs.count {
                     dropIndicator
+                        .saturation(tabBarSaturation)
                 }
             }
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -119,7 +119,8 @@ struct TabBarView: View {
                 }
             },
             onClose: {
-                withAnimation(.easeInOut(duration: TabBarMetrics.closeDuration)) {
+                // Close should be instant (no fade-out/removal animation).
+                withTransaction(Transaction(animation: nil)) {
                     _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
             }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -110,7 +110,10 @@ struct TabBarView: View {
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
             onSelect: {
-                withAnimation(.easeInOut(duration: TabBarMetrics.selectionDuration)) {
+                // Tab selection must be instant. Animating this transaction causes the pane
+                // content (often swapped via opacity) to crossfade, which is undesirable for
+                // terminal/browser surfaces.
+                withTransaction(Transaction(animation: nil)) {
                     pane.selectTab(tab.id)
                     controller.focusPane(pane.id)
                 }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -11,29 +11,29 @@ struct TabItemView: View {
     @State private var isCloseHovered = false
 
     var body: some View {
-        HStack(spacing: TabBarMetrics.contentSpacing) {
-            // Icon
-            if let iconName = tab.icon {
-                let iconSize: CGFloat = {
-                    // `terminal.fill` reads visually heavier than most symbols at the same point size.
-                    // Keep other icons as-is, but slightly downsize terminal icons.
-                    if iconName == "terminal.fill" || iconName == "terminal" || iconName == "globe" {
-                        return max(10, TabBarMetrics.iconSize - 2.5)
-                    }
-                    return TabBarMetrics.iconSize
-                }()
-                Image(systemName: iconName)
-                    .font(.system(size: iconSize))
+        HStack(spacing: 0) {
+            // Icon + title block uses the standard spacing, but keep the close affordance tight.
+            HStack(spacing: TabBarMetrics.contentSpacing) {
+                if let iconName = tab.icon {
+                    let iconSize: CGFloat = {
+                        // `terminal.fill` reads visually heavier than most symbols at the same point size.
+                        // Keep other icons as-is, but slightly downsize terminal/browser icons.
+                        if iconName == "terminal.fill" || iconName == "terminal" || iconName == "globe" {
+                            return max(10, TabBarMetrics.iconSize - 2.5)
+                        }
+                        return TabBarMetrics.iconSize
+                    }()
+                    Image(systemName: iconName)
+                        .font(.system(size: iconSize))
+                        .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
+                }
+
+                Text(tab.title)
+                    .font(.system(size: TabBarMetrics.titleFontSize))
+                    .lineLimit(1)
                     .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
             }
 
-            // Title
-            Text(tab.title)
-                .font(.system(size: TabBarMetrics.titleFontSize))
-                .lineLimit(1)
-                .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
-
-            // Reduce the minimum gap so the close button doesn't feel overly padded.
             Spacer(minLength: 0)
 
             // Close button or dirty indicator

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -445,15 +445,16 @@ private struct MiddleClickMonitorView: NSViewRepresentable {
         context.coordinator.onMiddleClick = onMiddleClick
 
         // Monitor only middle clicks so we don't break drag/reorder or normal selection.
-        context.coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.otherMouseUp]) { event in
+        let coordinator = context.coordinator
+        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.otherMouseUp]) { [weak coordinator] event in
             guard event.buttonNumber == 2 else { return event }
-            guard let v = context.coordinator.view, let w = v.window else { return event }
+            guard let coordinator, let v = coordinator.view, let w = v.window else { return event }
             guard event.window === w else { return event }
 
             let p = v.convert(event.locationInWindow, from: nil)
             guard v.bounds.contains(p) else { return event }
 
-            context.coordinator.onMiddleClick?()
+            coordinator.onMiddleClick?()
             return nil // swallow so it doesn't also select the tab
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -15,6 +15,12 @@ private enum TabControlShortcutHintDebugSettings {
     }
 }
 
+enum TabItemStyling {
+    static func iconSaturation(hasRasterIcon: Bool, tabSaturation: Double) -> Double {
+        hasRasterIcon ? 1.0 : tabSaturation
+    }
+}
+
 /// Individual tab view with icon, title, close button, and dirty indicator
 struct TabItemView: View {
     let tab: TabItem
@@ -42,12 +48,13 @@ struct TabItemView: View {
             HStack(spacing: TabBarMetrics.contentSpacing) {
                 let iconSlotSize = TabBarMetrics.iconSize
                 let iconTint = isSelected ? TabBarColors.activeText : TabBarColors.inactiveText
+                let faviconImage = tab.iconImageData.flatMap { NSImage(data: $0) }
 
                 Group {
                     if tab.isLoading {
                         // Slightly smaller than the icon slot so it reads cleaner at tab scale.
                         TabLoadingSpinner(size: iconSlotSize * 0.86, color: iconTint)
-                    } else if let data = tab.iconImageData, let image = NSImage(data: data) {
+                    } else if let image = faviconImage {
                         Image(nsImage: image)
                             .resizable()
                             .interpolation(.high)
@@ -66,6 +73,8 @@ struct TabItemView: View {
                         }
                     }
                 }
+                // Keep downloaded favicon bitmaps in full color even for inactive tab bars.
+                .saturation(TabItemStyling.iconSaturation(hasRasterIcon: faviconImage != nil, tabSaturation: saturation))
                 .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
                 .onAppear { updateGlobeFallback() }
                 .onDisappear {
@@ -80,8 +89,8 @@ struct TabItemView: View {
                     .font(.system(size: TabBarMetrics.titleFontSize))
                     .lineLimit(1)
                     .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
+                    .saturation(saturation)
             }
-            .saturation(saturation)
 
             Spacer(minLength: 0)
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -17,8 +17,8 @@ struct TabItemView: View {
                 let iconSize: CGFloat = {
                     // `terminal.fill` reads visually heavier than most symbols at the same point size.
                     // Keep other icons as-is, but slightly downsize terminal icons.
-                    if iconName == "terminal.fill" || iconName == "terminal" {
-                        return max(10, TabBarMetrics.iconSize - 2)
+                    if iconName == "terminal.fill" || iconName == "terminal" || iconName == "globe" {
+                        return max(10, TabBarMetrics.iconSize - 2.5)
                     }
                     return TabBarMetrics.iconSize
                 }()

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -25,7 +25,8 @@ struct TabItemView: View {
                 .lineLimit(1)
                 .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
 
-            Spacer(minLength: 4)
+            // Reduce the minimum gap so the close button doesn't feel overly padded.
+            Spacer(minLength: 0)
 
             // Close button or dirty indicator
             closeOrDirtyIndicator

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -14,8 +14,16 @@ struct TabItemView: View {
         HStack(spacing: TabBarMetrics.contentSpacing) {
             // Icon
             if let iconName = tab.icon {
+                let iconSize: CGFloat = {
+                    // `terminal.fill` reads visually heavier than most symbols at the same point size.
+                    // Keep other icons as-is, but slightly downsize terminal icons.
+                    if iconName == "terminal.fill" || iconName == "terminal" {
+                        return max(10, TabBarMetrics.iconSize - 2)
+                    }
+                    return TabBarMetrics.iconSize
+                }()
                 Image(systemName: iconName)
-                    .font(.system(size: TabBarMetrics.iconSize))
+                    .font(.system(size: iconSize))
                     .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
             }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -34,20 +34,24 @@ public final class BonsplitController {
     /// - Parameters:
     ///   - title: The tab title
     ///   - icon: Optional SF Symbol name for the tab icon
+    ///   - iconImageData: Optional image data (PNG recommended) for the tab icon. When present, takes precedence over `icon`.
     ///   - isDirty: Whether the tab shows a dirty indicator
     ///   - showsNotificationBadge: Whether the tab shows an "unread/activity" badge
+    ///   - isLoading: Whether the tab shows an activity/loading indicator (e.g. spinning icon)
     ///   - pane: Optional pane to add the tab to (defaults to focused pane)
     /// - Returns: The TabID of the created tab, or nil if creation was vetoed by delegate
     @discardableResult
     public func createTab(
         title: String,
         icon: String? = "doc.text",
+        iconImageData: Data? = nil,
         isDirty: Bool = false,
         showsNotificationBadge: Bool = false,
+        isLoading: Bool = false,
         inPane pane: PaneID? = nil
     ) -> TabID? {
         let tabId = TabID()
-        let tab = Tab(id: tabId, title: title, icon: icon, isDirty: isDirty, showsNotificationBadge: showsNotificationBadge)
+        let tab = Tab(id: tabId, title: title, icon: icon, iconImageData: iconImageData, isDirty: isDirty, showsNotificationBadge: showsNotificationBadge, isLoading: isLoading)
         let targetPane = pane ?? focusedPaneId ?? PaneID(id: internalController.rootNode.allPaneIds.first!.id)
 
         // Check with delegate
@@ -77,8 +81,10 @@ public final class BonsplitController {
             id: tabId.id,
             title: title,
             icon: icon,
+            iconImageData: iconImageData,
             isDirty: isDirty,
-            showsNotificationBadge: showsNotificationBadge
+            showsNotificationBadge: showsNotificationBadge,
+            isLoading: isLoading
         )
         internalController.addTab(tabItem, toPane: PaneID(id: targetPane.id), atIndex: insertIndex)
 
@@ -93,14 +99,18 @@ public final class BonsplitController {
     ///   - tabId: The tab to update
     ///   - title: New title (pass nil to keep current)
     ///   - icon: New icon (pass nil to keep current, pass .some(nil) to remove icon)
+    ///   - iconImageData: New icon image data (pass nil to keep current, pass .some(nil) to remove)
     ///   - isDirty: New dirty state (pass nil to keep current)
     ///   - showsNotificationBadge: New badge state (pass nil to keep current)
+    ///   - isLoading: New loading/busy state (pass nil to keep current)
     public func updateTab(
         _ tabId: TabID,
         title: String? = nil,
         icon: String?? = nil,
+        iconImageData: Data?? = nil,
         isDirty: Bool? = nil,
-        showsNotificationBadge: Bool? = nil
+        showsNotificationBadge: Bool? = nil,
+        isLoading: Bool? = nil
     ) {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return }
 
@@ -110,11 +120,17 @@ public final class BonsplitController {
         if let icon = icon {
             pane.tabs[tabIndex].icon = icon
         }
+        if let iconImageData = iconImageData {
+            pane.tabs[tabIndex].iconImageData = iconImageData
+        }
         if let isDirty = isDirty {
             pane.tabs[tabIndex].isDirty = isDirty
         }
         if let showsNotificationBadge = showsNotificationBadge {
             pane.tabs[tabIndex].showsNotificationBadge = showsNotificationBadge
+        }
+        if let isLoading = isLoading {
+            pane.tabs[tabIndex].isLoading = isLoading
         }
     }
 
@@ -216,8 +232,10 @@ public final class BonsplitController {
                 id: tab.id.id,
                 title: tab.title,
                 icon: tab.icon,
+                iconImageData: tab.iconImageData,
                 isDirty: tab.isDirty,
-                showsNotificationBadge: tab.showsNotificationBadge
+                showsNotificationBadge: tab.showsNotificationBadge,
+                isLoading: tab.isLoading
             )
         } else {
             internalTab = nil
@@ -276,8 +294,10 @@ public final class BonsplitController {
             id: tab.id.id,
             title: tab.title,
             icon: tab.icon,
+            iconImageData: tab.iconImageData,
             isDirty: tab.isDirty,
-            showsNotificationBadge: tab.showsNotificationBadge
+            showsNotificationBadge: tab.showsNotificationBadge,
+            isLoading: tab.isLoading
         )
 
         // Perform split with insertion side.

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -173,6 +173,7 @@ public final class BonsplitController {
 
         // Notify delegate
         delegate?.splitTabBar(self, didCloseTab: tabId, fromPane: paneId)
+        notifyGeometryChange()
 
         return true
     }
@@ -254,10 +255,7 @@ public final class BonsplitController {
         // Notify delegate
         delegate?.splitTabBar(self, didSplitPane: targetPaneId, newPane: newPaneId, orientation: orientation)
 
-        // Notify geometry change after a brief delay to allow layout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.notifyGeometryChange()
-        }
+        notifyGeometryChange()
 
         return newPaneId
     }
@@ -313,10 +311,7 @@ public final class BonsplitController {
         // Notify delegate
         delegate?.splitTabBar(self, didSplitPane: targetPaneId, newPane: newPaneId, orientation: orientation)
 
-        // Notify geometry change after a brief delay to allow layout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.notifyGeometryChange()
-        }
+        notifyGeometryChange()
 
         return newPaneId
     }
@@ -382,10 +377,7 @@ public final class BonsplitController {
         // Notify delegate
         delegate?.splitTabBar(self, didSplitPane: targetPaneId, newPane: newPaneId, orientation: orientation)
 
-        // Notify geometry change after a brief delay to allow layout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.notifyGeometryChange()
-        }
+        notifyGeometryChange()
 
         return newPaneId
     }
@@ -410,10 +402,7 @@ public final class BonsplitController {
         // Notify delegate
         delegate?.splitTabBar(self, didClosePane: paneId)
 
-        // Notify geometry change after a brief delay to allow layout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.notifyGeometryChange()
-        }
+        notifyGeometryChange()
 
         return true
     }
@@ -612,12 +601,13 @@ public final class BonsplitController {
             guard shouldNotify else { return }
         }
 
-        // Debounce: skip if less than 50ms since last notification
-        let now = Date().timeIntervalSince1970
-        let debounceInterval: TimeInterval = 0.05
-        guard now - internalController.lastGeometryNotificationTime >= debounceInterval else { return }
-
-        internalController.lastGeometryNotificationTime = now
+        if isDragging {
+            // Debounce drag updates to avoid flooding delegates during divider moves.
+            let now = Date().timeIntervalSince1970
+            let debounceInterval: TimeInterval = 0.05
+            guard now - internalController.lastGeometryNotificationTime >= debounceInterval else { return }
+            internalController.lastGeometryNotificationTime = now
+        }
 
         let snapshot = layoutSnapshot()
         delegate?.splitTabBar(self, didChangeGeometry: snapshot)

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -35,6 +35,7 @@ public final class BonsplitController {
     ///   - title: The tab title
     ///   - icon: Optional SF Symbol name for the tab icon
     ///   - isDirty: Whether the tab shows a dirty indicator
+    ///   - showsNotificationBadge: Whether the tab shows an "unread/activity" badge
     ///   - pane: Optional pane to add the tab to (defaults to focused pane)
     /// - Returns: The TabID of the created tab, or nil if creation was vetoed by delegate
     @discardableResult
@@ -42,10 +43,11 @@ public final class BonsplitController {
         title: String,
         icon: String? = "doc.text",
         isDirty: Bool = false,
+        showsNotificationBadge: Bool = false,
         inPane pane: PaneID? = nil
     ) -> TabID? {
         let tabId = TabID()
-        let tab = Tab(id: tabId, title: title, icon: icon, isDirty: isDirty)
+        let tab = Tab(id: tabId, title: title, icon: icon, isDirty: isDirty, showsNotificationBadge: showsNotificationBadge)
         let targetPane = pane ?? focusedPaneId ?? PaneID(id: internalController.rootNode.allPaneIds.first!.id)
 
         // Check with delegate
@@ -71,7 +73,13 @@ public final class BonsplitController {
         }
 
         // Create internal TabItem
-        let tabItem = TabItem(id: tabId.id, title: title, icon: icon, isDirty: isDirty)
+        let tabItem = TabItem(
+            id: tabId.id,
+            title: title,
+            icon: icon,
+            isDirty: isDirty,
+            showsNotificationBadge: showsNotificationBadge
+        )
         internalController.addTab(tabItem, toPane: PaneID(id: targetPane.id), atIndex: insertIndex)
 
         // Notify delegate
@@ -86,11 +94,13 @@ public final class BonsplitController {
     ///   - title: New title (pass nil to keep current)
     ///   - icon: New icon (pass nil to keep current, pass .some(nil) to remove icon)
     ///   - isDirty: New dirty state (pass nil to keep current)
+    ///   - showsNotificationBadge: New badge state (pass nil to keep current)
     public func updateTab(
         _ tabId: TabID,
         title: String? = nil,
         icon: String?? = nil,
-        isDirty: Bool? = nil
+        isDirty: Bool? = nil,
+        showsNotificationBadge: Bool? = nil
     ) {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return }
 
@@ -102,6 +112,9 @@ public final class BonsplitController {
         }
         if let isDirty = isDirty {
             pane.tabs[tabIndex].isDirty = isDirty
+        }
+        if let showsNotificationBadge = showsNotificationBadge {
+            pane.tabs[tabIndex].showsNotificationBadge = showsNotificationBadge
         }
     }
 
@@ -199,7 +212,13 @@ public final class BonsplitController {
 
         let internalTab: TabItem?
         if let tab {
-            internalTab = TabItem(id: tab.id.id, title: tab.title, icon: tab.icon, isDirty: tab.isDirty)
+            internalTab = TabItem(
+                id: tab.id.id,
+                title: tab.title,
+                icon: tab.icon,
+                isDirty: tab.isDirty,
+                showsNotificationBadge: tab.showsNotificationBadge
+            )
         } else {
             internalTab = nil
         }
@@ -253,7 +272,13 @@ public final class BonsplitController {
             return nil
         }
 
-        let internalTab = TabItem(id: tab.id.id, title: tab.title, icon: tab.icon, isDirty: tab.isDirty)
+        let internalTab = TabItem(
+            id: tab.id.id,
+            title: tab.title,
+            icon: tab.icon,
+            isDirty: tab.isDirty,
+            showsNotificationBadge: tab.showsNotificationBadge
+        )
 
         // Perform split with insertion side.
         internalController.splitPaneWithTab(

--- a/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
+++ b/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+#if DEBUG
+/// Debug-only counters for Bonsplit internal behavior.
+///
+/// These are intended for automated tests (via cmuxterm's debug socket) to
+/// detect transient structural updates that can cause visible flashes.
+public enum BonsplitDebugCounters {
+    public private(set) static var arrangedSubviewUnderflowCount: Int = 0
+
+    public static func reset() {
+        arrangedSubviewUnderflowCount = 0
+    }
+
+    internal static func recordArrangedSubviewUnderflow() {
+        arrangedSubviewUnderflowCount += 1
+    }
+}
+#endif

--- a/Sources/Bonsplit/Public/Types/Tab.swift
+++ b/Sources/Bonsplit/Public/Types/Tab.swift
@@ -5,29 +5,39 @@ public struct Tab: Identifiable, Hashable, Sendable {
     public let id: TabID
     public let title: String
     public let icon: String?
+    /// Optional image data (PNG recommended) for the tab icon. When present, this takes precedence over `icon`.
+    public let iconImageData: Data?
     public let isDirty: Bool
     /// Whether the tab should show an "unread/activity" badge (library consumer-defined meaning).
     public let showsNotificationBadge: Bool
+    /// Whether the tab should show an activity/loading indicator (e.g. spinning icon).
+    public let isLoading: Bool
 
     public init(
         id: TabID = TabID(),
         title: String,
         icon: String? = nil,
+        iconImageData: Data? = nil,
         isDirty: Bool = false,
-        showsNotificationBadge: Bool = false
+        showsNotificationBadge: Bool = false,
+        isLoading: Bool = false
     ) {
         self.id = id
         self.title = title
         self.icon = icon
+        self.iconImageData = iconImageData
         self.isDirty = isDirty
         self.showsNotificationBadge = showsNotificationBadge
+        self.isLoading = isLoading
     }
 
     internal init(from tabItem: TabItem) {
         self.id = TabID(id: tabItem.id)
         self.title = tabItem.title
         self.icon = tabItem.icon
+        self.iconImageData = tabItem.iconImageData
         self.isDirty = tabItem.isDirty
         self.showsNotificationBadge = tabItem.showsNotificationBadge
+        self.isLoading = tabItem.isLoading
     }
 }

--- a/Sources/Bonsplit/Public/Types/Tab.swift
+++ b/Sources/Bonsplit/Public/Types/Tab.swift
@@ -6,12 +6,21 @@ public struct Tab: Identifiable, Hashable, Sendable {
     public let title: String
     public let icon: String?
     public let isDirty: Bool
+    /// Whether the tab should show an "unread/activity" badge (library consumer-defined meaning).
+    public let showsNotificationBadge: Bool
 
-    public init(id: TabID = TabID(), title: String, icon: String? = nil, isDirty: Bool = false) {
+    public init(
+        id: TabID = TabID(),
+        title: String,
+        icon: String? = nil,
+        isDirty: Bool = false,
+        showsNotificationBadge: Bool = false
+    ) {
         self.id = id
         self.title = title
         self.icon = icon
         self.isDirty = isDirty
+        self.showsNotificationBadge = showsNotificationBadge
     }
 
     internal init(from tabItem: TabItem) {
@@ -19,5 +28,6 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.title = tabItem.title
         self.icon = tabItem.icon
         self.isDirty = tabItem.isDirty
+        self.showsNotificationBadge = tabItem.showsNotificationBadge
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -102,4 +102,22 @@ final class BonsplitTests: XCTestCase {
         XCTAssertFalse(controller.configuration.allowSplits)
         XCTAssertTrue(controller.configuration.allowCloseTabs)
     }
+
+    @MainActor
+    func testMoveTabNoopAfterItself() {
+        let t0 = TabItem(title: "0")
+        let t1 = TabItem(title: "1")
+        let pane = PaneState(tabs: [t0, t1], selectedTabId: t1.id)
+
+        // Dragging the last tab to the right corresponds to moving it to `tabs.count`,
+        // which should be treated as a no-op.
+        pane.moveTab(from: 1, to: 2)
+        XCTAssertEqual(pane.tabs.map(\.id), [t0.id, t1.id])
+        XCTAssertEqual(pane.selectedTabId, t1.id)
+
+        // Still allow real moves.
+        pane.moveTab(from: 0, to: 2)
+        XCTAssertEqual(pane.tabs.map(\.id), [t1.id, t0.id])
+        XCTAssertEqual(pane.selectedTabId, t1.id)
+    }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import Bonsplit
+import AppKit
 
 final class BonsplitTests: XCTestCase {
 
@@ -133,5 +134,33 @@ final class BonsplitTests: XCTestCase {
             TabItemStyling.iconSaturation(hasRasterIcon: false, tabSaturation: 0.0),
             0.0
         )
+    }
+
+    func testResolvedFaviconImageUsesIncomingDataWhenDecodable() {
+        let existing = NSImage(size: NSSize(width: 12, height: 12))
+        let incoming = NSImage(size: NSSize(width: 16, height: 16))
+        incoming.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSBezierPath(rect: NSRect(x: 0, y: 0, width: 16, height: 16)).fill()
+        incoming.unlockFocus()
+        let data = incoming.tiffRepresentation
+
+        let resolved = TabItemStyling.resolvedFaviconImage(existing: existing, incomingData: data)
+        XCTAssertNotNil(resolved)
+        XCTAssertFalse(resolved === existing)
+    }
+
+    func testResolvedFaviconImageKeepsExistingImageWhenIncomingDataIsInvalid() {
+        let existing = NSImage(size: NSSize(width: 16, height: 16))
+        let invalidData = Data([0x00, 0x11, 0x22, 0x33])
+
+        let resolved = TabItemStyling.resolvedFaviconImage(existing: existing, incomingData: invalidData)
+        XCTAssertTrue(resolved === existing)
+    }
+
+    func testResolvedFaviconImageClearsWhenIncomingDataIsNil() {
+        let existing = NSImage(size: NSSize(width: 16, height: 16))
+        let resolved = TabItemStyling.resolvedFaviconImage(existing: existing, incomingData: nil)
+        XCTAssertNil(resolved)
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -120,4 +120,18 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(pane.tabs.map(\.id), [t1.id, t0.id])
         XCTAssertEqual(pane.selectedTabId, t1.id)
     }
+
+    func testIconSaturationKeepsRasterFaviconInColorWhenInactive() {
+        XCTAssertEqual(
+            TabItemStyling.iconSaturation(hasRasterIcon: true, tabSaturation: 0.0),
+            1.0
+        )
+    }
+
+    func testIconSaturationStillDesaturatesSymbolIconsWhenInactive() {
+        XCTAssertEqual(
+            TabItemStyling.iconSaturation(hasRasterIcon: false, tabSaturation: 0.0),
+            0.0
+        )
+    }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -49,6 +49,49 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testCloseSelectedTabKeepsIndexStableWhenPossible() {
+        do {
+            let config = BonsplitConfiguration(newTabPosition: .end)
+            let controller = BonsplitController(configuration: config)
+
+            let tab0 = controller.createTab(title: "0")!
+            let tab1 = controller.createTab(title: "1")!
+            let tab2 = controller.createTab(title: "2")!
+
+            let pane = controller.focusedPaneId!
+
+            controller.selectTab(tab1)
+            XCTAssertEqual(controller.selectedTab(inPane: pane)?.id, tab1)
+
+            _ = controller.closeTab(tab1)
+
+            // Order is [0,1,2] and 1 was selected; after close we should select 2 (same index).
+            XCTAssertEqual(controller.selectedTab(inPane: pane)?.id, tab2)
+            XCTAssertNotNil(controller.tab(tab0))
+        }
+
+        do {
+            let config = BonsplitConfiguration(newTabPosition: .end)
+            let controller = BonsplitController(configuration: config)
+
+            let tab0 = controller.createTab(title: "0")!
+            let tab1 = controller.createTab(title: "1")!
+            let tab2 = controller.createTab(title: "2")!
+
+            let pane = controller.focusedPaneId!
+
+            controller.selectTab(tab2)
+            XCTAssertEqual(controller.selectedTab(inPane: pane)?.id, tab2)
+
+            _ = controller.closeTab(tab2)
+
+            // Closing last should select previous.
+            XCTAssertEqual(controller.selectedTab(inPane: pane)?.id, tab1)
+            XCTAssertNotNil(controller.tab(tab0))
+        }
+    }
+
+    @MainActor
     func testConfiguration() {
         let config = BonsplitConfiguration(
             allowSplits: false,


### PR DESCRIPTION
Fixes a transient NSSplitView arrangedSubviews underflow during pane<->split structural updates which can make existing splits disappear/flash. Adds debug underflow counter used by cmuxterm regression tests.