### PR TITLE
Clamp pane hosting and relax intrinsic sizing for narrow splits

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -357,11 +357,24 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
     private func makeHostingController(for node: SplitNode) -> NSHostingController<AnyView> {
         let hostingController = NSHostingController(rootView: AnyView(makeView(for: node)))
+        if #available(macOS 13.0, *) {
+            // NSSplitView owns pane geometry. Keep NSHostingController from publishing
+            // intrinsic-size constraints that force a minimum pane width.
+            hostingController.sizingOptions = []
+        }
+
+        let hostedView = hostingController.view
         // NSSplitView lays out arranged subviews by setting frames. Leaving Auto Layout
         // enabled on these NSHostingViews can allow them to compress to 0 during
         // structural updates, collapsing panes.
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = true
-        hostingController.view.autoresizingMask = [.width, .height]
+        hostedView.translatesAutoresizingMaskIntoConstraints = true
+        hostedView.autoresizingMask = [.width, .height]
+        // Do not let SwiftUI intrinsic size push split panes wider than the model frame.
+        let relaxed = NSLayoutConstraint.Priority(1)
+        hostedView.setContentHuggingPriority(relaxed, for: .horizontal)
+        hostedView.setContentCompressionResistancePriority(relaxed, for: .horizontal)
+        hostedView.setContentHuggingPriority(relaxed, for: .vertical)
+        hostedView.setContentCompressionResistancePriority(relaxed, for: .vertical)
         return hostingController
     }
 

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -70,6 +70,8 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 
         let containerView = PaneDragContainerView()
+        containerView.wantsLayer = true
+        containerView.layer?.masksToBounds = true
         containerView.addSubview(hostingController.view)
 
         NSLayoutConstraint.activate([
@@ -89,6 +91,8 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
         // Hide the container when inactive so AppKit's drag routing doesn't deliver
         // drag sessions to views belonging to background workspaces.
         nsView.isHidden = !controller.isInteractive
+        nsView.wantsLayer = true
+        nsView.layer?.masksToBounds = true
 
         let paneView = PaneContainerView(
             pane: pane,


### PR DESCRIPTION
## Summary
- relax `NSHostingController` sizing behavior so split panes are not forced by intrinsic-size constraints
- mask pane container layers to clip overdraw during aggressive narrow resizing

## Validation
- built via parent cmux Debug build (Bonsplit integrated as local package)
- validated issue #348 workflow in cmux