### PR TITLE
Add pane split-zoom API, lifecycle safety, and zoom indicator UX

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -11,6 +11,10 @@ final class SplitViewController {
     /// Currently focused pane ID
     var focusedPaneId: PaneID?
 
+    /// Optional pane currently shown in zoomed mode.
+    /// When set, view rendering bypasses split layout and shows only this pane.
+    var zoomedPaneId: PaneID?
+
     /// Tab currently being dragged (for visual feedback and hit-testing).
     /// This is @Observable so SwiftUI views react (e.g. allowsHitTesting).
     var draggingTab: TabItem?
@@ -66,6 +70,22 @@ final class SplitViewController {
         }
     }
 
+    @discardableResult
+    func setZoomedPane(_ paneId: PaneID?) -> Bool {
+        if let paneId {
+            guard rootNode.findPane(paneId) != nil else { return false }
+        }
+        zoomedPaneId = paneId
+        return true
+    }
+
+    private func clearZoomIfInvalid() {
+        guard let zoomedPaneId else { return }
+        if rootNode.findPane(zoomedPaneId) == nil {
+            self.zoomedPaneId = nil
+        }
+    }
+
     // MARK: - Focus Management
 
     /// Set focus to a specific pane
@@ -87,6 +107,7 @@ final class SplitViewController {
 
     /// Split the specified pane in the given orientation
     func splitPane(_ paneId: PaneID, orientation: SplitOrientation, with newTab: TabItem? = nil) {
+        zoomedPaneId = nil
         rootNode = splitNodeRecursively(
             node: rootNode,
             targetPaneId: paneId,
@@ -150,6 +171,7 @@ final class SplitViewController {
 
     /// Split a pane with a specific tab, optionally inserting the new pane first
     func splitPaneWithTab(_ paneId: PaneID, orientation: SplitOrientation, tab: TabItem, insertFirst: Bool) {
+        zoomedPaneId = nil
         rootNode = splitNodeWithTabRecursively(
             node: rootNode,
             targetPaneId: paneId,
@@ -225,6 +247,10 @@ final class SplitViewController {
         // Don't close the last pane
         guard rootNode.allPaneIds.count > 1 else { return }
 
+        if zoomedPaneId == paneId {
+            zoomedPaneId = nil
+        }
+
         let (newRoot, siblingPaneId) = closePaneRecursively(node: rootNode, targetPaneId: paneId)
 
         if let newRoot {
@@ -237,6 +263,7 @@ final class SplitViewController {
         } else if let firstPane = rootNode.allPaneIds.first {
             focusedPaneId = firstPane
         }
+        clearZoomIfInvalid()
     }
 
     private func closePaneRecursively(
@@ -317,6 +344,7 @@ final class SplitViewController {
         if sourcePane.tabs.isEmpty && rootNode.allPaneIds.count > 1 {
             closePane(sourcePaneId)
         }
+        clearZoomIfInvalid()
     }
 
     /// Close a tab in a specific pane
@@ -329,6 +357,7 @@ final class SplitViewController {
         if pane.tabs.isEmpty && rootNode.allPaneIds.count > 1 {
             closePane(paneId)
         }
+        clearZoomIfInvalid()
     }
 
     // MARK: - Keyboard Navigation

--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -112,6 +112,38 @@ extension TabItem: Transferable {
 struct TabTransferData: Codable, Transferable {
     let tab: TabItem
     let sourcePaneId: UUID
+    let sourceProcessId: Int32
+
+    init(tab: TabItem, sourcePaneId: UUID, sourceProcessId: Int32 = Int32(ProcessInfo.processInfo.processIdentifier)) {
+        self.tab = tab
+        self.sourcePaneId = sourcePaneId
+        self.sourceProcessId = sourceProcessId
+    }
+
+    var isFromCurrentProcess: Bool {
+        sourceProcessId == Int32(ProcessInfo.processInfo.processIdentifier)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case tab
+        case sourcePaneId
+        case sourceProcessId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.tab = try container.decode(TabItem.self, forKey: .tab)
+        self.sourcePaneId = try container.decode(UUID.self, forKey: .sourcePaneId)
+        // Legacy payloads won't include this field. Treat as foreign process to reject cross-instance drops.
+        self.sourceProcessId = try container.decodeIfPresent(Int32.self, forKey: .sourceProcessId) ?? -1
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(tab, forKey: .tab)
+        try container.encode(sourcePaneId, forKey: .sourcePaneId)
+        try container.encode(sourceProcessId, forKey: .sourceProcessId)
+    }
 
     static var transferRepresentation: some TransferRepresentation {
         CodableRepresentation(contentType: .tabTransfer)

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UniformTypeIdentifiers
+import AppKit
 
 /// Drop zone positions for creating splits
 public enum DropZone: Equatable {
@@ -324,7 +325,31 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            return false
+            guard let transfer = decodeTransfer(from: info) else { return false }
+            let destination: BonsplitController.ExternalTabDropRequest.Destination
+            if zone == .center {
+                destination = .insert(targetPane: pane.id, targetIndex: nil)
+            } else if let orientation = zone.orientation {
+                destination = .split(
+                    targetPane: pane.id,
+                    orientation: orientation,
+                    insertFirst: zone.insertsFirst
+                )
+            } else {
+                return false
+            }
+
+            let request = BonsplitController.ExternalTabDropRequest(
+                tabId: TabID(id: transfer.tab.id),
+                sourcePaneId: PaneID(id: transfer.sourcePaneId),
+                destination: destination
+            )
+            let handled = bonsplitController.onExternalTabDrop?(request) ?? false
+            if handled {
+                dropLifecycle = .idle
+                activeDropZone = nil
+            }
+            return handled
         }
 
         // Clear both observable and non-observable drag state.
@@ -433,5 +458,18 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             return nil
         }
         return transfer
+    }
+
+    private func decodeTransfer(from info: DropInfo) -> TabTransferData? {
+        let pasteboard = NSPasteboard(name: .drag)
+        let type = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+        if let data = pasteboard.data(forType: type),
+           let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) {
+            return transfer
+        }
+        if let raw = pasteboard.string(forType: type) {
+            return decodeTransfer(from: raw)
+        }
+        return nil
     }
 }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -325,7 +325,10 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            guard let transfer = decodeTransfer(from: info) else { return false }
+            guard let transfer = decodeTransfer(from: info),
+                  transfer.isFromCurrentProcess else {
+                return false
+            }
             let destination: BonsplitController.ExternalTabDropRequest.Destination
             if zone == .center {
                 destination = .insert(targetPane: pane.id, targetIndex: nil)
@@ -441,6 +444,18 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         // Do NOT gate on draggingTab != nil: @Observable changes from createItemProvider
         // may not have propagated to the drop delegate yet, causing false rejections.
         let hasType = info.hasItemsConforming(to: [.tabTransfer])
+        guard hasType else { return false }
+
+        // Local drags use in-memory state and are always same-process.
+        if controller.activeDragTab != nil || controller.draggingTab != nil {
+            return true
+        }
+
+        // External drags (another Bonsplit controller) must include a payload from this process.
+        guard let transfer = decodeTransfer(from: info),
+              transfer.isFromCurrentProcess else {
+            return false
+        }
 #if DEBUG
         let hasDrag = controller.draggingTab != nil
         let hasActive = controller.activeDragTab != nil
@@ -449,7 +464,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             "allowed=\(hasType ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
         )
 #endif
-        return hasType
+        return true
     }
 
     private func decodeTransfer(from string: String) -> TabTransferData? {

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -79,6 +79,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
     let appearance: BonsplitConfiguration.Appearance
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
+    var excludedPaneID: PaneID? = nil
     var showSplitButtons: Bool = true
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
     /// Callback when geometry changes. Bool indicates if change is during active divider drag.
@@ -420,14 +421,18 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
     private func makeView(for node: SplitNode) -> some View {
         switch node {
         case .pane(let paneState):
-            PaneContainerView(
-                pane: paneState,
-                controller: controller,
-                contentBuilder: contentBuilder,
-                emptyPaneBuilder: emptyPaneBuilder,
-                showSplitButtons: showSplitButtons,
-                contentViewLifecycle: contentViewLifecycle
-            )
+            if paneState.id == excludedPaneID {
+                Color.clear
+            } else {
+                PaneContainerView(
+                    pane: paneState,
+                    controller: controller,
+                    contentBuilder: contentBuilder,
+                    emptyPaneBuilder: emptyPaneBuilder,
+                    showSplitButtons: showSplitButtons,
+                    contentViewLifecycle: contentViewLifecycle
+                )
+            }
         case .split(let nestedSplitState):
             SplitContainerView(
                 splitState: nestedSplitState,
@@ -435,6 +440,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 appearance: appearance,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
+                excludedPaneID: excludedPaneID,
                 showSplitButtons: showSplitButtons,
                 contentViewLifecycle: contentViewLifecycle,
                 onGeometryChange: onGeometryChange,

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -9,6 +9,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
+    var excludedPaneID: PaneID? = nil
     var showSplitButtons: Bool = true
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
     var onGeometryChange: ((_ isDragging: Bool) -> Void)?
@@ -18,14 +19,18 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
     var body: some View {
         switch node {
         case .pane(let paneState):
-            // Wrap in NSHostingController for proper layout constraints
-            SinglePaneWrapper(
-                pane: paneState,
-                contentBuilder: contentBuilder,
-                emptyPaneBuilder: emptyPaneBuilder,
-                showSplitButtons: showSplitButtons,
-                contentViewLifecycle: contentViewLifecycle
-            )
+            if paneState.id == excludedPaneID {
+                Color.clear
+            } else {
+                // Wrap in NSHostingController for proper layout constraints
+                SinglePaneWrapper(
+                    pane: paneState,
+                    contentBuilder: contentBuilder,
+                    emptyPaneBuilder: emptyPaneBuilder,
+                    showSplitButtons: showSplitButtons,
+                    contentViewLifecycle: contentViewLifecycle
+                )
+            }
 
         case .split(let splitState):
             SplitContainerView(
@@ -34,6 +39,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
                 appearance: appearance,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
+                excludedPaneID: excludedPaneID,
                 showSplitButtons: showSplitButtons,
                 contentViewLifecycle: contentViewLifecycle,
                 onGeometryChange: onGeometryChange,

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -37,16 +37,50 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var splitNodeContent: some View {
-        SplitNodeView(
-            node: controller.rootNode,
-            contentBuilder: contentBuilder,
-            emptyPaneBuilder: emptyPaneBuilder,
-            appearance: appearance,
-            showSplitButtons: showSplitButtons,
-            contentViewLifecycle: contentViewLifecycle,
-            onGeometryChange: onGeometryChange,
-            enableAnimations: enableAnimations,
-            animationDuration: animationDuration
-        )
+        if let zoomedPaneId = controller.zoomedPaneId,
+           let zoomedPane = controller.rootNode.findPane(zoomedPaneId) {
+            // Keep the full split tree mounted so existing pane views can receive
+            // visibility updates (important for portal-hosted native surfaces),
+            // then overlay a fullscreen render of the zoomed pane.
+            ZStack {
+                SplitNodeView(
+                    node: controller.rootNode,
+                    contentBuilder: contentBuilder,
+                    emptyPaneBuilder: emptyPaneBuilder,
+                    appearance: appearance,
+                    excludedPaneID: zoomedPaneId,
+                    showSplitButtons: showSplitButtons,
+                    contentViewLifecycle: contentViewLifecycle,
+                    onGeometryChange: onGeometryChange,
+                    enableAnimations: enableAnimations,
+                    animationDuration: animationDuration
+                )
+                // Keep split content mounted for state propagation, but visually transparent.
+                // This preserves pane update callbacks needed by portal-hosted surfaces.
+                .opacity(0)
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+
+                SinglePaneWrapper(
+                    pane: zoomedPane,
+                    contentBuilder: contentBuilder,
+                    emptyPaneBuilder: emptyPaneBuilder,
+                    showSplitButtons: showSplitButtons,
+                    contentViewLifecycle: contentViewLifecycle
+                )
+            }
+        } else {
+            SplitNodeView(
+                node: controller.rootNode,
+                contentBuilder: contentBuilder,
+                emptyPaneBuilder: emptyPaneBuilder,
+                appearance: appearance,
+                showSplitButtons: showSplitButtons,
+                contentViewLifecycle: contentViewLifecycle,
+                onGeometryChange: onGeometryChange,
+                enableAnimations: enableAnimations,
+                animationDuration: animationDuration
+            )
+        }
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -92,6 +92,12 @@ struct TabBarView: View {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
 
+    private var isSplitZoomActive: Bool {
+        guard splitViewController.rootNode.allPaneIds.count > 1 else { return false }
+        guard let zoomedPaneId = splitViewController.zoomedPaneId else { return false }
+        return zoomedPaneId == pane.id
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             // Scrollable tabs with fade overlays
@@ -174,6 +180,10 @@ struct TabBarView: View {
             if showSplitButtons {
                 splitButtons
                     .saturation(tabBarSaturation)
+            }
+
+            if isSplitZoomActive {
+                splitZoomIndicator
             }
         }
         .frame(height: TabBarMetrics.barHeight)
@@ -472,6 +482,32 @@ struct TabBarView: View {
             .help(tooltips.splitDown)
         }
         .padding(.trailing, 8)
+    }
+
+    private var splitZoomIndicator: some View {
+        Button {
+            _ = controller.setZoomedPane(nil)
+        } label: {
+            HStack(spacing: 0) {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 10, weight: .semibold))
+            }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(.blue.opacity(0.95))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(.white.opacity(0.20), lineWidth: 0.8)
+                )
+        }
+        .buttonStyle(.plain)
+        .help("Exit Split Zoom")
+        .accessibilityLabel("Exit Split Zoom")
+        .padding(.trailing, showSplitButtons ? 2 : 8)
     }
 
     // MARK: - Fade Overlays

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -359,7 +359,7 @@ struct TabBarView: View {
             let provider = NSItemProvider()
             provider.registerDataRepresentation(
                 forTypeIdentifier: UTType.tabTransfer.identifier,
-                visibility: .all
+                visibility: .ownProcess
             ) { completion in
                 completion(data, nil)
                 return nil
@@ -846,7 +846,10 @@ struct TabDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            guard let transfer = decodeTransfer(from: info) else { return false }
+            guard let transfer = decodeTransfer(from: info),
+                  transfer.isFromCurrentProcess else {
+                return false
+            }
             let request = BonsplitController.ExternalTabDropRequest(
                 tabId: TabID(id: transfer.tab.id),
                 sourcePaneId: PaneID(id: transfer.sourcePaneId),
@@ -958,6 +961,18 @@ struct TabDropDelegate: DropDelegate {
         // Do NOT gate on draggingTab != nil: @Observable changes from createItemProvider
         // may not have propagated to the drop delegate yet, causing false rejections.
         let hasType = info.hasItemsConforming(to: [.tabTransfer])
+        guard hasType else { return false }
+
+        // Local drags use in-memory state and are always same-process.
+        if controller.activeDragTab != nil || controller.draggingTab != nil {
+            return true
+        }
+
+        // External drags (another Bonsplit controller) must include a payload from this process.
+        guard let transfer = decodeTransfer(from: info),
+              transfer.isFromCurrentProcess else {
+            return false
+        }
 #if DEBUG
         let hasDrag = controller.draggingTab != nil
         let hasActive = controller.activeDragTab != nil
@@ -966,7 +981,7 @@ struct TabDropDelegate: DropDelegate {
             "allowed=\(hasType ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
         )
 #endif
-        return hasType
+        return true
     }
 
     private func shouldSuppressIndicatorForNoopSamePaneDrop() -> Bool {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -139,6 +139,7 @@ struct TabBarView: View {
                                 .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
                                     targetIndex: pane.tabs.count,
                                     pane: pane,
+                                    bonsplitController: controller,
                                     controller: splitViewController,
                                     dropTargetIndex: $dropTargetIndex,
                                     dropLifecycle: $dropLifecycle
@@ -268,6 +269,7 @@ struct TabBarView: View {
         .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
             targetIndex: index,
             pane: pane,
+            bonsplitController: controller,
             controller: splitViewController,
             dropTargetIndex: $dropTargetIndex,
             dropLifecycle: $dropLifecycle
@@ -402,6 +404,7 @@ struct TabBarView: View {
             .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
                 targetIndex: pane.tabs.count,
                 pane: pane,
+                bonsplitController: controller,
                 controller: splitViewController,
                 dropTargetIndex: $dropTargetIndex,
                 dropLifecycle: $dropLifecycle
@@ -818,6 +821,7 @@ enum TabDropLifecycle {
 struct TabDropDelegate: DropDelegate {
     let targetIndex: Int
     let pane: PaneState
+    let bonsplitController: BonsplitController
     let controller: SplitViewController
     @Binding var dropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
@@ -842,7 +846,18 @@ struct TabDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            return false
+            guard let transfer = decodeTransfer(from: info) else { return false }
+            let request = BonsplitController.ExternalTabDropRequest(
+                tabId: TabID(id: transfer.tab.id),
+                sourcePaneId: PaneID(id: transfer.sourcePaneId),
+                destination: .insert(targetPane: pane.id, targetIndex: targetIndex)
+            )
+            let handled = bonsplitController.onExternalTabDrop?(request) ?? false
+            if handled {
+                dropLifecycle = .idle
+                dropTargetIndex = nil
+            }
+            return handled
         }
 
         // Execute synchronously when possible so the dragged tab disappears immediately.
@@ -971,5 +986,18 @@ struct TabDropDelegate: DropDelegate {
             return nil
         }
         return transfer
+    }
+
+    private func decodeTransfer(from info: DropInfo) -> TabTransferData? {
+        let pasteboard = NSPasteboard(name: .drag)
+        let type = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+        if let data = pasteboard.data(forType: type),
+           let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) {
+            return transfer
+        }
+        if let raw = pasteboard.string(forType: type) {
+            return decodeTransfer(from: raw)
+        }
+        return nil
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -317,6 +317,10 @@ struct TabItemView: View {
         }
         .disabled(!contextMenuState.canCloseOthers)
 
+        Button("Move Tab…") {
+            onContextAction(.move)
+        }
+
         Divider()
 
         Button("New Terminal Tab to Right") {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -550,6 +550,35 @@ public final class BonsplitController {
         return true
     }
 
+    // MARK: - Pane Zoom
+
+    /// Currently zoomed pane ID, if any.
+    public var zoomedPaneId: PaneID? {
+        internalController.zoomedPaneId
+    }
+
+    /// Set the currently zoomed pane.
+    /// - Parameter paneId: Pane to zoom, or nil to clear zoom.
+    /// - Returns: true if the pane exists (or paneId is nil) and state was accepted.
+    @discardableResult
+    public func setZoomedPane(_ paneId: PaneID?) -> Bool {
+        let previous = internalController.zoomedPaneId
+        guard internalController.setZoomedPane(paneId) else { return false }
+        if previous != internalController.zoomedPaneId {
+            notifyGeometryChange()
+        }
+        return true
+    }
+
+    /// Toggle zoom for a pane.
+    /// - Parameter paneId: Pane to toggle.
+    /// - Returns: true if the operation was accepted.
+    @discardableResult
+    public func togglePaneZoom(_ paneId: PaneID) -> Bool {
+        let target: PaneID? = internalController.zoomedPaneId == paneId ? nil : paneId
+        return setZoomedPane(target)
+    }
+
     // MARK: - Focus Management
 
     /// Currently focused pane ID

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -6,6 +6,23 @@ import SwiftUI
 @Observable
 public final class BonsplitController {
 
+    public struct ExternalTabDropRequest {
+        public enum Destination {
+            case insert(targetPane: PaneID, targetIndex: Int?)
+            case split(targetPane: PaneID, orientation: SplitOrientation, insertFirst: Bool)
+        }
+
+        public let tabId: TabID
+        public let sourcePaneId: PaneID
+        public let destination: Destination
+
+        public init(tabId: TabID, sourcePaneId: PaneID, destination: Destination) {
+            self.tabId = tabId
+            self.sourcePaneId = sourcePaneId
+            self.destination = destination
+        }
+    }
+
     // MARK: - Delegate
 
     /// Delegate for receiving callbacks about tab bar events
@@ -29,6 +46,10 @@ public final class BonsplitController {
     @ObservationIgnored public var onFileDrop: ((_ urls: [URL], _ paneId: PaneID) -> Bool)? {
         didSet { internalController.onFileDrop = onFileDrop }
     }
+
+    /// Handler for tab drops originating from another Bonsplit controller (e.g. another workspace/window).
+    /// Return `true` when the drop has been handled by the host application.
+    @ObservationIgnored public var onExternalTabDrop: ((ExternalTabDropRequest) -> Bool)?
 
     // MARK: - Internal State
 

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -7,6 +7,7 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case closeToLeft
     case closeToRight
     case closeOthers
+    case move
     case newTerminalToRight
     case newBrowserToRight
     case reload

--- a/Sources/Bonsplit/Public/Types/TabID.swift
+++ b/Sources/Bonsplit/Public/Types/TabID.swift
@@ -8,6 +8,14 @@ public struct TabID: Hashable, Codable, Sendable {
         self.id = UUID()
     }
 
+    public init(uuid: UUID) {
+        self.id = uuid
+    }
+
+    public var uuid: UUID {
+        id
+    }
+
     internal init(id: UUID) {
         self.id = id
     }


### PR DESCRIPTION
## Dependency Linkage

- Provides the Bonsplit API and behavior required by [`manaflow-ai/cmux` PR #412](https://github.com/manaflow-ai/cmux/pull/412).
- `cmux` #412 is a downstream dependent PR and is expected to merge after this PR.

## Summary

This PR introduces a complete split-zoom capability in Bonsplit, including:

- Public controller APIs for host apps
- Internal state management for safe zoom lifecycle
- Rendering changes that preserve correctness for mounted pane trees
- Tab-bar UX affordance to exit zoom quickly

While the headline feature is pane-level split zoom, the practical value is broader:

- Gives host apps a reliable maximize-one-pane interaction without losing split state
- Avoids stale/invalid zoom state during pane topology changes
- Preserves mounted view state and update flow in integrations that depend on it
- Unblocks downstream consumers (notably `cmux`) that already implement split-zoom commands and UI

This change is directly motivated by downstream integration work in
[`manaflow-ai/cmux` PR #412](https://github.com/manaflow-ai/cmux/pull/412),
which adds split-zoom commands and UI in cmux and depends on Bonsplit zoom APIs.

## Motivation

Bonsplit currently supports split panes but has no first-class zoom mode for a single pane. Downstream apps need this to provide a "focus one pane" workflow similar to maximize in tiling layouts.

Concrete downstream driver:
- [`manaflow-ai/cmux` PR #412](https://github.com/manaflow-ai/cmux/pull/412)
  adds "Toggle Split Zoom" behavior and pane zoom indicators in cmux.
- That PR requires Bonsplit to expose zoom state/control primitives and
  robust zoom rendering behavior.

Without this PR, downstream code either:

- Reimplements zoom behavior outside Bonsplit (fragile and duplicated), or
- Cannot compile when trying to integrate split zoom via missing APIs.

## Considered Alternatives

### 1. Implement split zoom entirely in `cmux` without Bonsplit changes

- Approach: keep zoom state in app code and try to hide/show pane content externally.
- Rejected because:
- It duplicates layout/state ownership outside Bonsplit.
- It makes pane-topology edge cases (split/close/move) harder to keep correct.
- It creates brittle coupling between host app code and Bonsplit internals.

### 2. Add only minimal Bonsplit API symbols (no rendering/lifecycle work)

- Approach: add `zoomedPaneId`/set/toggle APIs only and leave internals mostly unchanged.
- Rejected because:
- API-only changes do not solve stale zoom targets during topology mutations.
- A naive zoom render path can regress mounted-view update behavior.
- Downstream integrations need both API and robust internal behavior.

### 3. Remove or defer split zoom in `cmux` and avoid Bonsplit changes

- Approach: drop split zoom integration in [`cmux` PR #412](https://github.com/manaflow-ai/cmux/pull/412).
- Rejected because:
- It removes intended user functionality already implemented in downstream UI/shortcuts.
- It leaves downstream code paths blocked on missing primitives.

### Why updating Bonsplit is the chosen path

- Split zoom is a layout primitive and belongs in the layout library.
- A shared implementation in Bonsplit prevents host-app duplication and divergence.
- It provides a stable API contract for downstream apps.
- It directly unblocks [`cmux` PR #412](https://github.com/manaflow-ai/cmux/pull/412) in a way that is upstream-safe and reproducible.

## Problems Solved

1. Missing public zoom primitives

- No API to query zoomed pane
- No API to set/clear/toggle zoom

1. Incorrect lifecycle behavior under topology mutations

- Pane close/move/split can invalidate zoom targets
- No built-in invalidation/cleanup handling

1. Rendering correctness for complex host integrations

- A naive "render only zoomed pane" approach can break state/update propagation in systems that rely on mounted split branches (e.g., portal-hosted native surfaces)

1. Incomplete UX for zoom state

- No in-context control in tab chrome to indicate and exit zoom

## What Changed

### Public API additions (`BonsplitController`)

- `public var zoomedPaneId: PaneID?`
- `public func setZoomedPane(_ paneId: PaneID?) -> Bool`
- `public func togglePaneZoom(_ paneId: PaneID) -> Bool`

Behavior notes:

- `setZoomedPane` validates pane existence when non-nil
- Geometry notifications fire when zoom state changes

### Internal state + safety (`SplitViewController`)

- Added `zoomedPaneId` state
- Added `setZoomedPane(_:)` with validation
- Added `clearZoomIfInvalid()` cleanup path
- Clears zoom during split operations where topology changes
- Clears/repairs zoom when panes are closed/moved and the target no longer exists

### Rendering model (`SplitViewContainer`, `SplitNodeView`, `SplitContainerView`)

- In zoom mode, keep full split tree mounted but hidden/non-interactive
- Overlay fullscreen zoomed pane render on top
- Added `excludedPaneID` plumbing to prevent duplicate zoomed-pane rendering in hidden tree

Benefits of this rendering model:

- Preserves mounted view state and callback/update behavior
- Reduces regressions for host apps with portal/native surface routing
- Keeps zoom behavior visually correct while retaining internal consistency

### Tab-bar UX (`TabBarView`)

- Adds zoom indicator/control on the currently zoomed pane
- One-click "Exit Split Zoom" affordance (`setZoomedPane(nil)`)
- Scoped to active split zoom state and zoomed pane only

## Non-Goals / Out of Scope

- No host-app keybinding policy changes
- No general tab-bar redesign outside zoom indicator path
- No unrelated split interaction refactors

## Compatibility

- Additive API only; existing consumers remain compatible
- Behavior unchanged unless zoom APIs are used

## Downstream Impact

This PR is the Bonsplit dependency for
[`manaflow-ai/cmux` PR #412](https://github.com/manaflow-ai/cmux/pull/412).

Specifically, cmux #412:
- adds split-zoom keyboard routing and pane-level zoom UX,
- calls `zoomedPaneId`, `setZoomedPane`, and `togglePaneZoom`,
- and therefore requires this Bonsplit API + rendering/lifecycle support.

## Validation

### Bonsplit package

- Command: `swift test`
- Result: pass (`34` tests, `0` failures)



## Latest QA Update (2026-02-24)

- Package tests on this PR branch pass:
  - `swift test`
  - Result: `34` tests, `0` failures.
- Downstream integration validation in isolated `/tmp` QA:
  - `cmux` PR #412 fails to compile without this Bonsplit PR (missing `zoomedPaneId`, `setZoomedPane`, `togglePaneZoom`).
  - With this Bonsplit PR applied, `cmux` PR #412 builds successfully.
  - Targeted `cmux` tests passed (`KeyboardShortcutSettingsTests`, `WorkspaceContentViewVisibilityTests`) on the paired setup.
- This confirms #11 is the required dependency for `cmux` #412.
