### PR TITLE
Respect Cmd-hold hint setting for pane tab hints

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -598,9 +598,10 @@ enum TabControlShortcutHintPolicy {
         for modifierFlags: NSEvent.ModifierFlags,
         defaults: UserDefaults = .standard
     ) -> TabControlShortcutModifier? {
+        guard showHintsOnCommandHoldEnabled(defaults: defaults) else { return nil }
         let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
         if flags == [.control] { return .control }
-        if flags == [.command], showHintsOnCommandHoldEnabled(defaults: defaults) { return .command }
+        if flags == [.command] { return .command }
         return nil
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -584,11 +584,23 @@ enum TabControlShortcutModifier: Equatable {
 
 enum TabControlShortcutHintPolicy {
     static let intentionalHoldDelay: TimeInterval = 0.30
+    static let showHintsOnCommandHoldKey = "shortcutHintShowOnCommandHold"
+    static let defaultShowHintsOnCommandHold = true
 
-    static func hintModifier(for modifierFlags: NSEvent.ModifierFlags) -> TabControlShortcutModifier? {
+    static func showHintsOnCommandHoldEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: showHintsOnCommandHoldKey) != nil else {
+            return defaultShowHintsOnCommandHold
+        }
+        return defaults.bool(forKey: showHintsOnCommandHoldKey)
+    }
+
+    static func hintModifier(
+        for modifierFlags: NSEvent.ModifierFlags,
+        defaults: UserDefaults = .standard
+    ) -> TabControlShortcutModifier? {
         let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
         if flags == [.control] { return .control }
-        if flags == [.command] { return .command }
+        if flags == [.command], showHintsOnCommandHoldEnabled(defaults: defaults) { return .command }
         return nil
     }
 
@@ -610,9 +622,10 @@ enum TabControlShortcutHintPolicy {
         hostWindowNumber: Int?,
         hostWindowIsKey: Bool,
         eventWindowNumber: Int?,
-        keyWindowNumber: Int?
+        keyWindowNumber: Int?,
+        defaults: UserDefaults = .standard
     ) -> Bool {
-        hintModifier(for: modifierFlags) != nil &&
+        hintModifier(for: modifierFlags, defaults: defaults) != nil &&
             isCurrentWindow(
                 hostWindowNumber: hostWindowNumber,
                 hostWindowIsKey: hostWindowIsKey,

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -500,20 +500,21 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
-    func testTabControlShortcutHintPolicyCanDisableCommandHints() {
+    func testTabControlShortcutHintPolicyCanDisableHoldHints() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
-            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults), .control)
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
         }
     }
 
-    func testTabControlShortcutHintPolicyDefaultsToShowingCommandHints() {
+    func testTabControlShortcutHintPolicyDefaultsToShowingHoldHints() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.removeObject(forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
             XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults), .command)
+            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults), .control)
         }
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -489,65 +489,99 @@ final class BonsplitTests: XCTestCase {
     }
 
     func testTabControlShortcutHintPolicyRequiresCommandOrControlOnly() {
-        XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.control]))
-        XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.command]))
-        XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: []))
-        XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control, .shift]))
-        XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command, .option]))
+        withShortcutHintDefaultsSuite { defaults in
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+
+            XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
+            XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [], defaults: defaults))
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control, .shift], defaults: defaults))
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command, .option], defaults: defaults))
+        }
+    }
+
+    func testTabControlShortcutHintPolicyCanDisableCommandHints() {
+        withShortcutHintDefaultsSuite { defaults in
+            defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
+            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults), .control)
+        }
+    }
+
+    func testTabControlShortcutHintPolicyDefaultsToShowingCommandHints() {
+        withShortcutHintDefaultsSuite { defaults in
+            defaults.removeObject(forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+
+            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults), .command)
+        }
     }
 
     func testTabControlShortcutHintsAreScopedToCurrentKeyWindow() {
-        XCTAssertTrue(
-            TabControlShortcutHintPolicy.shouldShowHints(
-                for: [.command],
-                hostWindowNumber: 42,
-                hostWindowIsKey: true,
-                eventWindowNumber: 42,
-                keyWindowNumber: 42
-            )
-        )
+        withShortcutHintDefaultsSuite { defaults in
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
-        XCTAssertFalse(
-            TabControlShortcutHintPolicy.shouldShowHints(
-                for: [.command],
-                hostWindowNumber: 42,
-                hostWindowIsKey: true,
-                eventWindowNumber: 7,
-                keyWindowNumber: 42
+            XCTAssertTrue(
+                TabControlShortcutHintPolicy.shouldShowHints(
+                    for: [.command],
+                    hostWindowNumber: 42,
+                    hostWindowIsKey: true,
+                    eventWindowNumber: 42,
+                    keyWindowNumber: 42,
+                    defaults: defaults
+                )
             )
-        )
 
-        XCTAssertFalse(
-            TabControlShortcutHintPolicy.shouldShowHints(
-                for: [.command],
-                hostWindowNumber: 42,
-                hostWindowIsKey: false,
-                eventWindowNumber: 42,
-                keyWindowNumber: 42
+            XCTAssertFalse(
+                TabControlShortcutHintPolicy.shouldShowHints(
+                    for: [.command],
+                    hostWindowNumber: 42,
+                    hostWindowIsKey: true,
+                    eventWindowNumber: 7,
+                    keyWindowNumber: 42,
+                    defaults: defaults
+                )
             )
-        )
+
+            XCTAssertFalse(
+                TabControlShortcutHintPolicy.shouldShowHints(
+                    for: [.command],
+                    hostWindowNumber: 42,
+                    hostWindowIsKey: false,
+                    eventWindowNumber: 42,
+                    keyWindowNumber: 42,
+                    defaults: defaults
+                )
+            )
+        }
     }
 
     func testTabControlShortcutHintsFallbackToKeyWindowWhenEventWindowMissing() {
-        XCTAssertTrue(
-            TabControlShortcutHintPolicy.shouldShowHints(
-                for: [.control],
-                hostWindowNumber: 42,
-                hostWindowIsKey: true,
-                eventWindowNumber: nil,
-                keyWindowNumber: 42
-            )
-        )
+        withShortcutHintDefaultsSuite { defaults in
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
-        XCTAssertFalse(
-            TabControlShortcutHintPolicy.shouldShowHints(
-                for: [.control],
-                hostWindowNumber: 42,
-                hostWindowIsKey: true,
-                eventWindowNumber: nil,
-                keyWindowNumber: 7
+            XCTAssertTrue(
+                TabControlShortcutHintPolicy.shouldShowHints(
+                    for: [.control],
+                    hostWindowNumber: 42,
+                    hostWindowIsKey: true,
+                    eventWindowNumber: nil,
+                    keyWindowNumber: 42,
+                    defaults: defaults
+                )
             )
-        )
+
+            XCTAssertFalse(
+                TabControlShortcutHintPolicy.shouldShowHints(
+                    for: [.control],
+                    hostWindowNumber: 42,
+                    hostWindowIsKey: true,
+                    eventWindowNumber: nil,
+                    keyWindowNumber: 7,
+                    defaults: defaults
+                )
+            )
+        }
     }
 
     func testSelectedTabNeverShowsHoverBackground() {
@@ -574,5 +608,17 @@ final class BonsplitTests: XCTestCase {
         segments = TabBarStyling.separatorSegments(totalWidth: 100, gap: nil)
         XCTAssertEqual(segments.left, 100, accuracy: 0.0001)
         XCTAssertEqual(segments.right, 0, accuracy: 0.0001)
+    }
+
+    private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {
+        let suiteName = "BonsplitShortcutHintPolicyTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create defaults suite")
+            return
+        }
+
+        defaults.removePersistentDomain(forName: suiteName)
+        body(defaults)
+        defaults.removePersistentDomain(forName: suiteName)
     }
 }


### PR DESCRIPTION
## Summary
- make `TabControlShortcutHintPolicy` honor the `shortcutHintShowOnCommandHold` setting for Cmd-only hint reveal
- keep Ctrl-only hint behavior unchanged
- add regression tests for disabled/enabled/default Cmd-hold hint behavior with isolated UserDefaults suites

## Testing
- `swift test` (pass)

## Issues
- Related task: "add a setting to cmux to not show the hints when pressing cmd"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable behavior for showing keyboard shortcut hints when holding the Command key, gated by a feature flag and enabled by default.
  * Users can control this behavior via a new preference.

* **Tests**
  * Updated tests to exercise and validate the new, preferences-driven shortcut-hint behavior using isolated test settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->