### PR TITLE
Fix pane background alpha stacking with translucent themes

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -49,11 +49,18 @@ enum TabBarColors {
     }
 
     static func paneBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor))
+        let color = effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor)
+        // When the background has transparency (from Ghostty background-opacity), the terminal
+        // renderer already draws translucent backgrounds. Adding another translucent layer here
+        // causes alpha stacking that makes the result appear nearly opaque.
+        if color.alphaComponent < 0.999 { return Color.clear }
+        return Color(nsColor: color)
     }
 
     static func nsColorPaneBackground(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
-        effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor)
+        let color = effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor)
+        if color.alphaComponent < 0.999 { return .clear }
+        return color
     }
 
     // MARK: - Tab Bar Background


### PR DESCRIPTION
## Summary
- Return `.clear` from `paneBackground()` / `nsColorPaneBackground()` when the resolved chrome color has alpha < 1.0
- Prevents alpha stacking where two translucent layers (Ghostty renderer + Bonsplit pane background) combine to appear nearly opaque (e.g. two layers at 0.9 → 0.99)
- Matches the existing pattern in `GhosttyTerminalView.panelBackgroundFillColor()`
- Fixes transparency being ignored when using more than one pane in a workspace

## Context
PR #29 fixed intermediate split wrapper/container layers but `SplitViewContainer` still applies `.background(TabBarColors.paneBackground(...))` at the root, which paints a duplicate translucent layer.

## Test plan
- [x] With `background-opacity = 0.9`: single pane should be visibly transparent
- [x] Split into 2+ panes: transparency maintained in all panes
- [x] With `background-opacity = 1.0` (or unset): solid background, no regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pane background alpha stacking with translucent themes so transparency looks correct in split panes. If the resolved chrome background is translucent, we stop drawing a second translucent layer.

- **Bug Fixes**
  - `TabBarColors.paneBackground(...)` and `nsColorPaneBackground(...)` return `.clear` when `alphaComponent < 0.999`.
  - Prevents compounding translucency (e.g., 0.9 + 0.9 → ~0.99) from the renderer and pane background.
  - Keeps solid backgrounds unchanged and matches `GhosttyTerminalView.panelBackgroundFillColor()`.

<sup>Written for commit ac2ea0740b21de1e27e46a2eef5f91575ff537f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed background color rendering in the tab bar to prevent unintended translucency stacking when using background opacity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->