### PR TITLE
Make pane drop hover overlay non-layout-affecting

### DIFF
--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -48,6 +48,103 @@ enum PaneDropLifecycle {
     case hovering
 }
 
+private struct PaneDropPlaceholderOverlay: View {
+    let zone: DropZone?
+    let size: CGSize
+
+    private let placeholderColor = Color.accentColor.opacity(0.25)
+    private let borderColor = Color.accentColor
+    private let padding: CGFloat = 4
+
+    var body: some View {
+        let frame = overlayFrame(for: zone, in: size)
+
+        RoundedRectangle(cornerRadius: 8)
+            .fill(placeholderColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(borderColor, lineWidth: 2)
+            )
+            .frame(width: frame.width, height: frame.height)
+            .offset(x: frame.minX, y: frame.minY)
+            .opacity(zone != nil ? 1 : 0)
+            .animation(.spring(duration: 0.25, bounce: 0.15), value: zone)
+    }
+
+    private func overlayFrame(for zone: DropZone?, in size: CGSize) -> CGRect {
+        switch zone {
+        case .center, .none:
+            return CGRect(
+                x: padding,
+                y: padding,
+                width: size.width - padding * 2,
+                height: size.height - padding * 2
+            )
+        case .left:
+            return CGRect(
+                x: padding,
+                y: padding,
+                width: size.width / 2 - padding,
+                height: size.height - padding * 2
+            )
+        case .right:
+            return CGRect(
+                x: size.width / 2,
+                y: padding,
+                width: size.width / 2 - padding,
+                height: size.height - padding * 2
+            )
+        case .top:
+            return CGRect(
+                x: padding,
+                y: padding,
+                width: size.width - padding * 2,
+                height: size.height / 2 - padding
+            )
+        case .bottom:
+            return CGRect(
+                x: padding,
+                y: size.height / 2,
+                width: size.width - padding * 2,
+                height: size.height / 2 - padding
+            )
+        }
+    }
+}
+
+struct PaneDropInteractionContainer<Content: View, DropLayer: View>: View {
+    let activeDropZone: DropZone?
+    let content: Content
+    let dropLayer: (CGSize) -> DropLayer
+
+    init(
+        activeDropZone: DropZone?,
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder dropLayer: @escaping (CGSize) -> DropLayer
+    ) {
+        self.activeDropZone = activeDropZone
+        self.content = content()
+        self.dropLayer = dropLayer
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let size = geometry.size
+
+            content
+                .frame(width: size.width, height: size.height)
+                .overlay {
+                    dropLayer(size)
+                }
+                .overlay(alignment: .topLeading) {
+                    PaneDropPlaceholderOverlay(zone: activeDropZone, size: size)
+                        .allowsHitTesting(false)
+                }
+        }
+        .clipped()
+    }
+}
+
 /// Container for a single pane with its tab bar and content area
 struct PaneContainerView<Content: View, EmptyContent: View>: View {
     @Environment(BonsplitController.self) private var bonsplitController
@@ -121,23 +218,12 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var contentAreaWithDropZones: some View {
-        GeometryReader { geometry in
-            let size = geometry.size
-
-            ZStack {
-                // Main content
-                contentArea
-
-                // Drop zones layer (above content, receives drops and taps)
-                dropZonesLayer(size: size)
-
-                // Visual placeholder (non-interactive)
-                dropPlaceholder(for: activeDropZone, in: size)
-                    .allowsHitTesting(false)
-            }
-            .frame(width: size.width, height: size.height)
+        PaneDropInteractionContainer(activeDropZone: activeDropZone) {
+            contentArea
+        } dropLayer: { size in
+            // Drop zones layer (above content, receives drops and taps)
+            dropZonesLayer(size: size)
         }
-        .clipped()
     }
 
     // MARK: - Content Area
@@ -227,42 +313,6 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
                     dropLifecycle: $dropLifecycle
                 ))
         }
-    }
-
-    // MARK: - Drop Placeholder
-
-    @ViewBuilder
-    private func dropPlaceholder(for zone: DropZone?, in size: CGSize) -> some View {
-        let placeholderColor = Color.accentColor.opacity(0.25)
-        let borderColor = Color.accentColor
-        let padding: CGFloat = 4
-
-        // Calculate frame based on zone
-        let frame: CGRect = {
-            switch zone {
-            case .center, .none:
-                return CGRect(x: padding, y: padding, width: size.width - padding * 2, height: size.height - padding * 2)
-            case .left:
-                return CGRect(x: padding, y: padding, width: size.width / 2 - padding, height: size.height - padding * 2)
-            case .right:
-                return CGRect(x: size.width / 2, y: padding, width: size.width / 2 - padding, height: size.height - padding * 2)
-            case .top:
-                return CGRect(x: padding, y: padding, width: size.width - padding * 2, height: size.height / 2 - padding)
-            case .bottom:
-                return CGRect(x: padding, y: size.height / 2, width: size.width - padding * 2, height: size.height / 2 - padding)
-            }
-        }()
-
-        RoundedRectangle(cornerRadius: 8)
-            .fill(placeholderColor)
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(borderColor, lineWidth: 2)
-            )
-            .frame(width: frame.width, height: frame.height)
-            .position(x: frame.midX, y: frame.midY)
-            .opacity(zone != nil ? 1 : 0)
-            .animation(.spring(duration: 0.25, bounce: 0.15), value: zone)
     }
 
     // MARK: - Empty Pane View

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1,14 +1,65 @@
 import XCTest
 @testable import Bonsplit
 import AppKit
+import SwiftUI
 
 final class BonsplitTests: XCTestCase {
+    @MainActor
+    private final class LayoutProbeView: NSView {
+        private(set) var sizeChangeCount = 0
+        private(set) var originChangeCount = 0
+
+        override func setFrameSize(_ newSize: NSSize) {
+            if frame.size != newSize {
+                sizeChangeCount += 1
+            }
+            super.setFrameSize(newSize)
+        }
+
+        override func setFrameOrigin(_ newOrigin: NSPoint) {
+            if frame.origin != newOrigin {
+                originChangeCount += 1
+            }
+            super.setFrameOrigin(newOrigin)
+        }
+    }
+
+    @MainActor
+    private struct LayoutProbeRepresentable: NSViewRepresentable {
+        let probeView: LayoutProbeView
+
+        func makeNSView(context: Context) -> LayoutProbeView {
+            probeView
+        }
+
+        func updateNSView(_ nsView: LayoutProbeView, context: Context) {}
+    }
+
+    @MainActor
+    private final class DropZoneModel: ObservableObject {
+        @Published var zone: DropZone?
+    }
+
+    @MainActor
+    private struct PaneDropInteractionHarness: View {
+        @ObservedObject var model: DropZoneModel
+        let probeView: LayoutProbeView
+
+        var body: some View {
+            PaneDropInteractionContainer(activeDropZone: model.zone) {
+                LayoutProbeRepresentable(probeView: probeView)
+            } dropLayer: { _ in
+                Color.clear
+            }
+        }
+    }
+
     private final class TabContextActionDelegateSpy: BonsplitDelegate {
         var action: TabContextAction?
         var tabId: TabID?
         var paneId: PaneID?
 
-        func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID) {
+        func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Bonsplit.Tab, inPane pane: PaneID) {
             self.action = action
             self.tabId = tab.id
             self.paneId = pane
@@ -346,7 +397,7 @@ final class BonsplitTests: XCTestCase {
         let controller = BonsplitController()
         _ = controller.createTab(title: "Base")
         let sourcePaneId = controller.focusedPaneId!
-        let customTab = Tab(title: "Custom", hasCustomTitle: true)
+        let customTab = Bonsplit.Tab(title: "Custom", hasCustomTitle: true)
 
         guard let newPaneId = controller.splitPane(sourcePaneId, orientation: .horizontal, withTab: customTab) else {
             return XCTFail("Expected splitPane to return new pane")
@@ -360,7 +411,7 @@ final class BonsplitTests: XCTestCase {
         let controller = BonsplitController()
         _ = controller.createTab(title: "Base")
         let sourcePaneId = controller.focusedPaneId!
-        let customTab = Tab(title: "Custom", hasCustomTitle: true)
+        let customTab = Bonsplit.Tab(title: "Custom", hasCustomTitle: true)
 
         guard let newPaneId = controller.splitPane(
             sourcePaneId,
@@ -609,6 +660,74 @@ final class BonsplitTests: XCTestCase {
         segments = TabBarStyling.separatorSegments(totalWidth: 100, gap: nil)
         XCTAssertEqual(segments.left, 100, accuracy: 0.0001)
         XCTAssertEqual(segments.right, 0, accuracy: 0.0001)
+    }
+
+    @MainActor
+    func testPaneDropOverlayDoesNotResizeHostedContentDuringHover() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let model = DropZoneModel()
+        let probeView = LayoutProbeView(frame: .zero)
+        let hostingView = NSHostingView(
+            rootView: PaneDropInteractionHarness(
+                model: model,
+                probeView: probeView
+            )
+        )
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        let initialFrame = probeView.frame
+        let initialSizeChanges = probeView.sizeChangeCount
+        let initialOriginChanges = probeView.originChangeCount
+
+        model.zone = .left
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(probeView.frame, initialFrame)
+        XCTAssertEqual(
+            probeView.sizeChangeCount,
+            initialSizeChanges,
+            "Drag-hover overlays must not resize the hosted pane content"
+        )
+        XCTAssertEqual(
+            probeView.originChangeCount,
+            initialOriginChanges,
+            "Drag-hover overlays must not move the hosted pane content"
+        )
+
+        model.zone = .bottom
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(probeView.frame, initialFrame)
+        XCTAssertEqual(
+            probeView.sizeChangeCount,
+            initialSizeChanges,
+            "Switching hover targets should keep the hosted pane geometry stable"
+        )
+        XCTAssertEqual(
+            probeView.originChangeCount,
+            initialOriginChanges,
+            "Switching hover targets should not reposition the hosted pane content"
+        )
     }
 
     private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {


### PR DESCRIPTION
## Summary
- render the pane drop indicator as a true overlay so drag hover does not participate in layout
- keep the underlying pane content frame stable while drop zones are active
- add a regression test that verifies hosted content geometry does not change during hover updates

## Testing
- GitHub Actions CI

## Context
This re-lands the issue #1045 fix on top of the repaired Bonsplit base that still includes `SafeTooltip.swift`, avoiding the regression that broke cmux CI in the first attempt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the pane drop hover indicator a true overlay so it no longer affects layout. This prevents content shifts during drag hover and keeps pane geometry stable.

- **Bug Fixes**
  - Added PaneDropInteractionContainer and PaneDropPlaceholderOverlay to render drop zones above content without resizing or moving it.
  - Added a regression test to assert the hosted content’s frame and origin stay unchanged while hover zones switch.

<sup>Written for commit 5dc3c82eaff5ebec10ddc2ae39b103eb376eb8ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

