### PR TITLE
Add configurable split button tooltips for tab bar actions

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -123,6 +123,29 @@ enum TabBarColors {
         effectiveTextColor(for: appearance, secondary: true)
     }
 
+    static func splitActionIcon(for appearance: BonsplitConfiguration.Appearance, isPressed: Bool) -> Color {
+        Color(nsColor: nsColorSplitActionIcon(for: appearance, isPressed: isPressed))
+    }
+
+    static func nsColorSplitActionIcon(
+        for appearance: BonsplitConfiguration.Appearance,
+        isPressed: Bool
+    ) -> NSColor {
+        isPressed ? nsColorActiveText(for: appearance) : nsColorInactiveText(for: appearance)
+    }
+
+    static func splitActionBackground(for appearance: BonsplitConfiguration.Appearance, isPressed: Bool) -> Color {
+        Color(nsColor: nsColorSplitActionBackground(for: appearance, isPressed: isPressed))
+    }
+
+    static func nsColorSplitActionBackground(
+        for appearance: BonsplitConfiguration.Appearance,
+        isPressed: Bool
+    ) -> NSColor {
+        let alpha: CGFloat = isPressed ? 0.18 : 0.0
+        return nsColorActiveText(for: appearance).withAlphaComponent(alpha)
+    }
+
     // MARK: - Borders & Indicators
 
     static var separator: Color {

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -134,18 +134,6 @@ enum TabBarColors {
         isPressed ? nsColorActiveText(for: appearance) : nsColorInactiveText(for: appearance)
     }
 
-    static func splitActionBackground(for appearance: BonsplitConfiguration.Appearance, isPressed: Bool) -> Color {
-        Color(nsColor: nsColorSplitActionBackground(for: appearance, isPressed: isPressed))
-    }
-
-    static func nsColorSplitActionBackground(
-        for appearance: BonsplitConfiguration.Appearance,
-        isPressed: Bool
-    ) -> NSColor {
-        let alpha: CGFloat = isPressed ? 0.18 : 0.0
-        return nsColorActiveText(for: appearance).withAlphaComponent(alpha)
-    }
-
     // MARK: - Borders & Indicators
 
     static var separator: Color {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -318,7 +318,6 @@ struct TabBarView: View {
     @ViewBuilder
     private var splitButtons: some View {
         let tooltips = controller.configuration.appearance.splitButtonTooltips
-        let iconColor = TabBarColors.inactiveText(for: appearance)
         HStack(spacing: 4) {
             Button {
                 controller.requestNewTab(kind: "terminal", inPane: pane.id)
@@ -326,7 +325,7 @@ struct TabBarView: View {
                 Image(systemName: "terminal")
                     .font(.system(size: 12))
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
             .help(tooltips.newTerminal)
 
             Button {
@@ -335,7 +334,7 @@ struct TabBarView: View {
                 Image(systemName: "globe")
                     .font(.system(size: 12))
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
             .help(tooltips.newBrowser)
 
             Button {
@@ -345,7 +344,7 @@ struct TabBarView: View {
                 Image(systemName: "square.split.2x1")
                     .font(.system(size: 12))
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
             .help(tooltips.splitRight)
 
             Button {
@@ -355,10 +354,9 @@ struct TabBarView: View {
                 Image(systemName: "square.split.1x2")
                     .font(.system(size: 12))
             }
-            .buttonStyle(.borderless)
+            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
             .help(tooltips.splitDown)
         }
-        .foregroundStyle(iconColor)
         .padding(.trailing, 8)
     }
 
@@ -414,6 +412,22 @@ struct TabBarView: View {
                     .fill(TabBarColors.separator(for: appearance))
                     .frame(height: 1)
             }
+    }
+}
+
+private struct SplitActionButtonStyle: ButtonStyle {
+    let appearance: BonsplitConfiguration.Appearance
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: 16, height: 16)
+            .padding(4)
+            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(TabBarColors.splitActionBackground(for: appearance, isPressed: configuration.isPressed))
+            )
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -312,6 +312,7 @@ struct TabBarView: View {
 
     @ViewBuilder
     private var splitButtons: some View {
+        let tooltips = controller.configuration.appearance.splitButtonTooltips
         HStack(spacing: 4) {
             Button {
                 controller.requestNewTab(kind: "terminal", inPane: pane.id)
@@ -320,7 +321,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(.borderless)
-            .help("New Terminal  ⌘T")
+            .help(tooltips.newTerminal)
 
             Button {
                 controller.requestNewTab(kind: "browser", inPane: pane.id)
@@ -329,7 +330,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(.borderless)
-            .help("New Browser  ⌘⇧L")
+            .help(tooltips.newBrowser)
 
             Button {
                 // 120fps animation handled by SplitAnimator
@@ -339,7 +340,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(.borderless)
-            .help("Split Right")
+            .help(tooltips.splitRight)
 
             Button {
                 // 120fps animation handled by SplitAnimator
@@ -349,7 +350,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(.borderless)
-            .help("Split Down")
+            .help(tooltips.splitDown)
         }
         .padding(.trailing, 8)
     }
@@ -673,5 +674,4 @@ struct TabDropDelegate: DropDelegate {
         return transfer
     }
 }
-
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -420,14 +420,7 @@ private struct SplitActionButtonStyle: ButtonStyle {
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .frame(width: 16, height: 16)
-            .padding(4)
-            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
-            .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(TabBarColors.splitActionBackground(for: appearance, isPressed: configuration.isPressed))
-            )
     }
 }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -102,6 +102,27 @@ public struct BonsplitConfiguration: Sendable {
 // MARK: - Appearance Configuration
 
 extension BonsplitConfiguration {
+    public struct SplitButtonTooltips: Sendable, Equatable {
+        public var newTerminal: String
+        public var newBrowser: String
+        public var splitRight: String
+        public var splitDown: String
+
+        public static let `default` = SplitButtonTooltips()
+
+        public init(
+            newTerminal: String = "New Terminal",
+            newBrowser: String = "New Browser",
+            splitRight: String = "Split Right",
+            splitDown: String = "Split Down"
+        ) {
+            self.newTerminal = newTerminal
+            self.newBrowser = newBrowser
+            self.splitRight = splitRight
+            self.splitDown = splitDown
+        }
+    }
+
     public struct Appearance: Sendable {
         // MARK: - Tab Bar
 
@@ -129,6 +150,9 @@ extension BonsplitConfiguration {
 
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
+
+        /// Tooltip text for the tab bar's right-side action buttons
+        public var splitButtonTooltips: SplitButtonTooltips
 
         // MARK: - Animations
 
@@ -165,6 +189,7 @@ extension BonsplitConfiguration {
             minimumPaneWidth: CGFloat = 100,
             minimumPaneHeight: CGFloat = 100,
             showSplitButtons: Bool = true,
+            splitButtonTooltips: SplitButtonTooltips = .default,
             animationDuration: Double = 0.15,
             enableAnimations: Bool = true
         ) {
@@ -175,6 +200,7 @@ extension BonsplitConfiguration {
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.showSplitButtons = showSplitButtons
+            self.splitButtonTooltips = splitButtonTooltips
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations
         }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -216,7 +216,7 @@ final class BonsplitTests: XCTestCase {
         XCTAssertGreaterThan(alpha, 0.6)
     }
 
-    func testSplitActionPressedStateUsesHigherContrastAndVisibleBackground() {
+    func testSplitActionPressedStateUsesHigherContrast() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(backgroundHex: "#272822")
         )
@@ -230,17 +230,6 @@ final class BonsplitTests: XCTestCase {
         pressedIcon.getRed(nil, green: nil, blue: nil, alpha: &pressedAlpha)
 
         XCTAssertGreaterThan(pressedAlpha, idleAlpha)
-
-        let idleBackground = TabBarColors.nsColorSplitActionBackground(for: appearance, isPressed: false).usingColorSpace(.sRGB)!
-        let pressedBackground = TabBarColors.nsColorSplitActionBackground(for: appearance, isPressed: true).usingColorSpace(.sRGB)!
-
-        var idleBackgroundAlpha: CGFloat = 0
-        idleBackground.getRed(nil, green: nil, blue: nil, alpha: &idleBackgroundAlpha)
-        var pressedBackgroundAlpha: CGFloat = 0
-        pressedBackground.getRed(nil, green: nil, blue: nil, alpha: &pressedBackgroundAlpha)
-
-        XCTAssertEqual(idleBackgroundAlpha, 0, accuracy: 0.0001)
-        XCTAssertGreaterThan(pressedBackgroundAlpha, 0.1)
     }
 
     @MainActor

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -216,6 +216,33 @@ final class BonsplitTests: XCTestCase {
         XCTAssertGreaterThan(alpha, 0.6)
     }
 
+    func testSplitActionPressedStateUsesHigherContrastAndVisibleBackground() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#272822")
+        )
+
+        let idleIcon = TabBarColors.nsColorSplitActionIcon(for: appearance, isPressed: false).usingColorSpace(.sRGB)!
+        let pressedIcon = TabBarColors.nsColorSplitActionIcon(for: appearance, isPressed: true).usingColorSpace(.sRGB)!
+
+        var idleAlpha: CGFloat = 0
+        idleIcon.getRed(nil, green: nil, blue: nil, alpha: &idleAlpha)
+        var pressedAlpha: CGFloat = 0
+        pressedIcon.getRed(nil, green: nil, blue: nil, alpha: &pressedAlpha)
+
+        XCTAssertGreaterThan(pressedAlpha, idleAlpha)
+
+        let idleBackground = TabBarColors.nsColorSplitActionBackground(for: appearance, isPressed: false).usingColorSpace(.sRGB)!
+        let pressedBackground = TabBarColors.nsColorSplitActionBackground(for: appearance, isPressed: true).usingColorSpace(.sRGB)!
+
+        var idleBackgroundAlpha: CGFloat = 0
+        idleBackground.getRed(nil, green: nil, blue: nil, alpha: &idleBackgroundAlpha)
+        var pressedBackgroundAlpha: CGFloat = 0
+        pressedBackground.getRed(nil, green: nil, blue: nil, alpha: &pressedBackgroundAlpha)
+
+        XCTAssertEqual(idleBackgroundAlpha, 0, accuracy: 0.0001)
+        XCTAssertGreaterThan(pressedBackgroundAlpha, 0.1)
+    }
+
     @MainActor
     func testMoveTabNoopAfterItself() {
         let t0 = TabItem(title: "0")

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -104,6 +104,32 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(controller.configuration.allowCloseTabs)
     }
 
+    func testDefaultSplitButtonTooltips() {
+        let defaults = BonsplitConfiguration.SplitButtonTooltips.default
+        XCTAssertEqual(defaults.newTerminal, "New Terminal")
+        XCTAssertEqual(defaults.newBrowser, "New Browser")
+        XCTAssertEqual(defaults.splitRight, "Split Right")
+        XCTAssertEqual(defaults.splitDown, "Split Down")
+    }
+
+    @MainActor
+    func testConfigurationAcceptsCustomSplitButtonTooltips() {
+        let customTooltips = BonsplitConfiguration.SplitButtonTooltips(
+            newTerminal: "Terminal (⌘T)",
+            newBrowser: "Browser (⌘⇧L)",
+            splitRight: "Split Right (⌘D)",
+            splitDown: "Split Down (⌘⇧D)"
+        )
+        let config = BonsplitConfiguration(
+            appearance: .init(
+                splitButtonTooltips: customTooltips
+            )
+        )
+        let controller = BonsplitController(configuration: config)
+
+        XCTAssertEqual(controller.configuration.appearance.splitButtonTooltips, customTooltips)
+    }
+
     @MainActor
     func testMoveTabNoopAfterItself() {
         let t0 = TabItem(title: "0")


### PR DESCRIPTION
## Summary
- add `BonsplitConfiguration.SplitButtonTooltips` so host apps can configure tab-bar action tooltip text
- update `TabBarView` split-button help text to use those configuration values
- add tests for default and custom split-button tooltip behavior

## Testing
- `swift test`
