### PR TITLE
Handle empty tab bar double clicks

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -141,7 +141,9 @@ struct TabBarView: View {
                                 .contentShape(Rectangle())
                                 .background(
                                     EmptyTabBarDoubleClickMonitorView {
+                                        guard splitViewController.isInteractive else { return false }
                                         controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                                        return true
                                     }
                                 )
                                 .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
@@ -420,7 +422,9 @@ struct TabBarView: View {
             .contentShape(Rectangle())
             .background(
                 EmptyTabBarDoubleClickMonitorView {
+                    guard splitViewController.isInteractive else { return false }
                     controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                    return true
                 }
             )
             .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
@@ -579,10 +583,10 @@ private struct SplitActionButtonStyle: ButtonStyle {
 }
 
 private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
-    let onDoubleClick: () -> Void
+    let onDoubleClick: () -> Bool
 
     final class Coordinator {
-        var onDoubleClick: (() -> Void)?
+        var onDoubleClick: (() -> Bool)?
         weak var view: NSView?
         var monitor: Any?
 
@@ -612,7 +616,7 @@ private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
             let point = view.convert(event.locationInWindow, from: nil)
             guard view.bounds.contains(point) else { return event }
 
-            coordinator.onDoubleClick?()
+            guard coordinator.onDoubleClick?() == true else { return event }
             return nil
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -139,6 +139,11 @@ struct TabBarView: View {
                             Color.clear
                                 .frame(width: trailing, height: TabBarMetrics.tabHeight)
                                 .contentShape(Rectangle())
+                                .background(
+                                    EmptyTabBarDoubleClickMonitorView {
+                                        controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                                    }
+                                )
                                 .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
                                     targetIndex: pane.tabs.count,
                                     pane: pane,
@@ -413,6 +418,11 @@ struct TabBarView: View {
             .fill(Color.clear)
             .frame(width: 30, height: TabBarMetrics.tabHeight)
             .contentShape(Rectangle())
+            .background(
+                EmptyTabBarDoubleClickMonitorView {
+                    controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                }
+            )
             .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
                 targetIndex: pane.tabs.count,
                 pane: pane,
@@ -565,6 +575,53 @@ private struct SplitActionButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+    }
+}
+
+private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
+    let onDoubleClick: () -> Void
+
+    final class Coordinator {
+        var onDoubleClick: (() -> Void)?
+        weak var view: NSView?
+        var monitor: Any?
+
+        deinit {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.clear.cgColor
+
+        context.coordinator.view = view
+        context.coordinator.onDoubleClick = onDoubleClick
+
+        let coordinator = context.coordinator
+        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak coordinator] event in
+            guard event.clickCount >= 2 else { return event }
+            guard let coordinator, let view = coordinator.view, let window = view.window else { return event }
+            guard event.window === window else { return event }
+
+            let point = view.convert(event.locationInWindow, from: nil)
+            guard view.bounds.contains(point) else { return event }
+
+            coordinator.onDoubleClick?()
+            return nil
+        }
+
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.view = nsView
+        context.coordinator.onDoubleClick = onDoubleClick
     }
 }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -66,6 +66,16 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    private final class NewTabRequestDelegateSpy: BonsplitDelegate {
+        var requestedKind: String?
+        var requestedPaneId: PaneID?
+
+        func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID) {
+            requestedKind = kind
+            requestedPaneId = pane
+        }
+    }
+
     @MainActor
     func testControllerCreation() {
         let controller = BonsplitController()
@@ -495,6 +505,52 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(spy.action, .markAsRead)
         XCTAssertEqual(spy.tabId, tabId)
         XCTAssertEqual(spy.paneId, pane)
+    }
+
+    @MainActor
+    func testDoubleClickingEmptyTrailingTabBarSpaceRequestsNewTerminalTab() {
+        let appearance = BonsplitConfiguration.Appearance(showSplitButtons: false)
+        let configuration = BonsplitConfiguration(appearance: appearance)
+        let controller = BonsplitController(configuration: configuration)
+        let pane = controller.internalController.rootNode.allPanes.first!
+        let spy = NewTabRequestDelegateSpy()
+        controller.delegate = spy
+
+        let hostingView = NSHostingView(
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: false)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 60),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        let clickPoint = NSPoint(x: hostingView.bounds.maxX - 12, y: hostingView.bounds.midY)
+        guard let event = try? makeLeftMouseDownEvent(in: hostingView, at: clickPoint, clickCount: 2) else {
+            XCTFail("Expected mouse event")
+            return
+        }
+        NSApp.sendEvent(event)
+
+        XCTAssertEqual(spy.requestedKind, "terminal")
+        XCTAssertEqual(spy.requestedPaneId, pane.id)
     }
 
     func testIconSaturationKeepsRasterFaviconInColorWhenInactive() {
@@ -936,5 +992,31 @@ final class BonsplitTests: XCTestCase {
               x < bitmap.pixelsWide,
               y < bitmap.pixelsHigh else { return nil }
         return bitmap.colorAt(x: x, y: y)
+    }
+
+    @MainActor
+    private func makeLeftMouseDownEvent(
+        in view: NSView,
+        at point: NSPoint,
+        clickCount: Int
+    ) throws -> NSEvent {
+        guard let window = view.window else {
+            throw NSError(domain: "BonsplitTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing window"])
+        }
+        let pointInWindow = view.convert(point, to: nil)
+        guard let event = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: pointInWindow,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: clickCount,
+            pressure: 1
+        ) else {
+            throw NSError(domain: "BonsplitTests", code: 2, userInfo: [NSLocalizedDescriptionKey: "Failed to create mouse event"])
+        }
+        return event
     }
 }


### PR DESCRIPTION
## Summary
- add a regression test for double-clicking empty trailing tab-bar space
- request a new terminal tab when the empty Bonsplit tab bar is double-clicked

## Testing
- `swift test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double-clicking empty space in the tab bar now opens a new Terminal tab, without consuming unrelated double-clicks. Adds a regression test to lock this behavior in.

- **New Features**
  - Detects double-clicks on empty trailing tab-bar space and triggers `requestNewTab(kind: "terminal", inPane:)` when interactive; unhandled events pass through.
  - Adds `EmptyTabBarDoubleClickMonitorView` using a local event monitor.

<sup>Written for commit f6d6ab720f3f796dc10c11b258071d2ae0aae624. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-click in empty areas of the tab bar (trailing empty space and end drop zone) to quickly create a new terminal tab.
* **Tests**
  * Added automated test coverage verifying double-clicking empty tab-bar areas requests a new terminal tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->