### PR TITLE
Add theme-aware chrome color overrides

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -106,12 +106,20 @@ enum TabBarColors {
         Color(nsColor: effectiveTextColor(for: appearance, secondary: false))
     }
 
+    static func nsColorActiveText(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        effectiveTextColor(for: appearance, secondary: false)
+    }
+
     static var inactiveText: Color {
         Color(nsColor: .secondaryLabelColor)
     }
 
     static func inactiveText(for appearance: BonsplitConfiguration.Appearance) -> Color {
         Color(nsColor: effectiveTextColor(for: appearance, secondary: true))
+    }
+
+    static func nsColorInactiveText(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        effectiveTextColor(for: appearance, secondary: true)
     }
 
     // MARK: - Borders & Indicators

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -3,10 +3,59 @@ import AppKit
 
 /// Native macOS colors for the tab bar
 enum TabBarColors {
+    private enum Constants {
+        static let darkTextAlpha: CGFloat = 0.82
+        static let darkSecondaryTextAlpha: CGFloat = 0.62
+        static let lightTextAlpha: CGFloat = 0.82
+        static let lightSecondaryTextAlpha: CGFloat = 0.68
+    }
+
+    private static func chromeBackgroundColor(
+        for appearance: BonsplitConfiguration.Appearance
+    ) -> NSColor? {
+        guard let value = appearance.chromeColors.backgroundHex else { return nil }
+        return NSColor(bonsplitHex: value)
+    }
+
+    private static func effectiveBackgroundColor(
+        for appearance: BonsplitConfiguration.Appearance
+    ) -> NSColor {
+        chromeBackgroundColor(for: appearance) ?? NSColor.windowBackgroundColor
+    }
+
+    private static func effectiveTextColor(
+        for appearance: BonsplitConfiguration.Appearance,
+        secondary: Bool
+    ) -> NSColor {
+        guard let custom = chromeBackgroundColor(for: appearance) else {
+            return secondary ? .secondaryLabelColor : .labelColor
+        }
+
+        if custom.isBonsplitLightColor {
+            let alpha = secondary ? Constants.darkSecondaryTextAlpha : Constants.darkTextAlpha
+            return NSColor.black.withAlphaComponent(alpha)
+        }
+
+        let alpha = secondary ? Constants.lightSecondaryTextAlpha : Constants.lightTextAlpha
+        return NSColor.white.withAlphaComponent(alpha)
+    }
+
+    static func paneBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        Color(nsColor: effectiveBackgroundColor(for: appearance))
+    }
+
+    static func nsColorPaneBackground(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        effectiveBackgroundColor(for: appearance)
+    }
+
     // MARK: - Tab Bar Background
 
     static var barBackground: Color {
         Color(nsColor: .windowBackgroundColor)
+    }
+
+    static func barBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        Color(nsColor: effectiveBackgroundColor(for: appearance))
     }
 
     static var barMaterial: Material {
@@ -19,8 +68,28 @@ enum TabBarColors {
         Color(nsColor: .controlBackgroundColor)
     }
 
+    static func activeTabBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        guard let custom = chromeBackgroundColor(for: appearance) else {
+            return activeTabBackground
+        }
+        let adjusted = custom.isBonsplitLightColor
+            ? custom.bonsplitDarken(by: 0.065)
+            : custom.bonsplitLighten(by: 0.12)
+        return Color(nsColor: adjusted)
+    }
+
     static var hoveredTabBackground: Color {
         Color(nsColor: .controlBackgroundColor).opacity(0.5)
+    }
+
+    static func hoveredTabBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        guard let custom = chromeBackgroundColor(for: appearance) else {
+            return hoveredTabBackground
+        }
+        let adjusted = custom.isBonsplitLightColor
+            ? custom.bonsplitDarken(by: 0.03)
+            : custom.bonsplitLighten(by: 0.07)
+        return Color(nsColor: adjusted.withAlphaComponent(0.78))
     }
 
     static var inactiveTabBackground: Color {
@@ -33,8 +102,16 @@ enum TabBarColors {
         Color(nsColor: .labelColor)
     }
 
+    static func activeText(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        Color(nsColor: effectiveTextColor(for: appearance, secondary: false))
+    }
+
     static var inactiveText: Color {
         Color(nsColor: .secondaryLabelColor)
+    }
+
+    static func inactiveText(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        Color(nsColor: effectiveTextColor(for: appearance, secondary: true))
     }
 
     // MARK: - Borders & Indicators
@@ -43,8 +120,24 @@ enum TabBarColors {
         Color(nsColor: .separatorColor)
     }
 
+    static func separator(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        guard let custom = chromeBackgroundColor(for: appearance) else {
+            return separator
+        }
+        let alpha: CGFloat = custom.isBonsplitLightColor ? 0.26 : 0.36
+        let tone = custom.isBonsplitLightColor
+            ? custom.bonsplitDarken(by: 0.12)
+            : custom.bonsplitLighten(by: 0.16)
+        return Color(nsColor: tone.withAlphaComponent(alpha))
+    }
+
     static var dropIndicator: Color {
         Color.accentColor
+    }
+
+    static func dropIndicator(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        _ = appearance
+        return dropIndicator
     }
 
     static var focusRing: Color {
@@ -55,13 +148,80 @@ enum TabBarColors {
         Color(nsColor: .labelColor).opacity(0.6)
     }
 
+    static func dirtyIndicator(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        guard chromeBackgroundColor(for: appearance) != nil else { return dirtyIndicator }
+        return activeText(for: appearance).opacity(0.72)
+    }
+
     static var notificationBadge: Color {
         Color(nsColor: .systemBlue)
+    }
+
+    static func notificationBadge(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        _ = appearance
+        return notificationBadge
     }
 
     // MARK: - Shadows
 
     static var tabShadow: Color {
         Color.black.opacity(0.08)
+    }
+}
+
+private extension NSColor {
+    convenience init?(bonsplitHex value: String) {
+        var hex = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if hex.hasPrefix("#") {
+            hex.removeFirst()
+        }
+        guard hex.count == 6 else { return nil }
+        var rgb: UInt64 = 0
+        guard Scanner(string: hex).scanHexInt64(&rgb) else { return nil }
+        let red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+        let green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+        let blue = CGFloat(rgb & 0x0000FF) / 255.0
+        self.init(red: red, green: green, blue: blue, alpha: 1.0)
+    }
+
+    var isBonsplitLightColor: Bool {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        let color = usingColorSpace(.sRGB) ?? self
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        let luminance = (0.299 * red) + (0.587 * green) + (0.114 * blue)
+        return luminance > 0.5
+    }
+
+    func bonsplitLighten(by amount: CGFloat) -> NSColor {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        let color = usingColorSpace(.sRGB) ?? self
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return NSColor(
+            red: min(1.0, red + amount),
+            green: min(1.0, green + amount),
+            blue: min(1.0, blue + amount),
+            alpha: alpha
+        )
+    }
+
+    func bonsplitDarken(by amount: CGFloat) -> NSColor {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        let color = usingColorSpace(.sRGB) ?? self
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return NSColor(
+            red: max(0.0, red - amount),
+            green: max(0.0, green - amount),
+            blue: max(0.0, blue - amount),
+            alpha: alpha
+        )
     }
 }

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -18,9 +18,10 @@ enum TabBarColors {
     }
 
     private static func effectiveBackgroundColor(
-        for appearance: BonsplitConfiguration.Appearance
+        for appearance: BonsplitConfiguration.Appearance,
+        fallback fallbackColor: NSColor
     ) -> NSColor {
-        chromeBackgroundColor(for: appearance) ?? NSColor.windowBackgroundColor
+        chromeBackgroundColor(for: appearance) ?? fallbackColor
     }
 
     private static func effectiveTextColor(
@@ -41,11 +42,11 @@ enum TabBarColors {
     }
 
     static func paneBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        Color(nsColor: effectiveBackgroundColor(for: appearance))
+        Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor))
     }
 
     static func nsColorPaneBackground(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
-        effectiveBackgroundColor(for: appearance)
+        effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor)
     }
 
     // MARK: - Tab Bar Background
@@ -55,7 +56,7 @@ enum TabBarColors {
     }
 
     static func barBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        Color(nsColor: effectiveBackgroundColor(for: appearance))
+        Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor))
     }
 
     static var barMaterial: Material {
@@ -178,14 +179,16 @@ enum TabBarColors {
 }
 
 private extension NSColor {
+    private static let bonsplitHexDigits = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+
     convenience init?(bonsplitHex value: String) {
         var hex = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if hex.hasPrefix("#") {
             hex.removeFirst()
         }
         guard hex.count == 6 else { return nil }
-        var rgb: UInt64 = 0
-        guard Scanner(string: hex).scanHexInt64(&rgb) else { return nil }
+        guard hex.unicodeScalars.allSatisfy({ Self.bonsplitHexDigits.contains($0) }) else { return nil }
+        guard let rgb = UInt64(hex, radix: 16) else { return nil }
         let red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
         let green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
         let blue = CGFloat(rgb & 0x0000FF) / 255.0

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -65,6 +65,10 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
         controller.focusedPaneId == pane.id
     }
 
+    private var appearance: BonsplitConfiguration.Appearance {
+        bonsplitController.configuration.appearance
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Tab bar
@@ -78,7 +82,7 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
             contentAreaWithDropZones
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(nsColor: .textBackgroundColor))
+        .background(TabBarColors.paneBackground(for: appearance))
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
         .onChange(of: controller.draggingTab) { _, newValue in
             if newValue == nil {

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -8,6 +8,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
     let node: SplitNode
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
+    let appearance: BonsplitConfiguration.Appearance
     var showSplitButtons: Bool = true
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
     var onGeometryChange: ((_ isDragging: Bool) -> Void)?
@@ -30,6 +31,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
             SplitContainerView(
                 splitState: splitState,
                 controller: controller,
+                appearance: appearance,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -6,6 +6,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
 
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
+    let appearance: BonsplitConfiguration.Appearance
     var showSplitButtons: Bool = true
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
     var onGeometryChange: ((_ isDragging: Bool) -> Void)?
@@ -40,6 +41,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
             node: controller.rootNode,
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
+            appearance: appearance,
             showSplitButtons: showSplitButtons,
             contentViewLifecycle: contentViewLifecycle,
             onGeometryChange: onGeometryChange,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -35,6 +35,10 @@ struct TabBarView: View {
         shouldShowFullSaturation ? 1.0 : 0.0
     }
 
+    private var appearance: BonsplitConfiguration.Appearance {
+        controller.configuration.appearance
+    }
+
     private var showsControlShortcutHints: Bool {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
@@ -147,6 +151,7 @@ struct TabBarView: View {
         TabItemView(
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
+            appearance: appearance,
             saturation: tabBarSaturation,
             controlShortcutDigit: tabControlShortcutDigit(for: index, tabCount: pane.tabs.count),
             showsControlShortcutHint: showsControlShortcutHints,
@@ -176,7 +181,7 @@ struct TabBarView: View {
         .onDrag {
             createItemProvider(for: tab)
         } preview: {
-            TabDragPreview(tab: tab)
+            TabDragPreview(tab: tab, appearance: appearance)
         }
         .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
             targetIndex: index,
@@ -303,7 +308,7 @@ struct TabBarView: View {
     @ViewBuilder
     private var dropIndicator: some View {
         Capsule()
-            .fill(TabBarColors.dropIndicator)
+            .fill(TabBarColors.dropIndicator(for: appearance))
             .frame(width: TabBarMetrics.dropIndicatorWidth, height: TabBarMetrics.dropIndicatorHeight)
             .offset(x: -1)
     }
@@ -363,7 +368,10 @@ struct TabBarView: View {
         HStack(spacing: 0) {
             // Left fade
             LinearGradient(
-                colors: [TabBarColors.barBackground, TabBarColors.barBackground.opacity(0)],
+                colors: [
+                    TabBarColors.barBackground(for: appearance),
+                    TabBarColors.barBackground(for: appearance).opacity(0),
+                ],
                 startPoint: .leading,
                 endPoint: .trailing
             )
@@ -375,7 +383,10 @@ struct TabBarView: View {
 
             // Right fade
             LinearGradient(
-                colors: [TabBarColors.barBackground.opacity(0), TabBarColors.barBackground],
+                colors: [
+                    TabBarColors.barBackground(for: appearance).opacity(0),
+                    TabBarColors.barBackground(for: appearance),
+                ],
                 startPoint: .leading,
                 endPoint: .trailing
             )
@@ -390,10 +401,14 @@ struct TabBarView: View {
     @ViewBuilder
     private var tabBarBackground: some View {
         Rectangle()
-            .fill(isFocused ? TabBarColors.barBackground : TabBarColors.barBackground.opacity(0.95))
+            .fill(
+                isFocused
+                    ? TabBarColors.barBackground(for: appearance)
+                    : TabBarColors.barBackground(for: appearance).opacity(0.95)
+            )
             .overlay(alignment: .bottom) {
                 Rectangle()
-                    .fill(TabBarColors.separator)
+                    .fill(TabBarColors.separator(for: appearance))
                     .frame(height: 1)
             }
     }
@@ -673,5 +688,3 @@ struct TabDropDelegate: DropDelegate {
         return transfer
     }
 }
-
-

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -317,6 +317,7 @@ struct TabBarView: View {
 
     @ViewBuilder
     private var splitButtons: some View {
+        let iconColor = TabBarColors.inactiveText(for: appearance)
         HStack(spacing: 4) {
             Button {
                 controller.requestNewTab(kind: "terminal", inPane: pane.id)
@@ -356,6 +357,7 @@ struct TabBarView: View {
             .buttonStyle(.borderless)
             .help("Split Down")
         }
+        .foregroundStyle(iconColor)
         .padding(.trailing, 8)
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabDragPreview.swift
+++ b/Sources/Bonsplit/Internal/Views/TabDragPreview.swift
@@ -3,23 +3,26 @@ import SwiftUI
 /// Preview shown during tab drag operations
 struct TabDragPreview: View {
     let tab: TabItem
+    let appearance: BonsplitConfiguration.Appearance
 
     var body: some View {
         HStack(spacing: TabBarMetrics.contentSpacing) {
             if let iconName = tab.icon {
                 Image(systemName: iconName)
                     .font(.system(size: TabBarMetrics.iconSize))
+                    .foregroundStyle(TabBarColors.activeText(for: appearance))
             }
 
             Text(tab.title)
                 .font(.system(size: TabBarMetrics.titleFontSize))
                 .lineLimit(1)
+                .foregroundStyle(TabBarColors.activeText(for: appearance))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
         .background(
             RoundedRectangle(cornerRadius: TabBarMetrics.tabCornerRadius, style: .continuous)
-                .fill(TabBarColors.activeTabBackground)
+                .fill(TabBarColors.activeTabBackground(for: appearance))
                 .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
         )
         .opacity(0.9)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -35,6 +35,7 @@ enum TabItemStyling {
 struct TabItemView: View {
     let tab: TabItem
     let isSelected: Bool
+    let appearance: BonsplitConfiguration.Appearance
     let saturation: Double
     let controlShortcutDigit: Int?
     let showsControlShortcutHint: Bool
@@ -59,7 +60,9 @@ struct TabItemView: View {
             // Icon + title block uses the standard spacing, but keep the close affordance tight.
             HStack(spacing: TabBarMetrics.contentSpacing) {
                 let iconSlotSize = TabBarMetrics.iconSize
-                let iconTint = isSelected ? TabBarColors.activeText : TabBarColors.inactiveText
+                let iconTint = isSelected
+                    ? TabBarColors.activeText(for: appearance)
+                    : TabBarColors.inactiveText(for: appearance)
                 let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { NSImage(data: $0) }
 
                 Group {
@@ -109,7 +112,11 @@ struct TabItemView: View {
                 Text(tab.title)
                     .font(.system(size: TabBarMetrics.titleFontSize))
                     .lineLimit(1)
-                    .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
+                    .foregroundStyle(
+                        isSelected
+                            ? TabBarColors.activeText(for: appearance)
+                            : TabBarColors.inactiveText(for: appearance)
+                    )
                     .saturation(saturation)
             }
 
@@ -187,7 +194,11 @@ struct TabItemView: View {
                     .monospacedDigit()
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
-                    .foregroundStyle(isSelected ? TabBarColors.activeText : TabBarColors.inactiveText)
+                    .foregroundStyle(
+                        isSelected
+                            ? TabBarColors.activeText(for: appearance)
+                            : TabBarColors.inactiveText(for: appearance)
+                    )
                     .padding(.horizontal, 4)
                     .padding(.vertical, 1)
                     .background(
@@ -272,10 +283,10 @@ struct TabItemView: View {
             // Background fill
             if isSelected {
                 Rectangle()
-                    .fill(TabBarColors.activeTabBackground)
+                    .fill(TabBarColors.activeTabBackground(for: appearance))
             } else if isHovered {
                 Rectangle()
-                    .fill(TabBarColors.hoveredTabBackground)
+                    .fill(TabBarColors.hoveredTabBackground(for: appearance))
             } else {
                 Color.clear
             }
@@ -291,7 +302,7 @@ struct TabItemView: View {
             HStack {
                 Spacer()
                 Rectangle()
-                    .fill(TabBarColors.separator)
+                    .fill(TabBarColors.separator(for: appearance))
                     .frame(width: 1)
             }
         }
@@ -307,12 +318,12 @@ struct TabItemView: View {
                 HStack(spacing: 2) {
                     if tab.showsNotificationBadge {
                         Circle()
-                            .fill(TabBarColors.notificationBadge)
+                            .fill(TabBarColors.notificationBadge(for: appearance))
                             .frame(width: TabBarMetrics.notificationBadgeSize, height: TabBarMetrics.notificationBadgeSize)
                     }
                     if tab.isDirty {
                         Circle()
-                            .fill(TabBarColors.dirtyIndicator)
+                            .fill(TabBarColors.dirtyIndicator(for: appearance))
                             .frame(width: TabBarMetrics.dirtyIndicatorSize, height: TabBarMetrics.dirtyIndicatorSize)
                             .saturation(saturation)
                     }
@@ -326,11 +337,19 @@ struct TabItemView: View {
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: TabBarMetrics.closeIconSize, weight: .semibold))
-                        .foregroundStyle(isCloseHovered ? TabBarColors.activeText : TabBarColors.inactiveText)
+                        .foregroundStyle(
+                            isCloseHovered
+                                ? TabBarColors.activeText(for: appearance)
+                                : TabBarColors.inactiveText(for: appearance)
+                        )
                         .frame(width: TabBarMetrics.closeButtonSize, height: TabBarMetrics.closeButtonSize)
                         .background(
                             Circle()
-                                .fill(isCloseHovered ? TabBarColors.hoveredTabBackground : .clear)
+                                .fill(
+                                    isCloseHovered
+                                        ? TabBarColors.hoveredTabBackground(for: appearance)
+                                        : .clear
+                                )
                         )
                 }
                 .buttonStyle(.plain)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -281,10 +281,7 @@ struct TabItemView: View {
     private var tabBackground: some View {
         ZStack(alignment: .top) {
             // Background fill
-            if isSelected {
-                Rectangle()
-                    .fill(TabBarColors.activeTabBackground(for: appearance))
-            } else if isHovered {
+            if !isSelected && isHovered {
                 Rectangle()
                     .fill(TabBarColors.hoveredTabBackground(for: appearance))
             } else {

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -103,6 +103,16 @@ public struct BonsplitConfiguration: Sendable {
 
 extension BonsplitConfiguration {
     public struct Appearance: Sendable {
+        public struct ChromeColors: Sendable {
+            /// Optional hex color (`#RRGGBB`) for tab/pane chrome backgrounds.
+            /// When unset, Bonsplit uses native system colors.
+            public var backgroundHex: String?
+
+            public init(backgroundHex: String? = nil) {
+                self.backgroundHex = backgroundHex
+            }
+        }
+
         // MARK: - Tab Bar
 
         /// Height of the tab bar
@@ -138,6 +148,11 @@ extension BonsplitConfiguration {
         /// Whether to enable animations
         public var enableAnimations: Bool
 
+        // MARK: - Theme Overrides
+
+        /// Optional color overrides for tab/pane chrome.
+        public var chromeColors: ChromeColors
+
         // MARK: - Presets
 
         public static let `default` = Appearance()
@@ -166,7 +181,8 @@ extension BonsplitConfiguration {
             minimumPaneHeight: CGFloat = 100,
             showSplitButtons: Bool = true,
             animationDuration: Double = 0.15,
-            enableAnimations: Bool = true
+            enableAnimations: Bool = true,
+            chromeColors: ChromeColors = .init()
         ) {
             self.tabBarHeight = tabBarHeight
             self.tabMinWidth = tabMinWidth
@@ -177,6 +193,7 @@ extension BonsplitConfiguration {
             self.showSplitButtons = showSplitButtons
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations
+            self.chromeColors = chromeColors
         }
     }
 }

--- a/Sources/Bonsplit/Public/BonsplitView.swift
+++ b/Sources/Bonsplit/Public/BonsplitView.swift
@@ -45,6 +45,7 @@ public struct BonsplitView<Content: View, EmptyContent: View>: View {
             emptyPaneBuilder: { internalPaneId in
                 emptyPaneBuilder(PaneID(id: internalPaneId.id))
             },
+            appearance: controller.configuration.appearance,
             showSplitButtons: controller.configuration.allowSplits && controller.configuration.appearance.showSplitButtons,
             contentViewLifecycle: controller.configuration.contentViewLifecycle,
             onGeometryChange: { [weak controller] isDragging in

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -104,6 +104,49 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(controller.configuration.allowCloseTabs)
     }
 
+    func testChromeBackgroundHexOverrideParsesForPaneBackground() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#FDF6E3")
+        )
+        let color = TabBarColors.nsColorPaneBackground(for: appearance).usingColorSpace(.sRGB)!
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(Int(round(red * 255)), 253)
+        XCTAssertEqual(Int(round(green * 255)), 246)
+        XCTAssertEqual(Int(round(blue * 255)), 227)
+        XCTAssertEqual(Int(round(alpha * 255)), 255)
+    }
+
+    func testInvalidChromeBackgroundHexFallsBackToWindowColor() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#ZZZZZZ")
+        )
+        let resolved = TabBarColors.nsColorPaneBackground(for: appearance).usingColorSpace(.sRGB)!
+        let fallback = NSColor.windowBackgroundColor.usingColorSpace(.sRGB)!
+
+        var rr: CGFloat = 0
+        var rg: CGFloat = 0
+        var rb: CGFloat = 0
+        var ra: CGFloat = 0
+        resolved.getRed(&rr, green: &rg, blue: &rb, alpha: &ra)
+
+        var fr: CGFloat = 0
+        var fg: CGFloat = 0
+        var fb: CGFloat = 0
+        var fa: CGFloat = 0
+        fallback.getRed(&fr, green: &fg, blue: &fb, alpha: &fa)
+
+        XCTAssertEqual(rr, fr, accuracy: 0.0001)
+        XCTAssertEqual(rg, fg, accuracy: 0.0001)
+        XCTAssertEqual(rb, fb, accuracy: 0.0001)
+        XCTAssertEqual(ra, fa, accuracy: 0.0001)
+    }
+
     @MainActor
     func testMoveTabNoopAfterItself() {
         let t0 = TabItem(title: "0")

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -122,12 +122,37 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(alpha * 255)), 255)
     }
 
-    func testInvalidChromeBackgroundHexFallsBackToWindowColor() {
+    func testInvalidChromeBackgroundHexFallsBackToPaneDefaultColor() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(backgroundHex: "#ZZZZZZ")
         )
         let resolved = TabBarColors.nsColorPaneBackground(for: appearance).usingColorSpace(.sRGB)!
-        let fallback = NSColor.windowBackgroundColor.usingColorSpace(.sRGB)!
+        let fallback = NSColor.textBackgroundColor.usingColorSpace(.sRGB)!
+
+        var rr: CGFloat = 0
+        var rg: CGFloat = 0
+        var rb: CGFloat = 0
+        var ra: CGFloat = 0
+        resolved.getRed(&rr, green: &rg, blue: &rb, alpha: &ra)
+
+        var fr: CGFloat = 0
+        var fg: CGFloat = 0
+        var fb: CGFloat = 0
+        var fa: CGFloat = 0
+        fallback.getRed(&fr, green: &fg, blue: &fb, alpha: &fa)
+
+        XCTAssertEqual(rr, fr, accuracy: 0.0001)
+        XCTAssertEqual(rg, fg, accuracy: 0.0001)
+        XCTAssertEqual(rb, fb, accuracy: 0.0001)
+        XCTAssertEqual(ra, fa, accuracy: 0.0001)
+    }
+
+    func testPartiallyInvalidChromeBackgroundHexFallsBackToPaneDefaultColor() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#FF000G")
+        )
+        let resolved = TabBarColors.nsColorPaneBackground(for: appearance).usingColorSpace(.sRGB)!
+        let fallback = NSColor.textBackgroundColor.usingColorSpace(.sRGB)!
 
         var rr: CGFloat = 0
         var rg: CGFloat = 0

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -147,6 +147,24 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(ra, fa, accuracy: 0.0001)
     }
 
+    func testInactiveTextUsesLightForegroundOnDarkCustomChromeBackground() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#272822")
+        )
+        let color = TabBarColors.nsColorInactiveText(for: appearance).usingColorSpace(.sRGB)!
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertGreaterThan(red, 0.5)
+        XCTAssertGreaterThan(green, 0.5)
+        XCTAssertGreaterThan(blue, 0.5)
+        XCTAssertGreaterThan(alpha, 0.6)
+    }
+
     @MainActor
     func testMoveTabNoopAfterItself() {
         let t0 = TabItem(title: "0")


### PR DESCRIPTION
## Summary
- add optional chrome background color override to Bonsplit appearance config
- derive tab bar, tab item, pane, and split container colors from override when present
- keep fallback behavior unchanged when override is unset
- add regression tests for valid/invalid hex override parsing

## Context
- Used by https://github.com/manaflow-ai/cmux/issues/150 to extend Ghostty theme colors into cmux titlebar/tab chrome.

## Validation
- \Test Suite 'All tests' started at 2026-02-20 03:16:47.703.
Test Suite 'BonsplitPackageTests.xctest' started at 2026-02-20 03:16:47.704.
Test Suite 'BonsplitTests' started at 2026-02-20 03:16:47.704.
Test Case '-[BonsplitTests.BonsplitTests testChromeBackgroundHexOverrideParsesForPaneBackground]' started.
Test Case '-[BonsplitTests.BonsplitTests testChromeBackgroundHexOverrideParsesForPaneBackground]' passed (0.001 seconds).
Test Case '-[BonsplitTests.BonsplitTests testCloseSelectedTabKeepsIndexStableWhenPossible]' started.
Test Case '-[BonsplitTests.BonsplitTests testCloseSelectedTabKeepsIndexStableWhenPossible]' passed (0.001 seconds).
Test Case '-[BonsplitTests.BonsplitTests testConfiguration]' started.
Test Case '-[BonsplitTests.BonsplitTests testConfiguration]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testControllerCreation]' started.
Test Case '-[BonsplitTests.BonsplitTests testControllerCreation]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testIconSaturationKeepsRasterFaviconInColorWhenInactive]' started.
Test Case '-[BonsplitTests.BonsplitTests testIconSaturationKeepsRasterFaviconInColorWhenInactive]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testIconSaturationStillDesaturatesSymbolIconsWhenInactive]' started.
Test Case '-[BonsplitTests.BonsplitTests testIconSaturationStillDesaturatesSymbolIconsWhenInactive]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testInvalidChromeBackgroundHexFallsBackToWindowColor]' started.
Test Case '-[BonsplitTests.BonsplitTests testInvalidChromeBackgroundHexFallsBackToWindowColor]' passed (0.030 seconds).
Test Case '-[BonsplitTests.BonsplitTests testMoveTabNoopAfterItself]' started.
Test Case '-[BonsplitTests.BonsplitTests testMoveTabNoopAfterItself]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testResolvedFaviconImageClearsWhenIncomingDataIsNil]' started.
Test Case '-[BonsplitTests.BonsplitTests testResolvedFaviconImageClearsWhenIncomingDataIsNil]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testResolvedFaviconImageKeepsExistingImageWhenIncomingDataIsInvalid]' started.
Test Case '-[BonsplitTests.BonsplitTests testResolvedFaviconImageKeepsExistingImageWhenIncomingDataIsInvalid]' passed (0.001 seconds).
Test Case '-[BonsplitTests.BonsplitTests testResolvedFaviconImageUsesIncomingDataWhenDecodable]' started.
Test Case '-[BonsplitTests.BonsplitTests testResolvedFaviconImageUsesIncomingDataWhenDecodable]' passed (0.015 seconds).
Test Case '-[BonsplitTests.BonsplitTests testTabClose]' started.
Test Case '-[BonsplitTests.BonsplitTests testTabClose]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testTabCreation]' started.
Test Case '-[BonsplitTests.BonsplitTests testTabCreation]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testTabRetrieval]' started.
Test Case '-[BonsplitTests.BonsplitTests testTabRetrieval]' passed (0.000 seconds).
Test Case '-[BonsplitTests.BonsplitTests testTabUpdate]' started.
Test Case '-[BonsplitTests.BonsplitTests testTabUpdate]' passed (0.000 seconds).
Test Suite 'BonsplitTests' passed at 2026-02-20 03:16:47.754.
	 Executed 15 tests, with 0 failures (0 unexpected) in 0.049 (0.050) seconds
Test Suite 'BonsplitPackageTests.xctest' passed at 2026-02-20 03:16:47.754.
	 Executed 15 tests, with 0 failures (0 unexpected) in 0.049 (0.050) seconds
Test Suite 'All tests' passed at 2026-02-20 03:16:47.754.
	 Executed 15 tests, with 0 failures (0 unexpected) in 0.049 (0.051) seconds
􀟈  Test run started.
􀄵  Testing Library Version: 1501
􀄵  Target Platform: arm64e-apple-macos14.0
􁁛  Test run with 0 tests in 0 suites passed after 0.001 seconds. passed