### PR TITLE
Add hover-only pane tab bar controls

### DIFF
--- a/Sources/Bonsplit/Internal/Views/BonsplitHostingView.swift
+++ b/Sources/Bonsplit/Internal/Views/BonsplitHostingView.swift
@@ -1,0 +1,53 @@
+import AppKit
+import SwiftUI
+
+class BonsplitHostingView<Content: View>: NSHostingView<Content> {
+    private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
+
+    override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
+    override var safeAreaRect: NSRect { bounds }
+    override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
+    override var mouseDownCanMoveWindow: Bool { false }
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
+    }
+
+    required init(rootView: Content) {
+        super.init(rootView: rootView)
+        addLayoutGuide(zeroSafeAreaLayoutGuide)
+        NSLayoutConstraint.activate([
+            zeroSafeAreaLayoutGuide.leadingAnchor.constraint(equalTo: leadingAnchor),
+            zeroSafeAreaLayoutGuide.trailingAnchor.constraint(equalTo: trailingAnchor),
+            zeroSafeAreaLayoutGuide.topAnchor.constraint(equalTo: topAnchor),
+            zeroSafeAreaLayoutGuide.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+final class BonsplitHostingController<Content: View>: NSViewController {
+    private let hostingView: BonsplitHostingView<Content>
+
+    var rootView: Content {
+        get { hostingView.rootView }
+        set { hostingView.rootView = newValue }
+    }
+
+    init(rootView: Content) {
+        hostingView = BonsplitHostingView(rootView: rootView)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = hostingView
+    }
+}

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -8,7 +8,12 @@ private final class TabBarInteractionContainerView: NSView {
     override func accessibilityRole() -> NSAccessibility.Role? { .group }
 }
 
-private final class TabBarInteractionHostingView<Content: View>: BonsplitHostingView<Content> {}
+private final class TabBarInteractionHostingView<Content: View>: BonsplitHostingView<Content> {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard super.hitTest(point) != nil else { return nil }
+        return self
+    }
+}
 
 private struct TabBarHostingWrapper<Content: View>: NSViewRepresentable {
     let content: Content

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -3,15 +3,101 @@ import UniformTypeIdentifiers
 import AppKit
 
 private final class TabBarInteractionContainerView: NSView {
+    private var eventMonitor: Any?
+    private weak var monitoredWindow: NSWindow?
+    private var previousWindowMovableState: Bool?
+
     override var mouseDownCanMoveWindow: Bool { false }
     override func isAccessibilityElement() -> Bool { true }
     override func accessibilityRole() -> NSAccessibility.Role? { .group }
-}
 
-private final class TabBarInteractionHostingView<Content: View>: BonsplitHostingView<Content> {
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        guard super.hitTest(point) != nil else { return nil }
-        return self
+    deinit {
+        removeEventMonitor()
+        restoreWindowDraggingIfNeeded()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+
+        if window !== monitoredWindow {
+            removeEventMonitor()
+            monitoredWindow = window
+            installEventMonitor()
+        }
+
+        if window == nil {
+            restoreWindowDraggingIfNeeded()
+        }
+    }
+
+    private func installEventMonitor() {
+        guard eventMonitor == nil else { return }
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]) { [weak self] event in
+            self?.handleLocalMouseEvent(event) ?? event
+        }
+    }
+
+    private func removeEventMonitor() {
+        guard let eventMonitor else { return }
+        NSEvent.removeMonitor(eventMonitor)
+        self.eventMonitor = nil
+    }
+
+    private func handleLocalMouseEvent(_ event: NSEvent) -> NSEvent? {
+        guard let window = monitoredWindow else {
+            return event
+        }
+
+        if event.window !== window {
+            if event.type == .leftMouseUp {
+                restoreWindowDraggingIfNeeded()
+            }
+            return event
+        }
+
+        let point = convert(event.locationInWindow, from: nil)
+        switch event.type {
+        case .leftMouseDown:
+            if bounds.contains(point), !hitTestRoutesToWindowDragRegion(at: point) {
+                suppressWindowDraggingIfNeeded(window: window)
+            }
+        case .leftMouseDragged:
+            if previousWindowMovableState == nil, bounds.contains(point), !hitTestRoutesToWindowDragRegion(at: point) {
+                suppressWindowDraggingIfNeeded(window: window)
+            }
+        case .leftMouseUp:
+            restoreWindowDraggingIfNeeded()
+        default:
+            break
+        }
+
+        return event
+    }
+
+    private func hitTestRoutesToWindowDragRegion(at point: NSPoint) -> Bool {
+        guard let hitView = super.hitTest(point) else { return false }
+        var current: NSView? = hitView
+        while let view = current {
+            if view is TabBarWindowDragRegionView {
+                return true
+            }
+            current = view.superview
+        }
+        return false
+    }
+
+    private func suppressWindowDraggingIfNeeded(window: NSWindow) {
+        guard previousWindowMovableState == nil else { return }
+        previousWindowMovableState = window.isMovable
+        if window.isMovable {
+            window.isMovable = false
+        }
+    }
+
+    private func restoreWindowDraggingIfNeeded() {
+        guard let previousWindowMovableState else { return }
+        monitoredWindow?.isMovable = previousWindowMovableState
+        self.previousWindowMovableState = nil
     }
 }
 
@@ -27,7 +113,7 @@ private struct TabBarHostingWrapper<Content: View>: NSViewRepresentable {
         containerView.setAccessibilityElement(true)
         containerView.setAccessibilityIdentifier("paneTabBar")
 
-        let hostingView = TabBarInteractionHostingView(rootView: content)
+        let hostingView = BonsplitHostingView(rootView: content)
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         hostingView.setAccessibilityElement(false)
         containerView.addSubview(hostingView)
@@ -48,7 +134,7 @@ private struct TabBarHostingWrapper<Content: View>: NSViewRepresentable {
     }
 
     final class Coordinator {
-        var hostingView: TabBarInteractionHostingView<Content>?
+        var hostingView: BonsplitHostingView<Content>?
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -2,6 +2,51 @@ import SwiftUI
 import UniformTypeIdentifiers
 import AppKit
 
+private final class TabBarInteractionContainerView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+}
+
+private final class TabBarInteractionHostingView<Content: View>: NSHostingView<Content> {
+    override var mouseDownCanMoveWindow: Bool { false }
+}
+
+private struct TabBarHostingWrapper<Content: View>: NSViewRepresentable {
+    let content: Content
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let containerView = TabBarInteractionContainerView()
+        containerView.setAccessibilityElement(true)
+        containerView.setAccessibilityIdentifier("paneTabBar")
+
+        let hostingView = TabBarInteractionHostingView(rootView: content)
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        hostingView.setAccessibilityElement(false)
+        containerView.addSubview(hostingView)
+
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+        ])
+
+        context.coordinator.hostingView = hostingView
+        return containerView
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.hostingView?.rootView = content
+    }
+
+    final class Coordinator {
+        var hostingView: TabBarInteractionHostingView<Content>?
+    }
+}
+
 /// Drop zone positions for creating splits
 public enum DropZone: Equatable {
     case center
@@ -174,10 +219,12 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
     var body: some View {
         VStack(spacing: 0) {
             // Tab bar
-            TabBarView(
-                pane: pane,
-                isFocused: isFocused,
-                showSplitButtons: showSplitButtons
+            TabBarHostingWrapper(
+                content: TabBarView(
+                    pane: pane,
+                    isFocused: isFocused,
+                    showSplitButtons: showSplitButtons
+                )
             )
 
             // Content area with drop zones

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -4,11 +4,11 @@ import AppKit
 
 private final class TabBarInteractionContainerView: NSView {
     override var mouseDownCanMoveWindow: Bool { false }
+    override func isAccessibilityElement() -> Bool { true }
+    override func accessibilityRole() -> NSAccessibility.Role? { .group }
 }
 
-private final class TabBarInteractionHostingView<Content: View>: NSHostingView<Content> {
-    override var mouseDownCanMoveWindow: Bool { false }
-}
+private final class TabBarInteractionHostingView<Content: View>: BonsplitHostingView<Content> {}
 
 private struct TabBarHostingWrapper<Content: View>: NSViewRepresentable {
     let content: Content

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -122,7 +122,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
         // Keep arranged subviews stable (always 2) to avoid transient "collapse" flashes when
         // replacing pane<->split content. We swap the hosted content within these containers.
-        let firstContainer = NSView()
+        let firstContainer = PaneDragContainerView()
         firstContainer.wantsLayer = true
         firstContainer.layer?.backgroundColor = chromeBackgroundColor.cgColor
         firstContainer.layer?.masksToBounds = true
@@ -131,7 +131,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.addArrangedSubview(firstContainer)
         context.coordinator.firstHostingController = firstController
 
-        let secondContainer = NSView()
+        let secondContainer = PaneDragContainerView()
         secondContainer.wantsLayer = true
         secondContainer.layer?.backgroundColor = chromeBackgroundColor.cgColor
         secondContainer.layer?.masksToBounds = true

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -355,14 +355,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
     // MARK: - Helpers
 
-    private func makeHostingController(for node: SplitNode) -> NSHostingController<AnyView> {
-        let hostingController = NSHostingController(rootView: AnyView(makeView(for: node)))
-        if #available(macOS 13.0, *) {
-            // NSSplitView owns pane geometry. Keep NSHostingController from publishing
-            // intrinsic-size constraints that force a minimum pane width.
-            hostingController.sizingOptions = []
-        }
-
+    private func makeHostingController(for node: SplitNode) -> BonsplitHostingController<AnyView> {
+        let hostingController = BonsplitHostingController(rootView: AnyView(makeView(for: node)))
         let hostedView = hostingController.view
         // NSSplitView lays out arranged subviews by setting frames. Leaving Auto Layout
         // enabled on these NSHostingViews can allow them to compress to 0 during
@@ -378,7 +372,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         return hostingController
     }
 
-    private func installHostingController(_ hostingController: NSHostingController<AnyView>, into container: NSView) {
+    private func installHostingController(_ hostingController: BonsplitHostingController<AnyView>, into container: NSView) {
         let hostedView = hostingController.view
         hostedView.frame = container.bounds
         hostedView.autoresizingMask = [.width, .height]
@@ -391,7 +385,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         in container: NSView,
         node: SplitNode,
         nodeTypeChanged: Bool,
-        controller: inout NSHostingController<AnyView>?
+        controller: inout BonsplitHostingController<AnyView>?
     ) {
         // Historically we recreated the NSHostingController when the child node type changed
         // (pane <-> split) to force a full detach/reattach of native AppKit subviews.
@@ -468,8 +462,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         var firstNodeType: SplitNode.NodeType
         var secondNodeType: SplitNode.NodeType
         /// Retain hosting controllers so SwiftUI content stays alive
-        var firstHostingController: NSHostingController<AnyView>?
-        var secondHostingController: NSHostingController<AnyView>?
+        var firstHostingController: BonsplitHostingController<AnyView>?
+        var secondHostingController: BonsplitHostingController<AnyView>?
 
         init(
             splitState: SplitState,

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -45,7 +45,9 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
 }
 
 /// Container NSView for a pane inside SinglePaneWrapper.
-class PaneDragContainerView: NSView {}
+class PaneDragContainerView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+}
 
 /// Wrapper that uses NSHostingController for proper AppKit layout constraints
 struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable {

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -68,7 +68,7 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
             showSplitButtons: showSplitButtons,
             contentViewLifecycle: contentViewLifecycle
         )
-        let hostingController = NSHostingController(rootView: paneView)
+        let hostingController = BonsplitHostingController(rootView: paneView)
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 
         let containerView = PaneDragContainerView()
@@ -112,6 +112,6 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
     }
 
     class Coordinator {
-        var hostingController: NSHostingController<PaneContainerView<Content, EmptyContent>>?
+        var hostingController: BonsplitHostingController<PaneContainerView<Content, EmptyContent>>?
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -12,6 +12,19 @@ private struct SelectedTabFramePreferenceKey: PreferenceKey {
     }
 }
 
+private struct TabDropFrame: Equatable {
+    let index: Int
+    let frame: CGRect
+}
+
+private struct TabDropFramesPreferenceKey: PreferenceKey {
+    static let defaultValue: [TabDropFrame] = []
+
+    static func reduce(value: inout [TabDropFrame], nextValue: () -> [TabDropFrame]) {
+        value.append(contentsOf: nextValue())
+    }
+}
+
 enum TabBarStyling {
     static func separatorSegments(
         totalWidth: CGFloat,
@@ -73,6 +86,7 @@ struct TabBarView: View {
     @State private var contentWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
+    @State private var tabDropFrames: [TabDropFrame] = []
     @State private var isHoveringTabBar = false
     @StateObject private var controlKeyMonitor = TabControlShortcutKeyMonitor()
     @AppStorage("paneTabBarControlsVisibilityMode")
@@ -230,11 +244,39 @@ struct TabBarView: View {
         .onPreferenceChange(SelectedTabFramePreferenceKey.self) { frame in
             selectedTabFrameInBar = frame
         }
+        .onPreferenceChange(TabDropFramesPreferenceKey.self) { frames in
+            tabDropFrames = frames.sorted { lhs, rhs in
+                if lhs.index == rhs.index {
+                    return lhs.frame.minX < rhs.frame.minX
+                }
+                return lhs.index < rhs.index
+            }
+        }
         .onDisappear {
             controlKeyMonitor.stop()
         }
         .onHover { hovering in
             isHoveringTabBar = hovering
+        }
+        .overlay {
+            if isTabDragActive {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+                        pane: pane,
+                        bonsplitController: controller,
+                        controller: splitViewController,
+                        dropTargetIndex: $dropTargetIndex,
+                        dropLifecycle: $dropLifecycle,
+                        resolveTargetIndex: { location in
+                            TabDropDelegate.resolvedTargetIndex(
+                                for: location,
+                                frames: tabDropFrames,
+                                fallbackCount: pane.tabs.count
+                            )
+                        }
+                    ))
+            }
         }
     }
 
@@ -285,11 +327,16 @@ struct TabBarView: View {
         )
         .background(
             GeometryReader { geometry in
+                let frame = geometry.frame(in: .named("tabBar"))
                 Color.clear.preference(
                     key: SelectedTabFramePreferenceKey.self,
                     value: pane.selectedTabId == tab.id
-                        ? geometry.frame(in: .named("tabBar"))
+                        ? frame
                         : nil
+                )
+                .preference(
+                    key: TabDropFramesPreferenceKey.self,
+                    value: [TabDropFrame(index: index, frame: frame)]
                 )
             }
         )
@@ -910,14 +957,47 @@ enum TabDropLifecycle {
 // MARK: - Tab Drop Delegate
 
 struct TabDropDelegate: DropDelegate {
-    let targetIndex: Int
     let pane: PaneState
     let bonsplitController: BonsplitController
     let controller: SplitViewController
     @Binding var dropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
+    let resolveTargetIndex: (CGPoint) -> Int
+
+    init(
+        targetIndex: Int,
+        pane: PaneState,
+        bonsplitController: BonsplitController,
+        controller: SplitViewController,
+        dropTargetIndex: Binding<Int?>,
+        dropLifecycle: Binding<TabDropLifecycle>
+    ) {
+        self.pane = pane
+        self.bonsplitController = bonsplitController
+        self.controller = controller
+        self._dropTargetIndex = dropTargetIndex
+        self._dropLifecycle = dropLifecycle
+        self.resolveTargetIndex = { _ in targetIndex }
+    }
+
+    init(
+        pane: PaneState,
+        bonsplitController: BonsplitController,
+        controller: SplitViewController,
+        dropTargetIndex: Binding<Int?>,
+        dropLifecycle: Binding<TabDropLifecycle>,
+        resolveTargetIndex: @escaping (CGPoint) -> Int
+    ) {
+        self.pane = pane
+        self.bonsplitController = bonsplitController
+        self.controller = controller
+        self._dropTargetIndex = dropTargetIndex
+        self._dropLifecycle = dropLifecycle
+        self.resolveTargetIndex = resolveTargetIndex
+    }
 
     func performDrop(info: DropInfo) -> Bool {
+        let targetIndex = resolveTargetIndex(info.location)
         #if DEBUG
         NSLog("[Bonsplit Drag] performDrop called, targetIndex: \(targetIndex)")
         #endif
@@ -991,6 +1071,7 @@ struct TabDropDelegate: DropDelegate {
     }
 
     func dropEntered(info: DropInfo) {
+        let targetIndex = resolveTargetIndex(info.location)
         #if DEBUG
         NSLog("[Bonsplit Drag] dropEntered at index: \(targetIndex)")
         dlog(
@@ -1000,7 +1081,7 @@ struct TabDropDelegate: DropDelegate {
         )
         #endif
         dropLifecycle = .hovering
-        if shouldSuppressIndicatorForNoopSamePaneDrop() {
+        if shouldSuppressIndicatorForNoopSamePaneDrop(targetIndex: targetIndex) {
             dropTargetIndex = nil
         } else {
             dropTargetIndex = targetIndex
@@ -1008,6 +1089,7 @@ struct TabDropDelegate: DropDelegate {
     }
 
     func dropExited(info: DropInfo) {
+        let targetIndex = resolveTargetIndex(info.location)
         #if DEBUG
         NSLog("[Bonsplit Drag] dropExited from index: \(targetIndex)")
         dlog("tab.dropExited pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex)")
@@ -1019,6 +1101,7 @@ struct TabDropDelegate: DropDelegate {
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
+        let targetIndex = resolveTargetIndex(info.location)
         // Guard against dropUpdated firing after performDrop/dropExited
         // This is the key fix for the lingering indicator bug
         guard dropLifecycle == .hovering else {
@@ -1028,7 +1111,7 @@ struct TabDropDelegate: DropDelegate {
             return DropProposal(operation: .move)
         }
         // Only update if this is the active target, and suppress same-pane no-op indicators.
-        if shouldSuppressIndicatorForNoopSamePaneDrop() {
+        if shouldSuppressIndicatorForNoopSamePaneDrop(targetIndex: targetIndex) {
             if dropTargetIndex == targetIndex {
                 dropTargetIndex = nil
             }
@@ -1079,7 +1162,7 @@ struct TabDropDelegate: DropDelegate {
         return true
     }
 
-    private func shouldSuppressIndicatorForNoopSamePaneDrop() -> Bool {
+    private func shouldSuppressIndicatorForNoopSamePaneDrop(targetIndex: Int) -> Bool {
         guard let draggedTab = controller.draggingTab,
               controller.dragSourcePaneId == pane.id,
               let sourceIndex = pane.tabs.firstIndex(where: { $0.id == draggedTab.id }) else {
@@ -1109,5 +1192,21 @@ struct TabDropDelegate: DropDelegate {
             return decodeTransfer(from: raw)
         }
         return nil
+    }
+
+    fileprivate static func resolvedTargetIndex(
+        for location: CGPoint,
+        frames: [TabDropFrame],
+        fallbackCount: Int
+    ) -> Int {
+        guard !frames.isEmpty else { return fallbackCount }
+
+        for frame in frames {
+            if location.x < frame.frame.midX {
+                return frame.index
+            }
+        }
+
+        return fallbackCount
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -25,6 +25,14 @@ private struct TabDropFramesPreferenceKey: PreferenceKey {
     }
 }
 
+func tabBarLeadingTrafficLightInset(
+    trafficLightMaxX: CGFloat,
+    tabBarMinXInWindow: CGFloat,
+    trailingPadding: CGFloat = 14
+) -> CGFloat {
+    max(0, trafficLightMaxX + trailingPadding)
+}
+
 final class TabBarLeadingInsetPassthroughView: NSView {
     var onInsetChange: ((CGFloat) -> Void)?
 
@@ -57,10 +65,14 @@ final class TabBarLeadingInsetPassthroughView: NSView {
             guard let self, let window = self.window ?? self.observedWindow else { return }
 
             let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
-            let maxX = buttonTypes
+            let trafficLightMaxX = buttonTypes
                 .compactMap { window.standardWindowButton($0)?.frame.maxX }
                 .max() ?? 0
-            let inset = max(0, maxX + 14)
+            let frameInWindow = self.convert(self.bounds, to: nil)
+            let inset = tabBarLeadingTrafficLightInset(
+                trafficLightMaxX: trafficLightMaxX,
+                tabBarMinXInWindow: frameInWindow.minX
+            )
             guard self.lastPublishedInset == nil || abs((self.lastPublishedInset ?? 0) - inset) > 0.5 else {
                 return
             }
@@ -424,7 +436,6 @@ struct TabBarView: View {
         )
         .background(
             TabBarLeadingInsetReader(inset: $leadingTrafficLightInset)
-                .frame(width: 0, height: 0)
         )
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
         .onChange(of: splitViewController.draggingTab) { _, newValue in

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -53,6 +53,11 @@ struct TabContextMenuState {
     }
 }
 
+private enum TabBarControlsVisibilityMode: String {
+    case always
+    case onHover
+}
+
 /// Tab bar view with scrollable tabs, drag/drop support, and split buttons
 struct TabBarView: View {
     @Environment(BonsplitController.self) private var controller
@@ -68,7 +73,12 @@ struct TabBarView: View {
     @State private var contentWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
+    @State private var isHoveringTabBar = false
     @StateObject private var controlKeyMonitor = TabControlShortcutKeyMonitor()
+    @AppStorage("paneTabBarControlsVisibilityMode")
+    private var controlsVisibilityModeRawValue = TabBarControlsVisibilityMode.always.rawValue
+    @AppStorage("workspaceTitlebarVisible")
+    private var showWorkspaceTitlebar = true
 
     private var canScrollLeft: Bool {
         scrollOffset > 1
@@ -93,6 +103,27 @@ struct TabBarView: View {
 
     private var showsControlShortcutHints: Bool {
         isFocused && controlKeyMonitor.isShortcutHintVisible
+    }
+
+    private var controlsVisibilityMode: TabBarControlsVisibilityMode {
+        TabBarControlsVisibilityMode(rawValue: controlsVisibilityModeRawValue) ?? .always
+    }
+
+    private var shouldShowSplitButtonsNow: Bool {
+        switch controlsVisibilityMode {
+        case .always:
+            return true
+        case .onHover:
+            return isHoveringTabBar
+        }
+    }
+
+    private var shouldUseTabBarDragRegion: Bool {
+        !showWorkspaceTitlebar
+    }
+
+    private var isTabDragActive: Bool {
+        splitViewController.draggingTab != nil || splitViewController.activeDragTab != nil
     }
 
     var body: some View {
@@ -136,17 +167,7 @@ struct TabBarView: View {
                     .overlay(alignment: .trailing) {
                         let trailing = max(0, containerGeo.size.width - contentWidth)
                         if trailing >= 1 {
-                            Color.clear
-                                .frame(width: trailing, height: TabBarMetrics.tabHeight)
-                                .contentShape(Rectangle())
-                                .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
-                                    targetIndex: pane.tabs.count,
-                                    pane: pane,
-                                    bonsplitController: controller,
-                                    controller: splitViewController,
-                                    dropTargetIndex: $dropTargetIndex,
-                                    dropLifecycle: $dropLifecycle
-                                ))
+                            trailingInteractionView(width: trailing)
                         }
                     }
                     .coordinateSpace(name: "tabScroll")
@@ -177,6 +198,14 @@ struct TabBarView: View {
             if showSplitButtons {
                 splitButtons
                     .saturation(tabBarSaturation)
+                    .opacity(shouldShowSplitButtonsNow ? 1 : 0)
+                    .allowsHitTesting(shouldShowSplitButtonsNow)
+                    .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: shouldShowSplitButtonsNow)
+                    .background {
+                        if !shouldShowSplitButtonsNow && shouldUseTabBarDragRegion && !isTabDragActive {
+                            TabBarWindowDragRegion()
+                        }
+                    }
             }
         }
         .frame(height: TabBarMetrics.barHeight)
@@ -211,6 +240,9 @@ struct TabBarView: View {
         }
         .onDisappear {
             controlKeyMonitor.stop()
+        }
+        .onHover { hovering in
+            isHoveringTabBar = hovering
         }
     }
 
@@ -436,6 +468,26 @@ struct TabBarView: View {
             .fill(TabBarColors.dropIndicator(for: appearance))
             .frame(width: TabBarMetrics.dropIndicatorWidth, height: TabBarMetrics.dropIndicatorHeight)
             .offset(x: -1)
+    }
+
+    @ViewBuilder
+    private func trailingInteractionView(width: CGFloat) -> some View {
+        if shouldUseTabBarDragRegion && !isTabDragActive {
+            TabBarWindowDragRegion()
+                .frame(width: width, height: TabBarMetrics.tabHeight)
+        } else {
+            Color.clear
+                .frame(width: width, height: TabBarMetrics.tabHeight)
+                .contentShape(Rectangle())
+                .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+                    targetIndex: pane.tabs.count,
+                    pane: pane,
+                    bonsplitController: controller,
+                    controller: splitViewController,
+                    dropTargetIndex: $dropTargetIndex,
+                    dropLifecycle: $dropLifecycle
+                ))
+        }
     }
 
     // MARK: - Split Buttons

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -73,7 +73,7 @@ struct TabBarView: View {
     @State private var contentWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
-    @State private var isHoveringSplitButtonsArea = false
+    @State private var isHoveringTabBar = false
     @StateObject private var controlKeyMonitor = TabControlShortcutKeyMonitor()
     @AppStorage("paneTabBarControlsVisibilityMode")
     private var controlsVisibilityModeRawValue = TabBarControlsVisibilityMode.always.rawValue
@@ -114,7 +114,7 @@ struct TabBarView: View {
         case .always:
             return true
         case .onHover:
-            return isHoveringSplitButtonsArea
+            return isHoveringTabBar
         }
     }
 
@@ -202,6 +202,7 @@ struct TabBarView: View {
         .frame(height: TabBarMetrics.barHeight)
         .coordinateSpace(name: "tabBar")
         .contentShape(Rectangle())
+        .accessibilityIdentifier("paneTabBar")
         .background(tabBarBackground)
         .background(
             TabBarHostWindowReader { window in
@@ -231,6 +232,9 @@ struct TabBarView: View {
         }
         .onDisappear {
             controlKeyMonitor.stop()
+        }
+        .onHover { hovering in
+            isHoveringTabBar = hovering
         }
     }
 
@@ -495,9 +499,6 @@ struct TabBarView: View {
                 .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: shouldShowSplitButtonsNow)
         }
         .contentShape(Rectangle())
-        .onHover { hovering in
-            isHoveringSplitButtonsArea = hovering
-        }
         .accessibilityIdentifier("paneTabBarControlsRegion")
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -25,6 +25,198 @@ private struct TabDropFramesPreferenceKey: PreferenceKey {
     }
 }
 
+final class TabBarLeadingInsetPassthroughView: NSView {
+    var onInsetChange: ((CGFloat) -> Void)?
+
+    private weak var observedWindow: NSWindow?
+    private var observers: [NSObjectProtocol] = []
+    private var lastPublishedInset: CGFloat?
+
+    override var mouseDownCanMoveWindow: Bool { false }
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window !== observedWindow {
+            reinstallObservers(for: window)
+        }
+        publishInsetIfNeeded()
+    }
+
+    override func layout() {
+        super.layout()
+        publishInsetIfNeeded()
+    }
+
+    deinit {
+        removeObservers()
+    }
+
+    func publishInsetIfNeeded() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let window = self.window ?? self.observedWindow else { return }
+
+            let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+            let maxX = buttonTypes
+                .compactMap { window.standardWindowButton($0)?.frame.maxX }
+                .max() ?? 0
+            let inset = max(0, maxX + 14)
+            guard self.lastPublishedInset == nil || abs((self.lastPublishedInset ?? 0) - inset) > 0.5 else {
+                return
+            }
+            self.lastPublishedInset = inset
+            self.onInsetChange?(inset)
+        }
+    }
+
+    private func reinstallObservers(for window: NSWindow?) {
+        removeObservers()
+        observedWindow = window
+        guard let window else { return }
+
+        let center = NotificationCenter.default
+        let names: [Notification.Name] = [
+            NSWindow.didResizeNotification,
+            NSWindow.didEndLiveResizeNotification,
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+        ]
+        observers = names.map { name in
+            center.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+                self?.publishInsetIfNeeded()
+            }
+        }
+    }
+
+    private func removeObservers() {
+        let center = NotificationCenter.default
+        for observer in observers {
+            center.removeObserver(observer)
+        }
+        observers.removeAll()
+    }
+}
+
+private struct TabBarLeadingInsetReader: NSViewRepresentable {
+    @Binding var inset: CGFloat
+
+    func makeNSView(context: Context) -> NSView {
+        let view = TabBarLeadingInsetPassthroughView()
+        view.setFrameSize(.zero)
+        view.onInsetChange = { nextInset in
+            if abs(nextInset - inset) > 0.5 {
+                inset = nextInset
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let view = nsView as? TabBarLeadingInsetPassthroughView else { return }
+        view.onInsetChange = { nextInset in
+            if abs(nextInset - inset) > 0.5 {
+                inset = nextInset
+            }
+        }
+        view.publishInsetIfNeeded()
+    }
+}
+
+private final class TabBarNativeDropDestinationView: NSView {
+    var isEnabled = false
+    var validateDrop: ((NSPasteboard) -> Bool)?
+    var updateDropTarget: ((CGPoint) -> Void)?
+    var clearDropState: (() -> Void)?
+    var performDrop: ((CGPoint, NSPasteboard) -> Bool)?
+
+    override var mouseDownCanMoveWindow: Bool { false }
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard isEnabled, bounds.contains(point) else { return nil }
+        return self
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        updateDrag(sender)
+    }
+
+    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        updateDrag(sender)
+    }
+
+    override func draggingExited(_ sender: (any NSDraggingInfo)?) {
+        clearDropState?()
+    }
+
+    override func prepareForDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        isEnabled && (validateDrop?(sender.draggingPasteboard) ?? false)
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        guard isEnabled, (validateDrop?(sender.draggingPasteboard) ?? false) else {
+            clearDropState?()
+            return false
+        }
+
+        let point = convert(sender.draggingLocation, from: nil)
+        guard bounds.contains(point) else {
+            clearDropState?()
+            return false
+        }
+        return performDrop?(CGPoint(x: point.x, y: point.y), sender.draggingPasteboard) ?? false
+    }
+
+    private func updateDrag(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        guard isEnabled, (validateDrop?(sender.draggingPasteboard) ?? false) else {
+            clearDropState?()
+            return []
+        }
+
+        let point = convert(sender.draggingLocation, from: nil)
+        guard bounds.contains(point) else {
+            clearDropState?()
+            return []
+        }
+
+        updateDropTarget?(CGPoint(x: point.x, y: point.y))
+        return .move
+    }
+}
+
+private struct TabBarNativeDropBridge: NSViewRepresentable {
+    let isEnabled: Bool
+    let validateDrop: (NSPasteboard) -> Bool
+    let updateDropTarget: (CGPoint) -> Void
+    let clearDropState: () -> Void
+    let performDrop: (CGPoint, NSPasteboard) -> Bool
+
+    func makeNSView(context: Context) -> NSView {
+        let view = TabBarNativeDropDestinationView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let view = nsView as? TabBarNativeDropDestinationView else { return }
+        view.isEnabled = isEnabled
+        view.validateDrop = validateDrop
+        view.updateDropTarget = updateDropTarget
+        view.clearDropState = clearDropState
+        view.performDrop = performDrop
+        if !isEnabled {
+            clearDropState()
+        }
+    }
+}
+
 enum TabBarStyling {
     static func separatorSegments(
         totalWidth: CGFloat,
@@ -88,6 +280,7 @@ struct TabBarView: View {
     @State private var selectedTabFrameInBar: CGRect?
     @State private var tabDropFrames: [TabDropFrame] = []
     @State private var isHoveringTabBar = false
+    @State private var leadingTrafficLightInset: CGFloat = 0
     @StateObject private var controlKeyMonitor = TabControlShortcutKeyMonitor()
     @AppStorage("paneTabBarControlsVisibilityMode")
     private var controlsVisibilityModeRawValue = TabBarControlsVisibilityMode.always.rawValue
@@ -140,6 +333,10 @@ struct TabBarView: View {
         splitViewController.draggingTab != nil || splitViewController.activeDragTab != nil
     }
 
+    private var effectiveLeadingInset: CGFloat {
+        showWorkspaceTitlebar ? 0 : leadingTrafficLightInset
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             // Scrollable tabs with fade overlays
@@ -157,7 +354,8 @@ struct TabBarView: View {
                             // supports dropping after the last tab.
                             dropZoneAfterTabs
                         }
-                        .padding(.horizontal, TabBarMetrics.barPadding)
+                        .padding(.leading, TabBarMetrics.barPadding + effectiveLeadingInset)
+                        .padding(.trailing, TabBarMetrics.barPadding)
                         // Keep tab insert/remove/reorder instant without suppressing unrelated
                         // subtree animations (for example, shortcut-hint fades).
                         .animation(nil, value: pane.tabs.map(\.id))
@@ -224,6 +422,10 @@ struct TabBarView: View {
             }
             .frame(width: 0, height: 0)
         )
+        .background(
+            TabBarLeadingInsetReader(inset: $leadingTrafficLightInset)
+                .frame(width: 0, height: 0)
+        )
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
         .onChange(of: splitViewController.draggingTab) { _, newValue in
 #if DEBUG
@@ -259,24 +461,48 @@ struct TabBarView: View {
             isHoveringTabBar = hovering
         }
         .overlay {
-            if isTabDragActive {
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+            TabBarNativeDropBridge(
+                isEnabled: isTabDragActive,
+                validateDrop: { pasteboard in
+                    TabDropDelegate.validateDrop(pasteboard: pasteboard, controller: splitViewController)
+                },
+                updateDropTarget: { location in
+                    let targetIndex = TabDropDelegate.resolvedTargetIndex(
+                        for: location,
+                        frames: tabDropFrames,
+                        fallbackCount: pane.tabs.count
+                    )
+                    TabDropDelegate.updateDropState(
+                        targetIndex: targetIndex,
+                        pane: pane,
+                        controller: splitViewController,
+                        dropTargetIndex: $dropTargetIndex,
+                        dropLifecycle: $dropLifecycle
+                    )
+                },
+                clearDropState: {
+                    TabDropDelegate.clearDropState(
+                        dropTargetIndex: $dropTargetIndex,
+                        dropLifecycle: $dropLifecycle
+                    )
+                },
+                performDrop: { location, pasteboard in
+                    let targetIndex = TabDropDelegate.resolvedTargetIndex(
+                        for: location,
+                        frames: tabDropFrames,
+                        fallbackCount: pane.tabs.count
+                    )
+                    return TabDropDelegate.performDrop(
+                        targetIndex: targetIndex,
+                        pasteboard: pasteboard,
                         pane: pane,
                         bonsplitController: controller,
                         controller: splitViewController,
                         dropTargetIndex: $dropTargetIndex,
-                        dropLifecycle: $dropLifecycle,
-                        resolveTargetIndex: { location in
-                            TabDropDelegate.resolvedTargetIndex(
-                                for: location,
-                                frames: tabDropFrames,
-                                fallbackCount: pane.tabs.count
-                            )
-                        }
-                    ))
-            }
+                        dropLifecycle: $dropLifecycle
+                    )
+                }
+            )
         }
     }
 
@@ -507,6 +733,8 @@ struct TabBarView: View {
             .fill(TabBarColors.dropIndicator(for: appearance))
             .frame(width: TabBarMetrics.dropIndicatorWidth, height: TabBarMetrics.dropIndicatorHeight)
             .offset(x: -1)
+            .accessibilityElement(children: .ignore)
+            .accessibilityIdentifier("paneTabBar.dropIndicator")
     }
 
     @ViewBuilder
@@ -998,6 +1226,26 @@ struct TabDropDelegate: DropDelegate {
 
     func performDrop(info: DropInfo) -> Bool {
         let targetIndex = resolveTargetIndex(info.location)
+        return Self.performDrop(
+            targetIndex: targetIndex,
+            pasteboard: NSPasteboard(name: .drag),
+            pane: pane,
+            bonsplitController: bonsplitController,
+            controller: controller,
+            dropTargetIndex: $dropTargetIndex,
+            dropLifecycle: $dropLifecycle
+        )
+    }
+
+    fileprivate static func performDrop(
+        targetIndex: Int,
+        pasteboard: NSPasteboard,
+        pane: PaneState,
+        bonsplitController: BonsplitController,
+        controller: SplitViewController,
+        dropTargetIndex: Binding<Int?>,
+        dropLifecycle: Binding<TabDropLifecycle>
+    ) -> Bool {
         #if DEBUG
         NSLog("[Bonsplit Drag] performDrop called, targetIndex: \(targetIndex)")
         #endif
@@ -1009,7 +1257,15 @@ struct TabDropDelegate: DropDelegate {
         // callbacks off-main, and SplitViewController is @MainActor.
         if !Thread.isMainThread {
             return DispatchQueue.main.sync {
-                performDrop(info: info)
+                performDrop(
+                    targetIndex: targetIndex,
+                    pasteboard: pasteboard,
+                    pane: pane,
+                    bonsplitController: bonsplitController,
+                    controller: controller,
+                    dropTargetIndex: dropTargetIndex,
+                    dropLifecycle: dropLifecycle
+                )
             }
         }
 
@@ -1017,7 +1273,7 @@ struct TabDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            guard let transfer = decodeTransfer(from: info),
+            guard let transfer = decodeTransfer(from: pasteboard),
                   transfer.isFromCurrentProcess else {
                 return false
             }
@@ -1028,8 +1284,7 @@ struct TabDropDelegate: DropDelegate {
             )
             let handled = bonsplitController.onExternalTabDrop?(request) ?? false
             if handled {
-                dropLifecycle = .idle
-                dropTargetIndex = nil
+                clearDropState(dropTargetIndex: dropTargetIndex, dropLifecycle: dropLifecycle)
             }
             return handled
         }
@@ -1060,8 +1315,7 @@ struct TabDropDelegate: DropDelegate {
         // Clear visual state immediately to prevent lingering indicators.
         // Must happen synchronously before returning, not in async callback.
         // Setting dropLifecycle to idle prevents dropUpdated from re-setting dropTargetIndex.
-        dropLifecycle = .idle
-        dropTargetIndex = nil
+        clearDropState(dropTargetIndex: dropTargetIndex, dropLifecycle: dropLifecycle)
         controller.draggingTab = nil
         controller.dragSourcePaneId = nil
         controller.activeDragTab = nil
@@ -1080,12 +1334,13 @@ struct TabDropDelegate: DropDelegate {
             "hasActive=\(controller.activeDragTab != nil ? 1 : 0)"
         )
         #endif
-        dropLifecycle = .hovering
-        if shouldSuppressIndicatorForNoopSamePaneDrop(targetIndex: targetIndex) {
-            dropTargetIndex = nil
-        } else {
-            dropTargetIndex = targetIndex
-        }
+        Self.updateDropState(
+            targetIndex: targetIndex,
+            pane: pane,
+            controller: controller,
+            dropTargetIndex: $dropTargetIndex,
+            dropLifecycle: $dropLifecycle
+        )
     }
 
     func dropExited(info: DropInfo) {
@@ -1094,10 +1349,7 @@ struct TabDropDelegate: DropDelegate {
         NSLog("[Bonsplit Drag] dropExited from index: \(targetIndex)")
         dlog("tab.dropExited pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex)")
         #endif
-        dropLifecycle = .idle
-        if dropTargetIndex == targetIndex {
-            dropTargetIndex = nil
-        }
+        Self.clearDropState(dropTargetIndex: $dropTargetIndex, dropLifecycle: $dropLifecycle)
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
@@ -1110,14 +1362,13 @@ struct TabDropDelegate: DropDelegate {
 #endif
             return DropProposal(operation: .move)
         }
-        // Only update if this is the active target, and suppress same-pane no-op indicators.
-        if shouldSuppressIndicatorForNoopSamePaneDrop(targetIndex: targetIndex) {
-            if dropTargetIndex == targetIndex {
-                dropTargetIndex = nil
-            }
-        } else if dropTargetIndex != targetIndex {
-            dropTargetIndex = targetIndex
-        }
+        Self.updateDropState(
+            targetIndex: targetIndex,
+            pane: pane,
+            controller: controller,
+            dropTargetIndex: $dropTargetIndex,
+            dropLifecycle: $dropLifecycle
+        )
 #if DEBUG
         dlog(
             "tab.dropUpdated pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex) " +
@@ -1128,41 +1379,62 @@ struct TabDropDelegate: DropDelegate {
     }
 
     func validateDrop(info: DropInfo) -> Bool {
-        // Reject drops on inactive workspaces whose views are kept alive in a ZStack.
-        guard controller.isInteractive else {
-#if DEBUG
-            dlog("tab.validateDrop pane=\(pane.id.id.uuidString.prefix(5)) allowed=0 reason=inactive")
-#endif
-            return false
-        }
-        // The custom UTType alone is sufficient — only Bonsplit tab drags produce it.
-        // Do NOT gate on draggingTab != nil: @Observable changes from createItemProvider
-        // may not have propagated to the drop delegate yet, causing false rejections.
-        let hasType = info.hasItemsConforming(to: [.tabTransfer])
-        guard hasType else { return false }
+        Self.validateDrop(pasteboard: NSPasteboard(name: .drag), controller: controller)
+    }
 
-        // Local drags use in-memory state and are always same-process.
+    fileprivate static func validateDrop(
+        pasteboard: NSPasteboard,
+        controller: SplitViewController
+    ) -> Bool {
+        guard controller.isInteractive else { return false }
+
+        let type = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+        guard pasteboard.availableType(from: [type]) != nil else { return false }
+
         if controller.activeDragTab != nil || controller.draggingTab != nil {
             return true
         }
 
-        // External drags (another Bonsplit controller) must include a payload from this process.
-        guard let transfer = decodeTransfer(from: info),
+        guard let transfer = decodeTransfer(from: pasteboard),
               transfer.isFromCurrentProcess else {
             return false
         }
-#if DEBUG
-        let hasDrag = controller.draggingTab != nil
-        let hasActive = controller.activeDragTab != nil
-        dlog(
-            "tab.validateDrop pane=\(pane.id.id.uuidString.prefix(5)) " +
-            "allowed=\(hasType ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
-        )
-#endif
+
         return true
     }
 
-    private func shouldSuppressIndicatorForNoopSamePaneDrop(targetIndex: Int) -> Bool {
+    fileprivate static func clearDropState(
+        dropTargetIndex: Binding<Int?>,
+        dropLifecycle: Binding<TabDropLifecycle>
+    ) {
+        dropLifecycle.wrappedValue = .idle
+        dropTargetIndex.wrappedValue = nil
+    }
+
+    fileprivate static func updateDropState(
+        targetIndex: Int,
+        pane: PaneState,
+        controller: SplitViewController,
+        dropTargetIndex: Binding<Int?>,
+        dropLifecycle: Binding<TabDropLifecycle>
+    ) {
+        dropLifecycle.wrappedValue = .hovering
+        if shouldSuppressIndicatorForNoopSamePaneDrop(
+            targetIndex: targetIndex,
+            pane: pane,
+            controller: controller
+        ) {
+            dropTargetIndex.wrappedValue = nil
+        } else if dropTargetIndex.wrappedValue != targetIndex {
+            dropTargetIndex.wrappedValue = targetIndex
+        }
+    }
+
+    fileprivate static func shouldSuppressIndicatorForNoopSamePaneDrop(
+        targetIndex: Int,
+        pane: PaneState,
+        controller: SplitViewController
+    ) -> Bool {
         guard let draggedTab = controller.draggingTab,
               controller.dragSourcePaneId == pane.id,
               let sourceIndex = pane.tabs.firstIndex(where: { $0.id == draggedTab.id }) else {
@@ -1173,7 +1445,7 @@ struct TabDropDelegate: DropDelegate {
         return targetIndex == sourceIndex || targetIndex == sourceIndex + 1
     }
 
-    private func decodeTransfer(from string: String) -> TabTransferData? {
+    private static func decodeTransfer(from string: String) -> TabTransferData? {
         guard let data = string.data(using: .utf8),
               let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) else {
             return nil
@@ -1181,8 +1453,7 @@ struct TabDropDelegate: DropDelegate {
         return transfer
     }
 
-    private func decodeTransfer(from info: DropInfo) -> TabTransferData? {
-        let pasteboard = NSPasteboard(name: .drag)
+    private static func decodeTransfer(from pasteboard: NSPasteboard) -> TabTransferData? {
         let type = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
         if let data = pasteboard.data(forType: type),
            let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -30,7 +30,7 @@ func tabBarLeadingTrafficLightInset(
     tabBarMinXInWindow: CGFloat,
     trailingPadding: CGFloat = 14
 ) -> CGFloat {
-    max(0, trafficLightMaxX + trailingPadding)
+    max(0, trafficLightMaxX + trailingPadding - tabBarMinXInWindow)
 }
 
 final class TabBarLeadingInsetPassthroughView: NSView {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -73,7 +73,7 @@ struct TabBarView: View {
     @State private var contentWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
-    @State private var isHoveringTabBar = false
+    @State private var isHoveringSplitButtonsArea = false
     @StateObject private var controlKeyMonitor = TabControlShortcutKeyMonitor()
     @AppStorage("paneTabBarControlsVisibilityMode")
     private var controlsVisibilityModeRawValue = TabBarControlsVisibilityMode.always.rawValue
@@ -114,7 +114,7 @@ struct TabBarView: View {
         case .always:
             return true
         case .onHover:
-            return isHoveringTabBar
+            return isHoveringSplitButtonsArea
         }
     }
 
@@ -196,16 +196,7 @@ struct TabBarView: View {
 
             // Split buttons
             if showSplitButtons {
-                splitButtons
-                    .saturation(tabBarSaturation)
-                    .opacity(shouldShowSplitButtonsNow ? 1 : 0)
-                    .allowsHitTesting(shouldShowSplitButtonsNow)
-                    .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: shouldShowSplitButtonsNow)
-                    .background {
-                        if !shouldShowSplitButtonsNow && shouldUseTabBarDragRegion && !isTabDragActive {
-                            TabBarWindowDragRegion()
-                        }
-                    }
+                splitButtonsArea
             }
         }
         .frame(height: TabBarMetrics.barHeight)
@@ -240,9 +231,6 @@ struct TabBarView: View {
         }
         .onDisappear {
             controlKeyMonitor.stop()
-        }
-        .onHover { hovering in
-            isHoveringTabBar = hovering
         }
     }
 
@@ -493,6 +481,27 @@ struct TabBarView: View {
     // MARK: - Split Buttons
 
     @ViewBuilder
+    private var splitButtonsArea: some View {
+        ZStack(alignment: .trailing) {
+            if !shouldShowSplitButtonsNow && shouldUseTabBarDragRegion && !isTabDragActive {
+                TabBarWindowDragRegion()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            splitButtons
+                .saturation(tabBarSaturation)
+                .opacity(shouldShowSplitButtonsNow ? 1 : 0)
+                .allowsHitTesting(shouldShowSplitButtonsNow)
+                .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: shouldShowSplitButtonsNow)
+        }
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isHoveringSplitButtonsArea = hovering
+        }
+        .accessibilityIdentifier("paneTabBarControlsRegion")
+    }
+
+    @ViewBuilder
     private var splitButtons: some View {
         let tooltips = controller.configuration.appearance.splitButtonTooltips
         HStack(spacing: 4) {
@@ -503,6 +512,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
+            .accessibilityIdentifier("paneTabBarControl.newTerminal")
             .safeHelp(tooltips.newTerminal)
 
             Button {
@@ -512,6 +522,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
+            .accessibilityIdentifier("paneTabBarControl.newBrowser")
             .safeHelp(tooltips.newBrowser)
 
             Button {
@@ -522,6 +533,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
+            .accessibilityIdentifier("paneTabBarControl.splitRight")
             .safeHelp(tooltips.splitRight)
 
             Button {
@@ -532,6 +544,7 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
+            .accessibilityIdentifier("paneTabBarControl.splitDown")
             .safeHelp(tooltips.splitDown)
         }
         .padding(.trailing, 8)

--- a/Sources/Bonsplit/Internal/Views/TabBarWindowDragRegion.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarWindowDragRegion.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+private func performTabBarStandardDoubleClick(window: NSWindow?) -> Bool {
+    guard let window else { return false }
+
+    let globalDefaults = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain) ?? [:]
+    if let action = (globalDefaults["AppleActionOnDoubleClick"] as? String)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased() {
+        switch action {
+        case "minimize":
+            window.miniaturize(nil)
+            return true
+        case "none":
+            return false
+        case "maximize", "zoom":
+            window.zoom(nil)
+            return true
+        default:
+            break
+        }
+    }
+
+    if let miniaturizeOnDoubleClick = globalDefaults["AppleMiniaturizeOnDoubleClick"] as? Bool,
+       miniaturizeOnDoubleClick {
+        window.miniaturize(nil)
+        return true
+    }
+
+    window.zoom(nil)
+    return true
+}
+
+struct TabBarWindowDragRegion: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        DraggableView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    private final class DraggableView: NSView {
+        override var mouseDownCanMoveWindow: Bool { false }
+
+        override func mouseDown(with event: NSEvent) {
+            if event.clickCount >= 2, performTabBarStandardDoubleClick(window: window) {
+                return
+            }
+
+            guard let window else {
+                super.mouseDown(with: event)
+                return
+            }
+
+            let previousMovableState = window.isMovable
+            if !previousMovableState {
+                window.isMovable = true
+            }
+            defer {
+                if window.isMovable != previousMovableState {
+                    window.isMovable = previousMovableState
+                }
+            }
+
+            window.performDrag(with: event)
+        }
+    }
+}

--- a/Sources/Bonsplit/Internal/Views/TabBarWindowDragRegion.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarWindowDragRegion.swift
@@ -34,35 +34,35 @@ private func performTabBarStandardDoubleClick(window: NSWindow?) -> Bool {
 
 struct TabBarWindowDragRegion: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
-        DraggableView()
+        TabBarWindowDragRegionView()
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {}
+}
 
-    private final class DraggableView: NSView {
-        override var mouseDownCanMoveWindow: Bool { false }
+final class TabBarWindowDragRegionView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
 
-        override func mouseDown(with event: NSEvent) {
-            if event.clickCount >= 2, performTabBarStandardDoubleClick(window: window) {
-                return
-            }
-
-            guard let window else {
-                super.mouseDown(with: event)
-                return
-            }
-
-            let previousMovableState = window.isMovable
-            if !previousMovableState {
-                window.isMovable = true
-            }
-            defer {
-                if window.isMovable != previousMovableState {
-                    window.isMovable = previousMovableState
-                }
-            }
-
-            window.performDrag(with: event)
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount >= 2, performTabBarStandardDoubleClick(window: window) {
+            return
         }
+
+        guard let window else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        let previousMovableState = window.isMovable
+        if !previousMovableState {
+            window.isMovable = true
+        }
+        defer {
+            if window.isMovable != previousMovableState {
+                window.isMovable = previousMovableState
+            }
+        }
+
+        window.performDrag(with: event)
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -4,6 +4,36 @@ import AppKit
 import SwiftUI
 
 final class BonsplitTests: XCTestCase {
+    func testTabBarLeadingTrafficLightInsetKeepsFullClearanceWhenTabBarStartsAtWindowEdge() {
+        XCTAssertEqual(
+            tabBarLeadingTrafficLightInset(
+                trafficLightMaxX: 64,
+                tabBarMinXInWindow: 0
+            ),
+            78
+        )
+    }
+
+    func testTabBarLeadingTrafficLightInsetDropsToZeroWhenTabBarStartsRightOfTrafficLights() {
+        XCTAssertEqual(
+            tabBarLeadingTrafficLightInset(
+                trafficLightMaxX: 64,
+                tabBarMinXInWindow: 220
+            ),
+            0
+        )
+    }
+
+    func testTabBarLeadingTrafficLightInsetKeepsOnlyRemainingOverlapClearance() {
+        XCTAssertEqual(
+            tabBarLeadingTrafficLightInset(
+                trafficLightMaxX: 64,
+                tabBarMinXInWindow: 40
+            ),
+            38
+        )
+    }
+
     @MainActor
     private final class LayoutProbeView: NSView {
         private(set) var sizeChangeCount = 0


### PR DESCRIPTION
## Summary
- add a hover-only visibility mode for pane tab bar split controls
- turn hidden split-control space into a window drag region when the host app hides its workspace titlebar

## Testing
- Built via the parent `cmux` tagged reload using this submodule branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hover-only pane tab bar controls and full-width tab drop capture. When the workspace titlebar is hidden, empty tab‑bar areas become a draggable region that honors double‑clicks and the macOS traffic‑light inset without breaking tab drags.

- **New Features**
  - Controls visibility mode: always or on-hover (`@AppStorage` `paneTabBarControlsVisibilityMode`).
  - Controls appear on hover; fade in/out and ignore hits when hidden.
  - When hidden and `workspaceTitlebarVisible` is false, a `TabBarWindowDragRegion` sits behind the controls and trailing space; it is disabled during tab drags; honors system double‑click actions.
  - Added accessibility IDs: `paneTabBar`, `paneTabBarControlsRegion`, and each split button.

- **Bug Fixes**
  - Captures tab drops across the full tab bar (including trailing space) with smarter target index resolution; fixes hidden‑titlebar drops and prevents lingering indicators.
  - Respects the macOS traffic‑light button inset when the titlebar is hidden, and skips it when the tab bar starts right of the buttons; added tests for edge cases.
  - Removed the pane titlebar safe-area inset to prevent layout shifts and accidental drag regions.
  - Disabled window dragging for pane hosts and wrapped the tab bar in a non‑movable host; kept tab‑bar hit‑testing inside the Bonsplit host to avoid pass-through and accidental window moves.

<sup>Written for commit f98559deca1738b35d2f3841b220e2e6befecbb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab bar controls can be set to always visible or show-on-hover.
  * Hover-sensitive split-button area with animated visibility and hit-testing.
  * Option to show the workspace title bar.

* **Improvements**
  * Enhanced drag regions for tabs and window dragging for more reliable drag behavior.
  * Refined double-click handling for window minimize/zoom actions.
  * Accessibility identifiers added for terminal, browser, and split controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->