### PR TITLE
feat: double-click pane tab to toggle zoom

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -249,6 +249,7 @@ struct TabBarView: View {
                 dlog("tab.close pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5)) title=\"\(tab.title)\"")
 #endif
                 withTransaction(Transaction(animation: nil)) {
+                    controller.onTabCloseRequest?(TabID(id: tab.id), pane.id)
                     _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
             },

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -181,6 +181,9 @@ struct TabItemView: View {
             guard !tab.isPinned else { return }
             onClose()
         }))
+        .onTapGesture(count: 2) {
+            onZoomToggle()
+        }
         .onTapGesture {
             onSelect()
         }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -51,6 +51,10 @@ public final class BonsplitController {
     /// Return `true` when the drop has been handled by the host application.
     @ObservationIgnored public var onExternalTabDrop: ((ExternalTabDropRequest) -> Bool)?
 
+    /// Called when the user explicitly requests to close a tab from the tab strip UI.
+    /// Internal host-driven closes should not use this hook.
+    @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Void)?
+
     // MARK: - Internal State
 
     internal var internalController: SplitViewController


### PR DESCRIPTION
## Summary
- Adds a double-tap gesture on `TabItemView` that calls the existing `onZoomToggle()` callback
- Double-clicking a tab title in the pane tab bar toggles pane zoom (maximizes/restores that pane within the split layout)
- 3-line addition — `.onTapGesture(count: 2)` placed before the existing single-tap handler

**Parent cmux PR:** https://github.com/manaflow-ai/cmux/pull/1422

## Test plan
- [ ] Open a workspace with multiple splits
- [ ] Double-click a tab title → pane should zoom to fill the content area
- [ ] Double-click again → splits should restore
- [ ] Single-click still selects tabs
- [ ] Middle-click still closes tabs
- [ ] Right-click context menu still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double-clicking a pane tab now toggles zoom to quickly maximize/restore a split. Added a host callback to detect user-initiated tab closes.

- **New Features**
  - Double-click a tab title to toggle pane zoom within the split layout.
  - New `onTabCloseRequest` in `BonsplitController` fires when a user closes a tab from the tab strip, allowing hosts to handle workspace-close logic.

<sup>Written for commit ad798c5545155ca23b23b430ded65a0af8b23d93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double-tap on tabs to toggle zoom functionality.
  * Added a new callback hook to intercept and respond to tab close requests, enabling custom close-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->