### PR TITLE
Support RRGGBBAA hex format for chrome colors

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -212,13 +212,25 @@ private extension NSColor {
         if hex.hasPrefix("#") {
             hex.removeFirst()
         }
-        guard hex.count == 6 else { return nil }
+        guard hex.count == 6 || hex.count == 8 else { return nil }
         guard hex.unicodeScalars.allSatisfy({ Self.bonsplitHexDigits.contains($0) }) else { return nil }
-        guard let rgb = UInt64(hex, radix: 16) else { return nil }
-        let red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
-        let green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
-        let blue = CGFloat(rgb & 0x0000FF) / 255.0
-        self.init(red: red, green: green, blue: blue, alpha: 1.0)
+        guard let rgba = UInt64(hex, radix: 16) else { return nil }
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+        let alpha: CGFloat
+        if hex.count == 8 {
+            red = CGFloat((rgba & 0xFF000000) >> 24) / 255.0
+            green = CGFloat((rgba & 0x00FF0000) >> 16) / 255.0
+            blue = CGFloat((rgba & 0x0000FF00) >> 8) / 255.0
+            alpha = CGFloat(rgba & 0x000000FF) / 255.0
+        } else {
+            red = CGFloat((rgba & 0xFF0000) >> 16) / 255.0
+            green = CGFloat((rgba & 0x00FF00) >> 8) / 255.0
+            blue = CGFloat(rgba & 0x0000FF) / 255.0
+            alpha = 1.0
+        }
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 
     var isBonsplitLightColor: Bool {

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -125,11 +125,11 @@ extension BonsplitConfiguration {
 
     public struct Appearance: Sendable {
         public struct ChromeColors: Sendable {
-            /// Optional hex color (`#RRGGBB`) for tab/pane chrome backgrounds.
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for tab/pane chrome backgrounds.
             /// When unset, Bonsplit uses native system colors.
             public var backgroundHex: String?
 
-            /// Optional hex color (`#RRGGBB`) for separators/dividers.
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for separators/dividers.
             /// When unset, Bonsplit derives separators from the chrome background.
             public var borderHex: String?
 


### PR DESCRIPTION
## Summary
- Accept 8-digit hex strings (`#RRGGBBAA`) in addition to 6-digit (`#RRGGBB`) for `backgroundHex` and `borderHex` in `ChromeColors`
- Enables translucent chrome backgrounds when the host app uses `background-opacity < 1.0`
- Backwards compatible: 6-digit hex strings continue to work as before with alpha = 1.0

## Test plan
- [ ] Verify 6-digit hex still works identically (alpha = 1.0)
- [ ] Verify 8-digit hex correctly parses RGBA (e.g., `#1122337F` = RGB(17,34,51) at ~50% opacity)
- [ ] Verify invalid lengths (5, 7, 9 digits) are rejected