### PR TITLE
Only measure selected bonsplit tab frame

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -259,16 +259,16 @@ struct TabBarView: View {
                 controller.requestTabContextAction(action, for: TabID(id: tab.id), inPane: pane.id)
             }
         )
-        .background(
-            GeometryReader { geometry in
-                Color.clear.preference(
-                    key: SelectedTabFramePreferenceKey.self,
-                    value: pane.selectedTabId == tab.id
-                        ? geometry.frame(in: .named("tabBar"))
-                        : nil
-                )
+        .background {
+            if pane.selectedTabId == tab.id {
+                GeometryReader { geometry in
+                    Color.clear.preference(
+                        key: SelectedTabFramePreferenceKey.self,
+                        value: geometry.frame(in: .named("tabBar"))
+                    )
+                }
             }
-        )
+        }
         .onDrag {
             createItemProvider(for: tab)
         } preview: {


### PR DESCRIPTION
## Summary
Only publish the selected tab frame preference in .

## Why
The cmux workspace typing-lag stress test showed the tab bar spending too much main-thread time recomputing frame preferences for every tab during dense workspace, split, and Bonsplit-tab churn.

## Testing
- Exercised from cmux's  against a tagged dev build on 
- Verified the hot path stopped dominating follow-up  captures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Measure and publish the tab frame only for the selected tab in `TabBarView` to cut main-thread work and reduce typing lag during heavy tab churn. Removes unnecessary `GeometryReader` work and preference updates for non-selected tabs, improving responsiveness in the cmux workspace stress test.

<sup>Written for commit 085411e6b19ee0d60a535651efad1a90b2659e91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tab bar rendering by reducing unnecessary view creation and computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->