### PR TITLE
Add split pane zoom with visual indicator and context menu shortcuts

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -8,6 +8,9 @@ final class SplitViewController {
     /// The root node of the split tree
     var rootNode: SplitNode
 
+    /// Currently zoomed pane. When set, rendering should only show this pane.
+    var zoomedPaneId: PaneID?
+
     /// Currently focused pane ID
     var focusedPaneId: PaneID?
 
@@ -83,10 +86,39 @@ final class SplitViewController {
         return rootNode.findPane(focusedPaneId)
     }
 
+    var zoomedNode: SplitNode? {
+        guard let zoomedPaneId else { return nil }
+        return rootNode.findNode(containing: zoomedPaneId)
+    }
+
+    @discardableResult
+    func clearPaneZoom() -> Bool {
+        guard zoomedPaneId != nil else { return false }
+        zoomedPaneId = nil
+        return true
+    }
+
+    @discardableResult
+    func togglePaneZoom(_ paneId: PaneID) -> Bool {
+        guard rootNode.findPane(paneId) != nil else { return false }
+
+        if zoomedPaneId == paneId {
+            zoomedPaneId = nil
+            return true
+        }
+
+        // Match Ghostty behavior: a single-pane layout can't be zoomed.
+        guard rootNode.allPaneIds.count > 1 else { return false }
+        zoomedPaneId = paneId
+        focusedPaneId = paneId
+        return true
+    }
+
     // MARK: - Split Operations
 
     /// Split the specified pane in the given orientation
     func splitPane(_ paneId: PaneID, orientation: SplitOrientation, with newTab: TabItem? = nil) {
+        clearPaneZoom()
         rootNode = splitNodeRecursively(
             node: rootNode,
             targetPaneId: paneId,
@@ -150,6 +182,7 @@ final class SplitViewController {
 
     /// Split a pane with a specific tab, optionally inserting the new pane first
     func splitPaneWithTab(_ paneId: PaneID, orientation: SplitOrientation, tab: TabItem, insertFirst: Bool) {
+        clearPaneZoom()
         rootNode = splitNodeWithTabRecursively(
             node: rootNode,
             targetPaneId: paneId,
@@ -236,6 +269,10 @@ final class SplitViewController {
             focusedPaneId = siblingPaneId
         } else if let firstPane = rootNode.allPaneIds.first {
             focusedPaneId = firstPane
+        }
+
+        if let zoomedPaneId, rootNode.findPane(zoomedPaneId) == nil {
+            self.zoomedPaneId = nil
         }
     }
 

--- a/Sources/Bonsplit/Internal/Models/SplitNode.swift
+++ b/Sources/Bonsplit/Internal/Models/SplitNode.swift
@@ -32,6 +32,16 @@ indirect enum SplitNode: Identifiable, Equatable {
         }
     }
 
+    /// Find the leaf node for a pane by ID.
+    func findNode(containing paneId: PaneID) -> SplitNode? {
+        switch self {
+        case .pane(let state):
+            return state.id == paneId ? self : nil
+        case .split(let state):
+            return state.first.findNode(containing: paneId) ?? state.second.findNode(containing: paneId)
+        }
+    }
+
     /// Get all pane IDs in the tree
     var allPaneIds: [PaneID] {
         switch self {

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -37,8 +37,9 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var splitNodeContent: some View {
+        let nodeToRender = controller.zoomedNode ?? controller.rootNode
         SplitNodeView(
-            node: controller.rootNode,
+            node: nodeToRender,
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
             appearance: appearance,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -40,6 +40,9 @@ struct TabContextMenuState {
     let canCloseToLeft: Bool
     let canCloseToRight: Bool
     let canCloseOthers: Bool
+    let isZoomed: Bool
+    let hasSplits: Bool
+    let shortcuts: [TabContextAction: KeyboardShortcut]
 
     var canMarkAsUnread: Bool {
         !isUnread
@@ -216,9 +219,11 @@ struct TabBarView: View {
     @ViewBuilder
     private func tabItem(for tab: TabItem, at index: Int) -> some View {
         let contextMenuState = contextMenuState(for: tab, at: index)
+        let showsZoomIndicator = splitViewController.zoomedPaneId == pane.id && pane.selectedTabId == tab.id
         TabItemView(
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
+            showsZoomIndicator: showsZoomIndicator,
             appearance: appearance,
             saturation: tabBarSaturation,
             controlShortcutDigit: tabControlShortcutDigit(for: index, tabCount: pane.tabs.count),
@@ -246,6 +251,9 @@ struct TabBarView: View {
                 withTransaction(Transaction(animation: nil)) {
                     _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
+            },
+            onZoomToggle: {
+                _ = splitViewController.togglePaneZoom(pane.id)
             },
             onContextAction: { action in
                 controller.requestTabContextAction(action, for: TabID(id: tab.id), inPane: pane.id)
@@ -301,7 +309,10 @@ struct TabBarView: View {
             hasCustomTitle: tab.hasCustomTitle,
             canCloseToLeft: canCloseToLeft,
             canCloseToRight: canCloseToRight,
-            canCloseOthers: canCloseOthers
+            canCloseOthers: canCloseOthers,
+            isZoomed: splitViewController.zoomedPaneId == pane.id,
+            hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
+            shortcuts: controller.contextMenuShortcuts
         )
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -39,6 +39,7 @@ enum TabItemStyling {
 struct TabItemView: View {
     let tab: TabItem
     let isSelected: Bool
+    let showsZoomIndicator: Bool
     let appearance: BonsplitConfiguration.Appearance
     let saturation: Double
     let controlShortcutDigit: Int?
@@ -47,10 +48,12 @@ struct TabItemView: View {
     let contextMenuState: TabContextMenuState
     let onSelect: () -> Void
     let onClose: () -> Void
+    let onZoomToggle: () -> Void
     let onContextAction: (TabContextAction) -> Void
 
     @State private var isHovered = false
     @State private var isCloseHovered = false
+    @State private var isZoomHovered = false
     @State private var showGlobeFallback = true
     @State private var globeFallbackWorkItem: DispatchWorkItem?
     @State private var lastIsLoadingObserved = false
@@ -124,6 +127,35 @@ struct TabItemView: View {
                             : TabBarColors.inactiveText(for: appearance)
                     )
                     .saturation(saturation)
+
+                if showsZoomIndicator {
+                    Button {
+                        onZoomToggle()
+                    } label: {
+                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                            .font(.system(size: max(8, TabBarMetrics.titleFontSize - 2), weight: .semibold))
+                            .foregroundStyle(
+                                isZoomHovered
+                                    ? TabBarColors.activeText(for: appearance)
+                                    : TabBarColors.inactiveText(for: appearance)
+                            )
+                            .frame(width: TabBarMetrics.closeButtonSize, height: TabBarMetrics.closeButtonSize)
+                            .background(
+                                Circle()
+                                    .fill(
+                                        isZoomHovered
+                                            ? TabBarColors.hoveredTabBackground(for: appearance)
+                                            : .clear
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        isZoomHovered = hovering
+                    }
+                    .saturation(saturation)
+                    .accessibilityLabel("Exit zoom")
+                }
             }
 
             Spacer(minLength: 0)
@@ -285,80 +317,79 @@ struct TabItemView: View {
         if tab.isPinned { parts.append("Pinned") }
         if tab.showsNotificationBadge { parts.append("Unread") }
         if tab.isDirty { parts.append("Modified") }
+        if showsZoomIndicator { parts.append("Zoomed") }
         return parts.joined(separator: ", ")
     }
 
     @ViewBuilder
     private var contextMenuContent: some View {
-        Button("Rename Tab…") {
-            onContextAction(.rename)
-        }
+        contextButton("Rename Tab…", action: .rename)
 
         if contextMenuState.hasCustomTitle {
-            Button("Remove Custom Tab Name") {
-                onContextAction(.clearName)
-            }
+            contextButton("Remove Custom Tab Name", action: .clearName)
         }
 
         Divider()
 
-        Button("Close Tabs to Left") {
-            onContextAction(.closeToLeft)
-        }
-        .disabled(!contextMenuState.canCloseToLeft)
+        contextButton("Close Tabs to Left", action: .closeToLeft)
+            .disabled(!contextMenuState.canCloseToLeft)
 
-        Button("Close Tabs to Right") {
-            onContextAction(.closeToRight)
-        }
-        .disabled(!contextMenuState.canCloseToRight)
+        contextButton("Close Tabs to Right", action: .closeToRight)
+            .disabled(!contextMenuState.canCloseToRight)
 
-        Button("Close Other Tabs") {
-            onContextAction(.closeOthers)
-        }
-        .disabled(!contextMenuState.canCloseOthers)
+        contextButton("Close Other Tabs", action: .closeOthers)
+            .disabled(!contextMenuState.canCloseOthers)
 
-        Button("Move Tab…") {
-            onContextAction(.move)
-        }
+        contextButton("Move Tab…", action: .move)
 
         Divider()
 
-        Button("New Terminal Tab to Right") {
-            onContextAction(.newTerminalToRight)
-        }
+        contextButton("New Terminal Tab to Right", action: .newTerminalToRight)
 
-        Button("New Browser Tab to Right") {
-            onContextAction(.newBrowserToRight)
-        }
+        contextButton("New Browser Tab to Right", action: .newBrowserToRight)
 
         if contextMenuState.isBrowser {
             Divider()
 
-            Button("Reload Tab") {
-                onContextAction(.reload)
-            }
+            contextButton("Reload Tab", action: .reload)
 
-            Button("Duplicate Tab") {
-                onContextAction(.duplicate)
-            }
+            contextButton("Duplicate Tab", action: .duplicate)
         }
 
         Divider()
 
-        Button(contextMenuState.isPinned ? "Unpin Tab" : "Pin Tab") {
-            onContextAction(.togglePin)
+        if contextMenuState.hasSplits {
+            contextButton(
+                contextMenuState.isZoomed ? "Exit Zoom" : "Zoom Pane",
+                action: .toggleZoom
+            )
         }
 
+        contextButton(
+            contextMenuState.isPinned ? "Unpin Tab" : "Pin Tab",
+            action: .togglePin
+        )
+
         if contextMenuState.isUnread {
-            Button("Mark Tab as Read") {
-                onContextAction(.markAsRead)
-            }
-            .disabled(!contextMenuState.canMarkAsRead)
+            contextButton("Mark Tab as Read", action: .markAsRead)
+                .disabled(!contextMenuState.canMarkAsRead)
         } else {
-            Button("Mark Tab as Unread") {
-                onContextAction(.markAsUnread)
+            contextButton("Mark Tab as Unread", action: .markAsUnread)
+                .disabled(!contextMenuState.canMarkAsUnread)
+        }
+    }
+
+    @ViewBuilder
+    private func contextButton(_ title: String, action: TabContextAction) -> some View {
+        if let shortcut = contextMenuState.shortcuts[action] {
+            Button(title) {
+                onContextAction(action)
             }
-            .disabled(!contextMenuState.canMarkAsUnread)
+            .keyboardShortcut(shortcut)
+        } else {
+            Button(title) {
+                onContextAction(action)
+            }
         }
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -572,6 +572,37 @@ public final class BonsplitController {
         }
     }
 
+    // MARK: - Split Zoom
+
+    /// Currently zoomed pane ID, if any.
+    public var zoomedPaneId: PaneID? {
+        internalController.zoomedPaneId
+    }
+
+    public var isSplitZoomed: Bool {
+        internalController.zoomedPaneId != nil
+    }
+
+    @discardableResult
+    public func clearPaneZoom() -> Bool {
+        internalController.clearPaneZoom()
+    }
+
+    /// Toggle zoom for a pane. When zoomed, only that pane is rendered in the split area.
+    /// Passing nil toggles the currently focused pane.
+    @discardableResult
+    public func togglePaneZoom(inPane paneId: PaneID? = nil) -> Bool {
+        let targetPaneId = paneId ?? focusedPaneId
+        guard let targetPaneId else { return false }
+        return internalController.togglePaneZoom(targetPaneId)
+    }
+
+    // MARK: - Context Menu Shortcut Hints
+
+    /// Keyboard shortcuts to display in tab context menus, keyed by context action.
+    /// Set by the host app to sync with its customizable keyboard shortcut settings.
+    public var contextMenuShortcuts: [TabContextAction: KeyboardShortcut] = [:]
+
     // MARK: - Query Methods
 
     /// Get all tab IDs

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -15,4 +15,5 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case togglePin
     case markAsRead
     case markAsUnread
+    case toggleZoom
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -375,6 +375,48 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTogglePaneZoomTracksState() {
+        let controller = BonsplitController()
+        guard let originalPane = controller.focusedPaneId else {
+            return XCTFail("Expected focused pane")
+        }
+
+        // Single-pane layouts cannot be zoomed.
+        XCTAssertFalse(controller.togglePaneZoom(inPane: originalPane))
+        XCTAssertNil(controller.zoomedPaneId)
+
+        guard controller.splitPane(originalPane, orientation: .horizontal) != nil else {
+            return XCTFail("Expected splitPane to create a new pane")
+        }
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: originalPane))
+        XCTAssertEqual(controller.zoomedPaneId, originalPane)
+        XCTAssertTrue(controller.isSplitZoomed)
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: originalPane))
+        XCTAssertNil(controller.zoomedPaneId)
+        XCTAssertFalse(controller.isSplitZoomed)
+    }
+
+    @MainActor
+    func testSplitClearsExistingPaneZoom() {
+        let controller = BonsplitController()
+        guard let originalPane = controller.focusedPaneId else {
+            return XCTFail("Expected focused pane")
+        }
+
+        guard let secondPane = controller.splitPane(originalPane, orientation: .horizontal) else {
+            return XCTFail("Expected splitPane to create a new pane")
+        }
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: secondPane))
+        XCTAssertEqual(controller.zoomedPaneId, secondPane)
+
+        _ = controller.splitPane(secondPane, orientation: .vertical)
+        XCTAssertNil(controller.zoomedPaneId, "Splitting should reset zoom state")
+    }
+
+    @MainActor
     func testRequestTabContextActionForwardsToDelegate() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!


### PR DESCRIPTION
## Summary
- Toggle zoom on a pane to fill the entire split area (other panes hidden, not destroyed)
- Clickable zoom icon button in tab bar (styled like close button with hover highlight)
- Right-click context menu: "Zoom Pane" / "Exit Zoom" with synced keyboard shortcut hints
- `contextMenuShortcuts` dictionary on BonsplitController for host apps to provide shortcut hints
- Auto-clears zoom on split or close operations
- Unit tests for toggle state and split-clears-zoom

For https://github.com/manaflow-ai/cmux/issues/136

## Test plan
- [ ] Split panes, call `togglePaneZoom` on one, verify only that pane renders
- [ ] Toggle again, verify all panes restore
- [ ] Split while zoomed, verify zoom clears
- [ ] Close zoomed pane, verify zoom clears
- [ ] Right-click tab in splits, verify "Zoom Pane" appears with shortcut hint
- [ ] `swift test` passes (36 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pane zoom functionality to focus on a specific pane while hiding others
  * Zoom indicator displays on tabs when active
  * Zoom toggle available in context menu
  * Configurable keyboard shortcuts for zoom actions
  * Zoom state automatically clears when panes are closed or split

* **Tests**
  * Added test coverage for zoom toggling and state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->