### PR TITLE
Restore SafeTooltip and revert overlay regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: macos-15
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      - name: Run tests
+        run: swift test

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -48,103 +48,6 @@ enum PaneDropLifecycle {
     case hovering
 }
 
-private struct PaneDropPlaceholderOverlay: View {
-    let zone: DropZone?
-    let size: CGSize
-
-    private let placeholderColor = Color.accentColor.opacity(0.25)
-    private let borderColor = Color.accentColor
-    private let padding: CGFloat = 4
-
-    var body: some View {
-        let frame = overlayFrame(for: zone, in: size)
-
-        RoundedRectangle(cornerRadius: 8)
-            .fill(placeholderColor)
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(borderColor, lineWidth: 2)
-            )
-            .frame(width: frame.width, height: frame.height)
-            .offset(x: frame.minX, y: frame.minY)
-            .opacity(zone != nil ? 1 : 0)
-            .animation(.spring(duration: 0.25, bounce: 0.15), value: zone)
-    }
-
-    private func overlayFrame(for zone: DropZone?, in size: CGSize) -> CGRect {
-        switch zone {
-        case .center, .none:
-            return CGRect(
-                x: padding,
-                y: padding,
-                width: size.width - padding * 2,
-                height: size.height - padding * 2
-            )
-        case .left:
-            return CGRect(
-                x: padding,
-                y: padding,
-                width: size.width / 2 - padding,
-                height: size.height - padding * 2
-            )
-        case .right:
-            return CGRect(
-                x: size.width / 2,
-                y: padding,
-                width: size.width / 2 - padding,
-                height: size.height - padding * 2
-            )
-        case .top:
-            return CGRect(
-                x: padding,
-                y: padding,
-                width: size.width - padding * 2,
-                height: size.height / 2 - padding
-            )
-        case .bottom:
-            return CGRect(
-                x: padding,
-                y: size.height / 2,
-                width: size.width - padding * 2,
-                height: size.height / 2 - padding
-            )
-        }
-    }
-}
-
-struct PaneDropInteractionContainer<Content: View, DropLayer: View>: View {
-    let activeDropZone: DropZone?
-    let content: Content
-    let dropLayer: (CGSize) -> DropLayer
-
-    init(
-        activeDropZone: DropZone?,
-        @ViewBuilder content: () -> Content,
-        @ViewBuilder dropLayer: @escaping (CGSize) -> DropLayer
-    ) {
-        self.activeDropZone = activeDropZone
-        self.content = content()
-        self.dropLayer = dropLayer
-    }
-
-    var body: some View {
-        GeometryReader { geometry in
-            let size = geometry.size
-
-            content
-                .frame(width: size.width, height: size.height)
-                .overlay {
-                    dropLayer(size)
-                }
-                .overlay(alignment: .topLeading) {
-                    PaneDropPlaceholderOverlay(zone: activeDropZone, size: size)
-                        .allowsHitTesting(false)
-                }
-        }
-        .clipped()
-    }
-}
-
 /// Container for a single pane with its tab bar and content area
 struct PaneContainerView<Content: View, EmptyContent: View>: View {
     @Environment(BonsplitController.self) private var bonsplitController
@@ -218,12 +121,23 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var contentAreaWithDropZones: some View {
-        PaneDropInteractionContainer(activeDropZone: activeDropZone) {
-            contentArea
-        } dropLayer: { size in
-            // Drop zones layer (above content, receives drops and taps)
-            dropZonesLayer(size: size)
+        GeometryReader { geometry in
+            let size = geometry.size
+
+            ZStack {
+                // Main content
+                contentArea
+
+                // Drop zones layer (above content, receives drops and taps)
+                dropZonesLayer(size: size)
+
+                // Visual placeholder (non-interactive)
+                dropPlaceholder(for: activeDropZone, in: size)
+                    .allowsHitTesting(false)
+            }
+            .frame(width: size.width, height: size.height)
         }
+        .clipped()
     }
 
     // MARK: - Content Area
@@ -313,6 +227,42 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
                     dropLifecycle: $dropLifecycle
                 ))
         }
+    }
+
+    // MARK: - Drop Placeholder
+
+    @ViewBuilder
+    private func dropPlaceholder(for zone: DropZone?, in size: CGSize) -> some View {
+        let placeholderColor = Color.accentColor.opacity(0.25)
+        let borderColor = Color.accentColor
+        let padding: CGFloat = 4
+
+        // Calculate frame based on zone
+        let frame: CGRect = {
+            switch zone {
+            case .center, .none:
+                return CGRect(x: padding, y: padding, width: size.width - padding * 2, height: size.height - padding * 2)
+            case .left:
+                return CGRect(x: padding, y: padding, width: size.width / 2 - padding, height: size.height - padding * 2)
+            case .right:
+                return CGRect(x: size.width / 2, y: padding, width: size.width / 2 - padding, height: size.height - padding * 2)
+            case .top:
+                return CGRect(x: padding, y: padding, width: size.width - padding * 2, height: size.height / 2 - padding)
+            case .bottom:
+                return CGRect(x: padding, y: size.height / 2, width: size.width - padding * 2, height: size.height / 2 - padding)
+            }
+        }()
+
+        RoundedRectangle(cornerRadius: 8)
+            .fill(placeholderColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(borderColor, lineWidth: 2)
+            )
+            .frame(width: frame.width, height: frame.height)
+            .position(x: frame.midX, y: frame.midY)
+            .opacity(zone != nil ? 1 : 0)
+            .animation(.spring(duration: 0.25, bounce: 0.15), value: zone)
     }
 
     // MARK: - Empty Pane View

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -451,7 +451,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .help(tooltips.newTerminal)
+            .safeHelp(tooltips.newTerminal)
 
             Button {
                 controller.requestNewTab(kind: "browser", inPane: pane.id)
@@ -460,7 +460,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .help(tooltips.newBrowser)
+            .safeHelp(tooltips.newBrowser)
 
             Button {
                 // 120fps animation handled by SplitAnimator
@@ -470,7 +470,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .help(tooltips.splitRight)
+            .safeHelp(tooltips.splitRight)
 
             Button {
                 // 120fps animation handled by SplitAnimator
@@ -480,7 +480,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .help(tooltips.splitDown)
+            .safeHelp(tooltips.splitDown)
         }
         .padding(.trailing, 8)
     }

--- a/Sources/Bonsplit/Public/SafeTooltip.swift
+++ b/Sources/Bonsplit/Public/SafeTooltip.swift
@@ -1,0 +1,136 @@
+import AppKit
+import SwiftUI
+
+private struct SafeTooltipModifier: ViewModifier {
+    let text: String?
+
+    func body(content: Content) -> some View {
+        content.background {
+            SafeTooltipViewRepresentable(text: text)
+                .allowsHitTesting(false)
+        }
+    }
+}
+
+private struct SafeTooltipViewRepresentable: NSViewRepresentable {
+    let text: String?
+
+    func makeNSView(context: Context) -> SafeTooltipView {
+        let view = SafeTooltipView()
+        view.updateTooltip(text)
+        return view
+    }
+
+    func updateNSView(_ nsView: SafeTooltipView, context: Context) {
+        nsView.updateTooltip(text)
+    }
+
+    static func dismantleNSView(_ nsView: SafeTooltipView, coordinator: ()) {
+        nsView.invalidateTooltip()
+    }
+}
+
+private final class SafeTooltipView: NSView {
+    private var tooltipTag: NSView.ToolTipTag?
+    private var registeredBounds: NSRect = .zero
+    private var registeredText: String?
+    private var tooltipText: String?
+
+    override var isOpaque: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func layout() {
+        super.layout()
+        refreshTooltipRegistration()
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        refreshTooltipRegistration()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            invalidateTooltip()
+        } else {
+            refreshTooltipRegistration()
+        }
+    }
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        if superview == nil {
+            invalidateTooltip()
+        } else {
+            refreshTooltipRegistration()
+        }
+    }
+
+    func updateTooltip(_ text: String?) {
+        let normalized = text?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        tooltipText = normalized?.isEmpty == false ? normalized : nil
+        refreshTooltipRegistration()
+    }
+
+    func invalidateTooltip() {
+        if let tooltipTag {
+            removeToolTip(tooltipTag)
+            self.tooltipTag = nil
+        }
+        registeredBounds = .zero
+        registeredText = nil
+    }
+
+    private func refreshTooltipRegistration() {
+        guard let tooltipText,
+              window != nil,
+              superview != nil else {
+            invalidateTooltip()
+            return
+        }
+
+        let nextBounds = bounds.standardized.integral
+        guard nextBounds.width > 0, nextBounds.height > 0 else {
+            invalidateTooltip()
+            return
+        }
+
+        if tooltipTag != nil,
+           nextBounds == registeredBounds,
+           tooltipText == registeredText {
+            return
+        }
+
+        invalidateTooltip()
+        tooltipTag = addToolTip(nextBounds, owner: self, userData: nil)
+        registeredBounds = nextBounds
+        registeredText = tooltipText
+    }
+
+    @objc
+    func view(
+        _ view: NSView,
+        stringForToolTip tag: NSView.ToolTipTag,
+        point: NSPoint,
+        userData data: UnsafeMutableRawPointer?
+    ) -> String {
+        tooltipText ?? ""
+    }
+
+    deinit {
+        invalidateTooltip()
+    }
+}
+
+public extension View {
+    /// Uses an AppKit-backed tooltip host that explicitly unregisters its tooltip
+    /// before the view is detached or deallocated.
+    func safeHelp(_ text: String?) -> some View {
+        modifier(SafeTooltipModifier(text: text))
+    }
+}

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1,65 +1,14 @@
 import XCTest
 @testable import Bonsplit
 import AppKit
-import SwiftUI
 
 final class BonsplitTests: XCTestCase {
-    @MainActor
-    private final class LayoutProbeView: NSView {
-        private(set) var sizeChangeCount = 0
-        private(set) var originChangeCount = 0
-
-        override func setFrameSize(_ newSize: NSSize) {
-            if frame.size != newSize {
-                sizeChangeCount += 1
-            }
-            super.setFrameSize(newSize)
-        }
-
-        override func setFrameOrigin(_ newOrigin: NSPoint) {
-            if frame.origin != newOrigin {
-                originChangeCount += 1
-            }
-            super.setFrameOrigin(newOrigin)
-        }
-    }
-
-    @MainActor
-    private struct LayoutProbeRepresentable: NSViewRepresentable {
-        let probeView: LayoutProbeView
-
-        func makeNSView(context: Context) -> LayoutProbeView {
-            probeView
-        }
-
-        func updateNSView(_ nsView: LayoutProbeView, context: Context) {}
-    }
-
-    @MainActor
-    private final class DropZoneModel: ObservableObject {
-        @Published var zone: DropZone?
-    }
-
-    @MainActor
-    private struct PaneDropInteractionHarness: View {
-        @ObservedObject var model: DropZoneModel
-        let probeView: LayoutProbeView
-
-        var body: some View {
-            PaneDropInteractionContainer(activeDropZone: model.zone) {
-                LayoutProbeRepresentable(probeView: probeView)
-            } dropLayer: { _ in
-                Color.clear
-            }
-        }
-    }
-
     private final class TabContextActionDelegateSpy: BonsplitDelegate {
         var action: TabContextAction?
         var tabId: TabID?
         var paneId: PaneID?
 
-        func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Bonsplit.Tab, inPane pane: PaneID) {
+        func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID) {
             self.action = action
             self.tabId = tab.id
             self.paneId = pane
@@ -397,7 +346,7 @@ final class BonsplitTests: XCTestCase {
         let controller = BonsplitController()
         _ = controller.createTab(title: "Base")
         let sourcePaneId = controller.focusedPaneId!
-        let customTab = Bonsplit.Tab(title: "Custom", hasCustomTitle: true)
+        let customTab = Tab(title: "Custom", hasCustomTitle: true)
 
         guard let newPaneId = controller.splitPane(sourcePaneId, orientation: .horizontal, withTab: customTab) else {
             return XCTFail("Expected splitPane to return new pane")
@@ -411,7 +360,7 @@ final class BonsplitTests: XCTestCase {
         let controller = BonsplitController()
         _ = controller.createTab(title: "Base")
         let sourcePaneId = controller.focusedPaneId!
-        let customTab = Bonsplit.Tab(title: "Custom", hasCustomTitle: true)
+        let customTab = Tab(title: "Custom", hasCustomTitle: true)
 
         guard let newPaneId = controller.splitPane(
             sourcePaneId,
@@ -660,74 +609,6 @@ final class BonsplitTests: XCTestCase {
         segments = TabBarStyling.separatorSegments(totalWidth: 100, gap: nil)
         XCTAssertEqual(segments.left, 100, accuracy: 0.0001)
         XCTAssertEqual(segments.right, 0, accuracy: 0.0001)
-    }
-
-    @MainActor
-    func testPaneDropOverlayDoesNotResizeHostedContentDuringHover() {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        defer { window.orderOut(nil) }
-        guard let contentView = window.contentView else {
-            XCTFail("Expected content view")
-            return
-        }
-
-        let model = DropZoneModel()
-        let probeView = LayoutProbeView(frame: .zero)
-        let hostingView = NSHostingView(
-            rootView: PaneDropInteractionHarness(
-                model: model,
-                probeView: probeView
-            )
-        )
-        hostingView.frame = contentView.bounds
-        hostingView.autoresizingMask = [.width, .height]
-        contentView.addSubview(hostingView)
-
-        window.makeKeyAndOrderFront(nil)
-        contentView.layoutSubtreeIfNeeded()
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        contentView.layoutSubtreeIfNeeded()
-
-        let initialFrame = probeView.frame
-        let initialSizeChanges = probeView.sizeChangeCount
-        let initialOriginChanges = probeView.originChangeCount
-
-        model.zone = .left
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        contentView.layoutSubtreeIfNeeded()
-
-        XCTAssertEqual(probeView.frame, initialFrame)
-        XCTAssertEqual(
-            probeView.sizeChangeCount,
-            initialSizeChanges,
-            "Drag-hover overlays must not resize the hosted pane content"
-        )
-        XCTAssertEqual(
-            probeView.originChangeCount,
-            initialOriginChanges,
-            "Drag-hover overlays must not move the hosted pane content"
-        )
-
-        model.zone = .bottom
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        contentView.layoutSubtreeIfNeeded()
-
-        XCTAssertEqual(probeView.frame, initialFrame)
-        XCTAssertEqual(
-            probeView.sizeChangeCount,
-            initialSizeChanges,
-            "Switching hover targets should keep the hosted pane geometry stable"
-        )
-        XCTAssertEqual(
-            probeView.originChangeCount,
-            initialOriginChanges,
-            "Switching hover targets should not reposition the hosted pane content"
-        )
     }
 
     private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {


### PR DESCRIPTION
## Summary
- restore Bonsplit's SafeTooltip host so cmux's `.safeHelp(...)` call sites compile again
- revert the overlay-only pane drop hover change so cmux can return to the pre-#18 behavior

## Testing
- relied on GitHub checks for verification before merge

## Context
This backs out the previously merged drop-hover overlay change so cmux can revert PR #1046 cleanly and re-land the fix from a green base.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores SafeTooltip and reverts the pane drop-hover overlay change to return to the previous behavior. This unblocks external call sites using safeHelp and makes tooltips reliable when views detach.

- **New Features**
  - Added AppKit-backed tooltip host with View.safeHelp(_:) that unregisters tooltips on detach; applied to TabBar action buttons.

- **Refactors**
  - Reverted overlay-only drop-hover and simplified PaneContainerView (removed PaneDropInteractionContainer and related tests); added CI workflow to run Swift tests on macOS 15 with Xcode 26.0.1.

<sup>Written for commit adf60f6b37be311b647cbe83628caa238ca99f18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced improved tooltip functionality with better accessibility support across UI elements.

* **Chores**
  * Added CI workflow for automated testing on pull requests and pushes to main.
  * Internal UI component refactoring for improved rendering efficiency.
  * Test suite cleanup and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->