### PR TITLE
Fix translucent split wrapper layers

### DIFF
--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -163,10 +163,6 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
         controller.focusedPaneId == pane.id
     }
 
-    private var appearance: BonsplitConfiguration.Appearance {
-        bonsplitController.configuration.appearance
-    }
-
     private var isTabDragActive: Bool {
         controller.draggingTab != nil || controller.activeDragTab != nil
     }
@@ -184,7 +180,6 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
             contentAreaWithDropZones
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(TabBarColors.paneBackground(for: appearance))
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
         .onChange(of: controller.draggingTab) { _, newValue in
 #if DEBUG

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -9,6 +9,8 @@ private class ThemedSplitView: NSSplitView {
     override var dividerColor: NSColor {
         customDividerColor ?? super.dividerColor
     }
+
+    override var isOpaque: Bool { false }
 }
 
 #if DEBUG
@@ -96,17 +98,6 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         )
     }
 
-    private var chromeBackgroundColor: NSColor {
-        TabBarColors.nsColorPaneBackground(for: appearance)
-    }
-
-    private var wrapperContainerBackgroundColor: NSColor {
-        // PaneContainerView already paints the pane chrome. Leaving the split-only wrapper
-        // containers translucent as well stacks alpha and makes transparent themes look opaque
-        // as soon as a workspace becomes a real NSSplitView.
-        chromeBackgroundColor.alphaComponent < 0.999 ? .clear : chromeBackgroundColor
-    }
-
     func makeNSView(context: Context) -> NSSplitView {
 #if DEBUG
         let splitView: ThemedSplitView = {
@@ -121,17 +112,16 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.isVertical = splitState.orientation == .horizontal
         splitView.dividerStyle = .thin
         splitView.delegate = context.coordinator
-        // Bonsplit is often embedded in transparent/vibrant window backgrounds. Ensure the
-        // split view itself is not fully transparent so divider regions don't "show through"
-        // to whatever is behind the split hierarchy.
         splitView.wantsLayer = true
-        splitView.layer?.backgroundColor = chromeBackgroundColor.cgColor
+        splitView.layer?.backgroundColor = NSColor.clear.cgColor
+        splitView.layer?.isOpaque = false
 
         // Keep arranged subviews stable (always 2) to avoid transient "collapse" flashes when
         // replacing pane<->split content. We swap the hosted content within these containers.
         let firstContainer = NSView()
         firstContainer.wantsLayer = true
-        firstContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
+        firstContainer.layer?.backgroundColor = NSColor.clear.cgColor
+        firstContainer.layer?.isOpaque = false
         firstContainer.layer?.masksToBounds = true
         let firstController = makeHostingController(for: splitState.first)
         installHostingController(firstController, into: firstContainer)
@@ -140,7 +130,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
         let secondContainer = NSView()
         secondContainer.wantsLayer = true
-        secondContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
+        secondContainer.layer?.backgroundColor = NSColor.clear.cgColor
+        secondContainer.layer?.isOpaque = false
         secondContainer.layer?.masksToBounds = true
         let secondController = makeHostingController(for: splitState.second)
         installHostingController(secondController, into: secondContainer)
@@ -315,7 +306,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // view-hierarchy-based NSDraggingDestination routing.
         splitView.isHidden = !controller.isInteractive
         splitView.wantsLayer = true
-        splitView.layer?.backgroundColor = chromeBackgroundColor.cgColor
+        splitView.layer?.backgroundColor = NSColor.clear.cgColor
+        splitView.layer?.isOpaque = false
         (splitView as? ThemedSplitView)?.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
 
         // Update orientation if changed
@@ -333,9 +325,11 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             let firstContainer = arranged[0]
             let secondContainer = arranged[1]
             firstContainer.wantsLayer = true
-            firstContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
+            firstContainer.layer?.backgroundColor = NSColor.clear.cgColor
+            firstContainer.layer?.isOpaque = false
             secondContainer.wantsLayer = true
-            secondContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
+            secondContainer.layer?.backgroundColor = NSColor.clear.cgColor
+            secondContainer.layer?.isOpaque = false
 
             updateHostedContent(
                 in: firstContainer,

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -100,6 +100,13 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         TabBarColors.nsColorPaneBackground(for: appearance)
     }
 
+    private var wrapperContainerBackgroundColor: NSColor {
+        // PaneContainerView already paints the pane chrome. Leaving the split-only wrapper
+        // containers translucent as well stacks alpha and makes transparent themes look opaque
+        // as soon as a workspace becomes a real NSSplitView.
+        chromeBackgroundColor.alphaComponent < 0.999 ? .clear : chromeBackgroundColor
+    }
+
     func makeNSView(context: Context) -> NSSplitView {
 #if DEBUG
         let splitView: ThemedSplitView = {
@@ -124,7 +131,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // replacing pane<->split content. We swap the hosted content within these containers.
         let firstContainer = NSView()
         firstContainer.wantsLayer = true
-        firstContainer.layer?.backgroundColor = chromeBackgroundColor.cgColor
+        firstContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
         firstContainer.layer?.masksToBounds = true
         let firstController = makeHostingController(for: splitState.first)
         installHostingController(firstController, into: firstContainer)
@@ -133,7 +140,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
         let secondContainer = NSView()
         secondContainer.wantsLayer = true
-        secondContainer.layer?.backgroundColor = chromeBackgroundColor.cgColor
+        secondContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
         secondContainer.layer?.masksToBounds = true
         let secondController = makeHostingController(for: splitState.second)
         installHostingController(secondController, into: secondContainer)
@@ -326,9 +333,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             let firstContainer = arranged[0]
             let secondContainer = arranged[1]
             firstContainer.wantsLayer = true
-            firstContainer.layer?.backgroundColor = chromeBackgroundColor.cgColor
+            firstContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
             secondContainer.wantsLayer = true
-            secondContainer.layer?.backgroundColor = chromeBackgroundColor.cgColor
+            secondContainer.layer?.backgroundColor = wrapperContainerBackgroundColor.cgColor
 
             updateHostedContent(
                 in: firstContainer,

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -45,7 +45,9 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
 }
 
 /// Container NSView for a pane inside SinglePaneWrapper.
-class PaneDragContainerView: NSView {}
+class PaneDragContainerView: NSView {
+    override var isOpaque: Bool { false }
+}
 
 /// Wrapper that uses NSHostingController for proper AppKit layout constraints
 struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable {
@@ -71,6 +73,8 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
 
         let containerView = PaneDragContainerView()
         containerView.wantsLayer = true
+        containerView.layer?.backgroundColor = NSColor.clear.cgColor
+        containerView.layer?.isOpaque = false
         containerView.layer?.masksToBounds = true
         containerView.addSubview(hostingController.view)
 
@@ -92,6 +96,8 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
         // drag sessions to views belonging to background workspaces.
         nsView.isHidden = !controller.isInteractive
         nsView.wantsLayer = true
+        nsView.layer?.backgroundColor = NSColor.clear.cgColor
+        nsView.layer?.isOpaque = false
         nsView.layer?.masksToBounds = true
 
         let paneView = PaneContainerView(

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -17,6 +17,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
         GeometryReader { geometry in
             splitNodeContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(TabBarColors.paneBackground(for: appearance))
                 .focusable()
                 .focusEffectDisabled()
                 .onChange(of: geometry.size) { _, newSize in

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -249,6 +249,7 @@ struct TabBarView: View {
                 dlog("tab.close pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5)) title=\"\(tab.title)\"")
 #endif
                 withTransaction(Transaction(animation: nil)) {
+                    controller.onTabCloseRequest?(TabID(id: tab.id), pane.id)
                     _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
             },

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -51,6 +51,10 @@ public final class BonsplitController {
     /// Return `true` when the drop has been handled by the host application.
     @ObservationIgnored public var onExternalTabDrop: ((ExternalTabDropRequest) -> Bool)?
 
+    /// Called when the user explicitly requests to close a tab from the tab strip UI.
+    /// Internal host-driven closes should not use this hook.
+    @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Void)?
+
     // MARK: - Internal State
 
     internal var internalController: SplitViewController

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -730,6 +730,78 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testTranslucentSplitContainersStayClear() {
+        let appearance = BonsplitConfiguration.Appearance(
+            enableAnimations: false,
+            chromeColors: .init(backgroundHex: "#11223380")
+        )
+        let configuration = BonsplitConfiguration(appearance: appearance)
+        let controller = BonsplitController(configuration: configuration)
+        _ = controller.createTab(title: "Base")
+        guard let sourcePane = controller.focusedPaneId else {
+            XCTFail("Expected focused pane")
+            return
+        }
+        guard controller.splitPane(sourcePane, orientation: .horizontal) != nil else {
+            XCTFail("Expected splitPane to create a new pane")
+            return
+        }
+
+        let hostingView = NSHostingView(
+            rootView: BonsplitView(controller: controller) { _, _ in
+                Color.clear
+            } emptyPane: { _ in
+                Color.clear
+            }
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        guard let splitView = firstDescendant(ofType: NSSplitView.self, in: hostingView) else {
+            XCTFail("Expected split view")
+            return
+        }
+        XCTAssertEqual(splitView.arrangedSubviews.count, 2)
+
+        let dividerBackground = splitView.layer?.backgroundColor.flatMap(NSColor.init(cgColor:))
+        XCTAssertNotNil(dividerBackground, "Expected split view to keep its divider background")
+        XCTAssertEqual(
+            dividerBackground?.alphaComponent ?? 0,
+            CGFloat(128.0 / 255.0),
+            accuracy: 0.01
+        )
+
+        for container in splitView.arrangedSubviews {
+            let background = container.layer?.backgroundColor.flatMap(NSColor.init(cgColor:))
+            XCTAssertNotNil(background, "Expected arranged subview to be layer-backed")
+            XCTAssertEqual(
+                background?.alphaComponent ?? -1,
+                0,
+                accuracy: 0.001,
+                "Split-only wrapper containers should stay clear so translucent pane chrome is not composited twice"
+            )
+        }
+    }
+
     private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {
         let suiteName = "BonsplitShortcutHintPolicyTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -740,5 +812,17 @@ final class BonsplitTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         body(defaults)
         defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func firstDescendant<T: NSView>(ofType type: T.Type, in root: NSView) -> T? {
+        if let match = root as? T {
+            return match
+        }
+        for subview in root.subviews {
+            if let match = firstDescendant(ofType: type, in: subview) {
+                return match
+            }
+        }
+        return nil
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -731,7 +731,7 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testTranslucentSplitContainersStayClear() {
+    func testTranslucentSplitWrappersStayClear() {
         let appearance = BonsplitConfiguration.Appearance(
             enableAnimations: false,
             chromeColors: .init(backgroundHex: "#11223380")
@@ -783,11 +783,12 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(splitView.arrangedSubviews.count, 2)
 
         let dividerBackground = splitView.layer?.backgroundColor.flatMap(NSColor.init(cgColor:))
-        XCTAssertNotNil(dividerBackground, "Expected split view to keep its divider background")
+        XCTAssertNotNil(dividerBackground, "Expected split view to be layer-backed")
         XCTAssertEqual(
             dividerBackground?.alphaComponent ?? 0,
-            CGFloat(128.0 / 255.0),
-            accuracy: 0.01
+            0,
+            accuracy: 0.001,
+            "Split root should stay clear so translucent pane chrome is painted only once"
         )
 
         for container in splitView.arrangedSubviews {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -802,6 +802,63 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testSplitContentAlphaMatchesSinglePane() {
+        let appearance = BonsplitConfiguration.Appearance(
+            enableAnimations: false,
+            chromeColors: .init(backgroundHex: "#11223380")
+        )
+        let expectedAlpha = CGFloat(128.0 / 255.0)
+        let samplePoint = NSPoint(x: 100, y: 100)
+
+        let singlePaneController = BonsplitController(
+            configuration: BonsplitConfiguration(appearance: appearance)
+        )
+        _ = singlePaneController.createTab(title: "Base")
+
+        guard let singlePaneAlpha = renderedAlpha(
+            for: singlePaneController,
+            samplePoint: samplePoint
+        ) else {
+            XCTFail("Expected single-pane rendered alpha")
+            return
+        }
+        XCTAssertEqual(
+            singlePaneAlpha,
+            expectedAlpha,
+            accuracy: 0.03,
+            "Single-pane content should preserve the configured translucent alpha"
+        )
+
+        let splitController = BonsplitController(
+            configuration: BonsplitConfiguration(appearance: appearance)
+        )
+        _ = splitController.createTab(title: "Base")
+        guard let sourcePane = splitController.focusedPaneId else {
+            XCTFail("Expected focused pane")
+            return
+        }
+        guard splitController.splitPane(sourcePane, orientation: .horizontal) != nil else {
+            XCTFail("Expected splitPane to create a new pane")
+            return
+        }
+
+        guard let splitAlpha = renderedAlpha(
+            for: splitController,
+            samplePoint: samplePoint
+        ) else {
+            XCTFail("Expected split rendered alpha")
+            return
+        }
+
+        XCTAssertEqual(
+            splitAlpha,
+            singlePaneAlpha,
+            accuracy: 0.03,
+            "Split mode should render the same content alpha as single-pane mode"
+        )
+    }
+
     private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {
         let suiteName = "BonsplitShortcutHintPolicyTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -824,5 +881,59 @@ final class BonsplitTests: XCTestCase {
             }
         }
         return nil
+    }
+
+    @MainActor
+    private func renderedAlpha(
+        for controller: BonsplitController,
+        samplePoint: NSPoint,
+        size: NSSize = NSSize(width: 800, height: 600)
+    ) -> CGFloat? {
+        let hostingView = NSHostingView(
+            rootView: BonsplitView(controller: controller) { _, _ in
+                Color.clear
+            } emptyPane: { _ in
+                Color.clear
+            }
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else { return nil }
+
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        return renderedColor(in: hostingView, at: samplePoint)?.alphaComponent
+    }
+
+    @MainActor
+    private func renderedColor(in view: NSView, at point: NSPoint) -> NSColor? {
+        let integralBounds = view.bounds.integral
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: integralBounds) else { return nil }
+        bitmap.size = integralBounds.size
+        view.cacheDisplay(in: integralBounds, to: bitmap)
+
+        let x = Int(point.x.rounded())
+        let y = Int(point.y.rounded())
+        guard x >= 0,
+              y >= 0,
+              x < bitmap.pixelsWide,
+              y < bitmap.pixelsHigh else { return nil }
+        return bitmap.colorAt(x: x, y: y)
     }
 }


### PR DESCRIPTION
## Summary
- add a runtime regression test for translucent split wrapper layers
- keep split-only wrapper containers clear so translucent pane chrome is not composited twice

## Testing
- not run locally (repo policy)

## Issues
- Related: plain-text task "transparency disappears when i make a split (ie cmd+d)"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix translucent themes turning opaque after splitting by keeping split root and wrapper layers clear and moving background painting to the root. Adds a callback for user‑initiated tab closes.

- **Bug Fixes**
  - Keep split root and wrapper containers clear and non-opaque; move pane background to `SplitViewContainer` to avoid alpha stacking and preserve translucency.
  - Maintain divider tint and add tests ensuring wrappers stay clear and split rendered alpha matches single‑pane.
  - Addresses Linear: transparency disappears when making a split (cmd+d).

- **New Features**
  - Add `onTabCloseRequest` to `BonsplitController` to signal explicit tab-close gestures.
  - `TabBarView` calls this hook before closing, so hosts can handle last-surface/workspace logic.

<sup>Written for commit 02fa188ccd244b1e6efc037e4ed631e966144795. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a callback hook allowing host apps to respond when users request closing a tab.

* **Bug Fixes / Visual**
  * Improved split and pane background handling so container surfaces render translucent/clear correctly.

* **Tests**
  * Added tests validating split container translucency and rendered alpha remain correct after pane operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->