### PR TITLE
Make syncPosition synchronous in splitViewDidResizeSubviews

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -756,6 +756,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             // Skip position updates during animation
             guard !isAnimating else { return }
             guard let splitView = notification.object as? NSSplitView else { return }
+#if DEBUG
+            let subframes = splitView.arrangedSubviews.enumerated().map { (i, v) in
+                "\(i)=\(Int(v.frame.width))x\(Int(v.frame.height))"
+            }.joined(separator: " ")
+            dlog("split.didResize split=\(splitState.id.uuidString.prefix(5)) orient=\(splitState.orientation == .horizontal ? "H" : "V") container=\(Int(splitView.frame.width))x\(Int(splitView.frame.height)) subs=[\(subframes)] anim=\(isAnimating ? 1 : 0) sync=\(isSyncingProgrammatically ? 1 : 0)")
+#endif
             if isSyncingProgrammatically || splitContainerProgrammaticSyncDepth > 0 {
                 return
             }
@@ -822,11 +828,11 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     )
 #endif
                     let statePosition = self.splitState.dividerPosition
-                    // Re-assert on the next runloop turn to avoid recursive NSSplitView resize callbacks.
-                    DispatchQueue.main.async { [weak self, weak splitView] in
-                        guard let self, let splitView else { return }
-                        self.syncPosition(statePosition, in: splitView)
-                    }
+                    // Re-assert synchronously. setPositionSafely sets isSyncingProgrammatically=true,
+                    // so the recursive splitViewDidResizeSubviews call is caught by the guard above.
+                    // Deferring to the next runloop turn would allow the transient frame to propagate
+                    // through SwiftUI layout → ghostty terminal resize → reflow, causing content shifts.
+                    self.syncPosition(statePosition, in: splitView)
                     self.onGeometryChange?(false)
                     return
                 }


### PR DESCRIPTION
## Summary
- Make the position re-assertion in `splitViewDidResizeSubviews` synchronous instead of deferring via `DispatchQueue.main.async`
- `setPositionSafely` already guards recursion via `isSyncingProgrammatically`, so synchronous correction is safe
- Prevents transient NSSplitView frame changes from propagating to downstream layout across runloop turns

Part of the fix for terminal content shifting during split operations in cmux.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make split position correction synchronous in splitViewDidResizeSubviews to keep layout stable during resize. Prevents transient split view frames from causing terminal content shifts.

- **Bug Fixes**
  - Call syncPosition immediately instead of deferring with DispatchQueue.main.async.
  - Safe due to setPositionSafely and isSyncingProgrammatically recursion guard.
  - Adds DEBUG logging for resize diagnostics.

<sup>Written for commit 49aef6673ab5689026391310b31c3201899789b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split view resizing to prevent transient layout-induced content shifts during container resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->