### PR TITLE
Add cross-workspace tab move hooks

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -112,6 +112,38 @@ extension TabItem: Transferable {
 struct TabTransferData: Codable, Transferable {
     let tab: TabItem
     let sourcePaneId: UUID
+    let sourceProcessId: Int32
+
+    init(tab: TabItem, sourcePaneId: UUID, sourceProcessId: Int32 = Int32(ProcessInfo.processInfo.processIdentifier)) {
+        self.tab = tab
+        self.sourcePaneId = sourcePaneId
+        self.sourceProcessId = sourceProcessId
+    }
+
+    var isFromCurrentProcess: Bool {
+        sourceProcessId == Int32(ProcessInfo.processInfo.processIdentifier)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case tab
+        case sourcePaneId
+        case sourceProcessId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.tab = try container.decode(TabItem.self, forKey: .tab)
+        self.sourcePaneId = try container.decode(UUID.self, forKey: .sourcePaneId)
+        // Legacy payloads won't include this field. Treat as foreign process to reject cross-instance drops.
+        self.sourceProcessId = try container.decodeIfPresent(Int32.self, forKey: .sourceProcessId) ?? -1
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(tab, forKey: .tab)
+        try container.encode(sourcePaneId, forKey: .sourcePaneId)
+        try container.encode(sourceProcessId, forKey: .sourceProcessId)
+    }
 
     static var transferRepresentation: some TransferRepresentation {
         CodableRepresentation(contentType: .tabTransfer)

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import AppKit
 
 /// Drop zone positions for creating splits
 public enum DropZone: Equatable {
@@ -324,7 +325,31 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            return false
+            guard let transfer = decodeTransfer(from: info) else { return false }
+            let destination: BonsplitController.ExternalTabDropRequest.Destination
+            if zone == .center {
+                destination = .insert(targetPane: pane.id, targetIndex: nil)
+            } else if let orientation = zone.orientation {
+                destination = .split(
+                    targetPane: pane.id,
+                    orientation: orientation,
+                    insertFirst: zone.insertsFirst
+                )
+            } else {
+                return false
+            }
+
+            let request = BonsplitController.ExternalTabDropRequest(
+                tabId: TabID(id: transfer.tab.id),
+                sourcePaneId: PaneID(id: transfer.sourcePaneId),
+                destination: destination
+            )
+            let handled = bonsplitController.onExternalTabDrop?(request) ?? false
+            if handled {
+                dropLifecycle = .idle
+                activeDropZone = nil
+            }
+            return handled
         }
 
         // Clear both observable and non-observable drag state.
@@ -433,5 +458,18 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             return nil
         }
         return transfer
+    }
+
+    private func decodeTransfer(from info: DropInfo) -> TabTransferData? {
+        let pasteboard = NSPasteboard(name: .drag)
+        let type = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+        if let data = pasteboard.data(forType: type),
+           let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) {
+            return transfer
+        }
+        if let raw = pasteboard.string(forType: type) {
+            return decodeTransfer(from: raw)
+        }
+        return nil
     }
 }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -325,7 +325,10 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            guard let transfer = decodeTransfer(from: info) else { return false }
+            guard let transfer = decodeTransfer(from: info),
+                  transfer.isFromCurrentProcess else {
+                return false
+            }
             let destination: BonsplitController.ExternalTabDropRequest.Destination
             if zone == .center {
                 destination = .insert(targetPane: pane.id, targetIndex: nil)
@@ -441,6 +444,18 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         // Do NOT gate on draggingTab != nil: @Observable changes from createItemProvider
         // may not have propagated to the drop delegate yet, causing false rejections.
         let hasType = info.hasItemsConforming(to: [.tabTransfer])
+        guard hasType else { return false }
+
+        // Local drags use in-memory state and are always same-process.
+        if controller.activeDragTab != nil || controller.draggingTab != nil {
+            return true
+        }
+
+        // External drags (another Bonsplit controller) must include a payload from this process.
+        guard let transfer = decodeTransfer(from: info),
+              transfer.isFromCurrentProcess else {
+            return false
+        }
 #if DEBUG
         let hasDrag = controller.draggingTab != nil
         let hasActive = controller.activeDragTab != nil
@@ -449,7 +464,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             "allowed=\(hasType ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
         )
 #endif
-        return hasType
+        return true
     }
 
     private func decodeTransfer(from string: String) -> TabTransferData? {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -359,7 +359,7 @@ struct TabBarView: View {
             let provider = NSItemProvider()
             provider.registerDataRepresentation(
                 forTypeIdentifier: UTType.tabTransfer.identifier,
-                visibility: .all
+                visibility: .ownProcess
             ) { completion in
                 completion(data, nil)
                 return nil
@@ -846,7 +846,10 @@ struct TabDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            guard let transfer = decodeTransfer(from: info) else { return false }
+            guard let transfer = decodeTransfer(from: info),
+                  transfer.isFromCurrentProcess else {
+                return false
+            }
             let request = BonsplitController.ExternalTabDropRequest(
                 tabId: TabID(id: transfer.tab.id),
                 sourcePaneId: PaneID(id: transfer.sourcePaneId),
@@ -958,6 +961,18 @@ struct TabDropDelegate: DropDelegate {
         // Do NOT gate on draggingTab != nil: @Observable changes from createItemProvider
         // may not have propagated to the drop delegate yet, causing false rejections.
         let hasType = info.hasItemsConforming(to: [.tabTransfer])
+        guard hasType else { return false }
+
+        // Local drags use in-memory state and are always same-process.
+        if controller.activeDragTab != nil || controller.draggingTab != nil {
+            return true
+        }
+
+        // External drags (another Bonsplit controller) must include a payload from this process.
+        guard let transfer = decodeTransfer(from: info),
+              transfer.isFromCurrentProcess else {
+            return false
+        }
 #if DEBUG
         let hasDrag = controller.draggingTab != nil
         let hasActive = controller.activeDragTab != nil
@@ -966,7 +981,7 @@ struct TabDropDelegate: DropDelegate {
             "allowed=\(hasType ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
         )
 #endif
-        return hasType
+        return true
     }
 
     private func shouldSuppressIndicatorForNoopSamePaneDrop() -> Bool {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -139,6 +139,7 @@ struct TabBarView: View {
                                 .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
                                     targetIndex: pane.tabs.count,
                                     pane: pane,
+                                    bonsplitController: controller,
                                     controller: splitViewController,
                                     dropTargetIndex: $dropTargetIndex,
                                     dropLifecycle: $dropLifecycle
@@ -268,6 +269,7 @@ struct TabBarView: View {
         .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
             targetIndex: index,
             pane: pane,
+            bonsplitController: controller,
             controller: splitViewController,
             dropTargetIndex: $dropTargetIndex,
             dropLifecycle: $dropLifecycle
@@ -402,6 +404,7 @@ struct TabBarView: View {
             .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
                 targetIndex: pane.tabs.count,
                 pane: pane,
+                bonsplitController: controller,
                 controller: splitViewController,
                 dropTargetIndex: $dropTargetIndex,
                 dropLifecycle: $dropLifecycle
@@ -818,6 +821,7 @@ enum TabDropLifecycle {
 struct TabDropDelegate: DropDelegate {
     let targetIndex: Int
     let pane: PaneState
+    let bonsplitController: BonsplitController
     let controller: SplitViewController
     @Binding var dropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
@@ -842,7 +846,18 @@ struct TabDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            return false
+            guard let transfer = decodeTransfer(from: info) else { return false }
+            let request = BonsplitController.ExternalTabDropRequest(
+                tabId: TabID(id: transfer.tab.id),
+                sourcePaneId: PaneID(id: transfer.sourcePaneId),
+                destination: .insert(targetPane: pane.id, targetIndex: targetIndex)
+            )
+            let handled = bonsplitController.onExternalTabDrop?(request) ?? false
+            if handled {
+                dropLifecycle = .idle
+                dropTargetIndex = nil
+            }
+            return handled
         }
 
         // Execute synchronously when possible so the dragged tab disappears immediately.
@@ -971,5 +986,18 @@ struct TabDropDelegate: DropDelegate {
             return nil
         }
         return transfer
+    }
+
+    private func decodeTransfer(from info: DropInfo) -> TabTransferData? {
+        let pasteboard = NSPasteboard(name: .drag)
+        let type = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+        if let data = pasteboard.data(forType: type),
+           let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) {
+            return transfer
+        }
+        if let raw = pasteboard.string(forType: type) {
+            return decodeTransfer(from: raw)
+        }
+        return nil
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -317,6 +317,10 @@ struct TabItemView: View {
         }
         .disabled(!contextMenuState.canCloseOthers)
 
+        Button("Move Tab…") {
+            onContextAction(.move)
+        }
+
         Divider()
 
         Button("New Terminal Tab to Right") {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -6,6 +6,23 @@ import SwiftUI
 @Observable
 public final class BonsplitController {
 
+    public struct ExternalTabDropRequest {
+        public enum Destination {
+            case insert(targetPane: PaneID, targetIndex: Int?)
+            case split(targetPane: PaneID, orientation: SplitOrientation, insertFirst: Bool)
+        }
+
+        public let tabId: TabID
+        public let sourcePaneId: PaneID
+        public let destination: Destination
+
+        public init(tabId: TabID, sourcePaneId: PaneID, destination: Destination) {
+            self.tabId = tabId
+            self.sourcePaneId = sourcePaneId
+            self.destination = destination
+        }
+    }
+
     // MARK: - Delegate
 
     /// Delegate for receiving callbacks about tab bar events
@@ -29,6 +46,10 @@ public final class BonsplitController {
     @ObservationIgnored public var onFileDrop: ((_ urls: [URL], _ paneId: PaneID) -> Bool)? {
         didSet { internalController.onFileDrop = onFileDrop }
     }
+
+    /// Handler for tab drops originating from another Bonsplit controller (e.g. another workspace/window).
+    /// Return `true` when the drop has been handled by the host application.
+    @ObservationIgnored public var onExternalTabDrop: ((ExternalTabDropRequest) -> Bool)?
 
     // MARK: - Internal State
 

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -7,6 +7,7 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case closeToLeft
     case closeToRight
     case closeOthers
+    case move
     case newTerminalToRight
     case newBrowserToRight
     case reload

--- a/Sources/Bonsplit/Public/Types/TabID.swift
+++ b/Sources/Bonsplit/Public/Types/TabID.swift
@@ -8,6 +8,14 @@ public struct TabID: Hashable, Codable, Sendable {
         self.id = UUID()
     }
 
+    public init(uuid: UUID) {
+        self.id = uuid
+    }
+
+    public var uuid: UUID {
+        id
+    }
+
     internal init(id: UUID) {
         self.id = id
     }


### PR DESCRIPTION
## Summary
- add a new tab context action (`move`) and expose it in the tab right-click menu
- add `BonsplitController.onExternalTabDrop` + request model so host apps can handle cross-controller tab drops
- teach tab-bar and pane drop delegates to fall back to external drop handling when drag state is from another workspace/window
- expose `TabID(uuid:)` and `TabID.uuid` for host-side routing

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' build` (from parent cmux worktree) ✅

## Issues
- Related: task-bonsplit-tab-drag-drop-between-windows-workspaces
