### PR TITLE
Add animate parameter to splitPane to skip entry animation

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -181,14 +181,15 @@ final class SplitViewController {
     }
 
     /// Split a pane with a specific tab, optionally inserting the new pane first
-    func splitPaneWithTab(_ paneId: PaneID, orientation: SplitOrientation, tab: TabItem, insertFirst: Bool) {
+    func splitPaneWithTab(_ paneId: PaneID, orientation: SplitOrientation, tab: TabItem, insertFirst: Bool, animate: Bool = true) {
         clearPaneZoom()
         rootNode = splitNodeWithTabRecursively(
             node: rootNode,
             targetPaneId: paneId,
             orientation: orientation,
             tab: tab,
-            insertFirst: insertFirst
+            insertFirst: insertFirst,
+            animate: animate
         )
     }
 
@@ -197,7 +198,8 @@ final class SplitViewController {
         targetPaneId: PaneID,
         orientation: SplitOrientation,
         tab: TabItem,
-        insertFirst: Bool
+        insertFirst: Bool,
+        animate: Bool
     ) -> SplitNode {
         switch node {
         case .pane(let paneState):
@@ -214,7 +216,7 @@ final class SplitViewController {
                         first: .pane(newPane),
                         second: .pane(paneState),
                         dividerPosition: 0.5,
-                        animationOrigin: .fromFirst
+                        animationOrigin: animate ? .fromFirst : nil
                     )
                 } else {
                     // New pane goes second (right or bottom).
@@ -223,7 +225,7 @@ final class SplitViewController {
                         first: .pane(paneState),
                         second: .pane(newPane),
                         dividerPosition: 0.5,
-                        animationOrigin: .fromSecond
+                        animationOrigin: animate ? .fromSecond : nil
                     )
                 }
 
@@ -240,14 +242,16 @@ final class SplitViewController {
                 targetPaneId: targetPaneId,
                 orientation: orientation,
                 tab: tab,
-                insertFirst: insertFirst
+                insertFirst: insertFirst,
+                animate: animate
             )
             splitState.second = splitNodeWithTabRecursively(
                 node: splitState.second,
                 targetPaneId: targetPaneId,
                 orientation: orientation,
                 tab: tab,
-                insertFirst: insertFirst
+                insertFirst: insertFirst,
+                animate: animate
             )
             return .split(splitState)
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -249,6 +249,7 @@ struct TabBarView: View {
                 dlog("tab.close pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5)) title=\"\(tab.title)\"")
 #endif
                 withTransaction(Transaction(animation: nil)) {
+                    controller.onTabCloseRequest?(TabID(id: tab.id), pane.id)
                     _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
             },

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -51,6 +51,10 @@ public final class BonsplitController {
     /// Return `true` when the drop has been handled by the host application.
     @ObservationIgnored public var onExternalTabDrop: ((ExternalTabDropRequest) -> Bool)?
 
+    /// Called when the user explicitly requests to close a tab from the tab strip UI.
+    /// Internal host-driven closes should not use this hook.
+    @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Void)?
+
     // MARK: - Internal State
 
     internal var internalController: SplitViewController

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -420,7 +420,8 @@ public final class BonsplitController {
         _ paneId: PaneID? = nil,
         orientation: SplitOrientation,
         withTab tab: Tab,
-        insertFirst: Bool
+        insertFirst: Bool,
+        animate: Bool = true
     ) -> PaneID? {
         guard configuration.allowSplits else { return nil }
 
@@ -450,7 +451,8 @@ public final class BonsplitController {
             PaneID(id: targetPaneId.id),
             orientation: orientation,
             tab: internalTab,
-            insertFirst: insertFirst
+            insertFirst: insertFirst,
+            animate: animate
         )
 
         let newPaneId = focusedPaneId!

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -414,6 +414,7 @@ public final class BonsplitController {
     ///   - orientation: Direction to split (horizontal = side-by-side, vertical = stacked).
     ///   - tab: The tab to add to the new pane.
     ///   - insertFirst: If true, insert the new pane first (left/top). Otherwise insert second (right/bottom).
+    ///   - animate: If true (default), the new pane slides in with an entry animation. Pass false to skip animation (e.g. during session restore).
     /// - Returns: The new pane ID, or nil if vetoed by delegate.
     @discardableResult
     public func splitPane(


### PR DESCRIPTION
Companion to manaflow-ai/cmux#1433 — fixes manaflow-ai/cmux#1376

## Summary
- add `animate: Bool = true` parameter to `splitPane(_:orientation:withTab:insertFirst:)` and its internal implementation
- when `false`, `SplitState` is created with `animationOrigin: nil` so the entry animation is skipped
- default behavior unchanged for all existing callers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Splitting panes with tabs now includes optional animation control—panes can slide in smoothly (default) or appear instantly.
  * Added callback handler for tab closure requests, enabling custom logic when users close tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->