### PR TITLE
Fix ThemedSplitView not available in Release builds

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -3,6 +3,14 @@ import AppKit
 
 private var splitContainerProgrammaticSyncDepth = 0
 
+private class ThemedSplitView: NSSplitView {
+    var customDividerColor: NSColor?
+
+    override var dividerColor: NSColor {
+        customDividerColor ?? super.dividerColor
+    }
+}
+
 #if DEBUG
 private func debugPointString(_ point: NSPoint) -> String {
     let x = Int(point.x.rounded())
@@ -16,14 +24,6 @@ private func debugRectString(_ rect: NSRect) -> String {
     let w = Int(rect.size.width.rounded())
     let h = Int(rect.size.height.rounded())
     return "\(x):\(y)+\(w)x\(h)"
-}
-
-private class ThemedSplitView: NSSplitView {
-    var customDividerColor: NSColor?
-
-    override var dividerColor: NSColor {
-        customDividerColor ?? super.dividerColor
-    }
 }
 
 private final class DebugSplitView: ThemedSplitView {


### PR DESCRIPTION
## Summary
- `ThemedSplitView` was defined inside `#if DEBUG` but referenced in non-DEBUG code paths (`makeNSView` `#else` branch at line 111 and `updateNSView` at line 312)
- This caused compilation errors in Release configuration, breaking the nightly build: https://github.com/manaflow-ai/cmux/actions/runs/22292693812
- Moved `ThemedSplitView` outside `#if DEBUG` since it's needed in all build configurations; only `DebugSplitView` remains DEBUG-only

## Test plan
- [ ] Verify Debug build compiles
- [ ] Verify Release build compiles (was previously broken)