### PR TITLE
Allow moving tabs to adjacent panes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "Bonsplit",
+    defaultLocalization: "en",
     platforms: [
         .macOS(.v14)
     ],
@@ -17,7 +18,10 @@ let package = Package(
         .target(
             name: "Bonsplit",
             dependencies: [],
-            path: "Sources/Bonsplit"
+            path: "Sources/Bonsplit",
+            resources: [
+                .process("Resources")
+            ]
         ),
         .testTarget(
             name: "BonsplitTests",

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -384,6 +384,20 @@ final class SplitViewController {
         // No neighbor found = at edge, do nothing
     }
 
+    /// Find the closest pane in the requested direction from the given pane.
+    func adjacentPane(to paneId: PaneID, direction: NavigationDirection) -> PaneID? {
+        let allPaneBounds = rootNode.computePaneBounds()
+        guard let currentBounds = allPaneBounds.first(where: { $0.paneId == paneId })?.bounds else {
+            return nil
+        }
+        return findBestNeighbor(
+            from: currentBounds,
+            currentPaneId: paneId,
+            direction: direction,
+            allPaneBounds: allPaneBounds
+        )
+    }
+
     private func findBestNeighbor(from currentBounds: CGRect, currentPaneId: PaneID,
                                   direction: NavigationDirection, allPaneBounds: [PaneBounds]) -> PaneID? {
         let epsilon: CGFloat = 0.001

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -310,31 +310,36 @@ struct UnifiedPaneDropDelegate: DropDelegate {
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
             return defaultZone
         }
-        guard shouldPreferAdjacentPaneMove(
+        guard let adjacentPaneMoveZone = adjacentPaneMoveZone(
             for: draggedTab,
             sourcePaneId: sourcePaneId,
             defaultZone: defaultZone
         ) else {
             return defaultZone
         }
-        return .center
+        return adjacentPaneMoveZone
     }
 
-    private func shouldPreferAdjacentPaneMove(
+    private func adjacentPaneMoveZone(
         for draggedTab: TabItem,
         sourcePaneId: PaneID,
         defaultZone: DropZone
-    ) -> Bool {
+    ) -> DropZone? {
         guard draggedTab.kind == "terminal",
               sourcePaneId != pane.id else {
-            return false
+            return nil
         }
-        guard defaultZone != .top, defaultZone != .bottom else {
-            return false
+        if defaultZone == .left,
+           bonsplitController.adjacentPane(to: sourcePaneId, direction: .right) == pane.id {
+            // Preserve the outer edge as a split affordance while treating the shared edge
+            // between adjacent panes as "drop into this pane".
+            return .center
         }
-        let leftNeighbor = bonsplitController.adjacentPane(to: sourcePaneId, direction: .left)
-        let rightNeighbor = bonsplitController.adjacentPane(to: sourcePaneId, direction: .right)
-        return leftNeighbor == pane.id || rightNeighbor == pane.id
+        if defaultZone == .right,
+           bonsplitController.adjacentPane(to: sourcePaneId, direction: .left) == pane.id {
+            return .center
+        }
+        return nil
     }
 
     func performDrop(info: DropInfo) -> Bool {

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -304,6 +304,39 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         }
     }
 
+    private func effectiveZone(for info: DropInfo) -> DropZone {
+        let defaultZone = zoneForLocation(info.location)
+        guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
+              let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
+            return defaultZone
+        }
+        guard shouldPreferAdjacentPaneMove(
+            for: draggedTab,
+            sourcePaneId: sourcePaneId,
+            defaultZone: defaultZone
+        ) else {
+            return defaultZone
+        }
+        return .center
+    }
+
+    private func shouldPreferAdjacentPaneMove(
+        for draggedTab: TabItem,
+        sourcePaneId: PaneID,
+        defaultZone: DropZone
+    ) -> Bool {
+        guard draggedTab.kind == "terminal",
+              sourcePaneId != pane.id else {
+            return false
+        }
+        guard defaultZone != .top, defaultZone != .bottom else {
+            return false
+        }
+        let leftNeighbor = bonsplitController.adjacentPane(to: sourcePaneId, direction: .left)
+        let rightNeighbor = bonsplitController.adjacentPane(to: sourcePaneId, direction: .right)
+        return leftNeighbor == pane.id || rightNeighbor == pane.id
+    }
+
     func performDrop(info: DropInfo) -> Bool {
         if !Thread.isMainThread {
             return DispatchQueue.main.sync {
@@ -311,7 +344,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             }
         }
 
-        let zone = zoneForLocation(info.location)
+        let zone = effectiveZone(for: info)
 #if DEBUG
         dlog(
             "pane.drop pane=\(pane.id.id.uuidString.prefix(5)) zone=\(zone) " +
@@ -401,7 +434,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 
     func dropEntered(info: DropInfo) {
         dropLifecycle = .hovering
-        let zone = zoneForLocation(info.location)
+        let zone = effectiveZone(for: info)
         activeDropZone = zone
 #if DEBUG
         dlog(
@@ -428,7 +461,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 #endif
             return DropProposal(operation: .move)
         }
-        let zone = zoneForLocation(info.location)
+        let zone = effectiveZone(for: info)
         activeDropZone = zone
 #if DEBUG
         dlog("pane.dropUpdated pane=\(pane.id.id.uuidString.prefix(5)) zone=\(zone)")

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -36,10 +36,13 @@ struct TabContextMenuState {
     let isPinned: Bool
     let isUnread: Bool
     let isBrowser: Bool
+    let isTerminal: Bool
     let hasCustomTitle: Bool
     let canCloseToLeft: Bool
     let canCloseToRight: Bool
     let canCloseOthers: Bool
+    let canMoveToLeftPane: Bool
+    let canMoveToRightPane: Bool
     let isZoomed: Bool
     let hasSplits: Bool
     let shortcuts: [TabContextAction: KeyboardShortcut]
@@ -306,10 +309,13 @@ struct TabBarView: View {
             isPinned: tab.isPinned,
             isUnread: tab.showsNotificationBadge,
             isBrowser: tab.kind == "browser",
+            isTerminal: tab.kind == "terminal",
             hasCustomTitle: tab.hasCustomTitle,
             canCloseToLeft: canCloseToLeft,
             canCloseToRight: canCloseToRight,
             canCloseOthers: canCloseOthers,
+            canMoveToLeftPane: controller.adjacentPane(to: pane.id, direction: .left) != nil,
+            canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
             isZoomed: splitViewController.zoomedPaneId == pane.id,
             hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
             shortcuts: controller.contextMenuShortcuts

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -343,10 +343,18 @@ struct TabItemView: View {
         contextButton("Move Tab…", action: .move)
 
         if contextMenuState.isTerminal {
-            localizedContextButton("command.moveTabToLeftPane.title", action: .moveToLeftPane)
+            localizedContextButton(
+                "command.moveTabToLeftPane.title",
+                defaultValue: "Move to Left Pane",
+                action: .moveToLeftPane
+            )
                 .disabled(!contextMenuState.canMoveToLeftPane)
 
-            localizedContextButton("command.moveTabToRightPane.title", action: .moveToRightPane)
+            localizedContextButton(
+                "command.moveTabToRightPane.title",
+                defaultValue: "Move to Right Pane",
+                action: .moveToRightPane
+            )
                 .disabled(!contextMenuState.canMoveToRightPane)
         }
 
@@ -402,21 +410,15 @@ struct TabItemView: View {
     }
 
     @ViewBuilder
-    private func localizedContextButton(_ titleKey: LocalizedStringKey, action: TabContextAction) -> some View {
-        if let shortcut = contextMenuState.shortcuts[action] {
-            Button {
-                onContextAction(action)
-            } label: {
-                Text(titleKey)
-            }
-            .keyboardShortcut(shortcut)
-        } else {
-            Button {
-                onContextAction(action)
-            } label: {
-                Text(titleKey)
-            }
-        }
+    private func localizedContextButton(
+        _ titleKey: String,
+        defaultValue: String,
+        action: TabContextAction
+    ) -> some View {
+        contextButton(
+            Bundle.module.localizedString(forKey: titleKey, value: defaultValue, table: nil),
+            action: action
+        )
     }
 
     // MARK: - Tab Background

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -342,6 +342,14 @@ struct TabItemView: View {
 
         contextButton("Move Tab…", action: .move)
 
+        if contextMenuState.isTerminal {
+            localizedContextButton("command.moveTabToLeftPane.title", action: .moveToLeftPane)
+                .disabled(!contextMenuState.canMoveToLeftPane)
+
+            localizedContextButton("command.moveTabToRightPane.title", action: .moveToRightPane)
+                .disabled(!contextMenuState.canMoveToRightPane)
+        }
+
         Divider()
 
         contextButton("New Terminal Tab to Right", action: .newTerminalToRight)
@@ -389,6 +397,24 @@ struct TabItemView: View {
         } else {
             Button(title) {
                 onContextAction(action)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func localizedContextButton(_ titleKey: LocalizedStringKey, action: TabContextAction) -> some View {
+        if let shortcut = contextMenuState.shortcuts[action] {
+            Button {
+                onContextAction(action)
+            } label: {
+                Text(titleKey)
+            }
+            .keyboardShortcut(shortcut)
+        } else {
+            Button {
+                onContextAction(action)
+            } label: {
+                Text(titleKey)
             }
         }
     }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -572,6 +572,11 @@ public final class BonsplitController {
         }
     }
 
+    /// Find the closest pane in the requested direction from the given pane.
+    public func adjacentPane(to paneId: PaneID, direction: NavigationDirection) -> PaneID? {
+        internalController.adjacentPane(to: paneId, direction: direction)
+    }
+
     // MARK: - Split Zoom
 
     /// Currently zoomed pane ID, if any.

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -8,6 +8,8 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case closeToRight
     case closeOthers
     case move
+    case moveToLeftPane
+    case moveToRightPane
     case newTerminalToRight
     case newBrowserToRight
     case reload

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"command.moveTabToLeftPane.title" = "Move to Left Pane";
+"command.moveTabToRightPane.title" = "Move to Right Pane";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,2 @@
+"command.moveTabToLeftPane.title" = "左のペインへ移動";
+"command.moveTabToRightPane.title" = "右のペインへ移動";


### PR DESCRIPTION
## Summary
- add adjacent-pane helpers for Bonsplit tab actions
- let terminal-tab drags prefer moving into left/right neighboring panes
- add terminal-tab context menu actions for moving into the left or right pane

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable moving terminal tabs to left/right adjacent panes via drag-and-drop and the tab menu to speed up pane moves and reduce accidental splits. Addresses Linear issue 981.

- **New Features**
  - Public API: BonsplitController.adjacentPane(to:direction:) to find neighbor panes.
  - Tab context menu adds Move to Left/Right Pane for terminal tabs (TabContextAction.moveToLeftPane/.moveToRightPane); disabled when no neighbor; supports shortcuts.

- **Bug Fixes**
  - Drag-and-drop now targets the neighbor via the shared edge while keeping the outer edge for splits, fixing misdrops; move-to-pane labels corrected and localized (EN/JA) with bundled resources.

<sup>Written for commit 282c43a7887783e636cf10ea99a3dd598d932c20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added public API to query the closest pane in a specified direction from any pane
  * Terminal tabs now support context menu actions to move to adjacent panes (left/right)
  * Improved drag-and-drop handling for terminal tabs between neighboring panes with intelligent drop zone detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->