### PR TITLE
Honor configurable surface number shortcut modifiers

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -635,19 +635,68 @@ private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
     }
 }
 
-enum TabControlShortcutModifier: Equatable {
-    case control
-    case command
+private struct TabControlShortcutStoredShortcut: Decodable {
+    let key: String
+    let command: Bool
+    let shift: Bool
+    let option: Bool
+    let control: Bool
 
-    var symbol: String {
-        switch self {
-        case .control:
-            return "⌃"
-        case .command:
-            // Command-hold can reveal pane hints, but pane navigation itself is control-based.
-            return "⌃"
-        }
+    init(
+        key: String,
+        command: Bool,
+        shift: Bool,
+        option: Bool,
+        control: Bool
+    ) {
+        self.key = key
+        self.command = command
+        self.shift = shift
+        self.option = option
+        self.control = control
     }
+
+    var modifierFlags: NSEvent.ModifierFlags {
+        var flags: NSEvent.ModifierFlags = []
+        if command { flags.insert(.command) }
+        if shift { flags.insert(.shift) }
+        if option { flags.insert(.option) }
+        if control { flags.insert(.control) }
+        return flags
+    }
+
+    var modifierSymbol: String {
+        var parts: [String] = []
+        if control { parts.append("⌃") }
+        if option { parts.append("⌥") }
+        if shift { parts.append("⇧") }
+        if command { parts.append("⌘") }
+        return parts.joined()
+    }
+}
+
+private enum TabControlShortcutSettings {
+    static let surfaceByNumberKey = "shortcut.selectSurfaceByNumber"
+    static let defaultShortcut = TabControlShortcutStoredShortcut(
+        key: "1",
+        command: false,
+        shift: false,
+        option: false,
+        control: true
+    )
+
+    static func surfaceByNumberShortcut(defaults: UserDefaults = .standard) -> TabControlShortcutStoredShortcut {
+        guard let data = defaults.data(forKey: surfaceByNumberKey),
+              let shortcut = try? JSONDecoder().decode(TabControlShortcutStoredShortcut.self, from: data) else {
+            return defaultShortcut
+        }
+        return shortcut
+    }
+}
+
+struct TabControlShortcutModifier: Equatable {
+    let modifierFlags: NSEvent.ModifierFlags
+    let symbol: String
 }
 
 enum TabControlShortcutHintPolicy {
@@ -668,9 +717,13 @@ enum TabControlShortcutHintPolicy {
     ) -> TabControlShortcutModifier? {
         guard showHintsOnCommandHoldEnabled(defaults: defaults) else { return nil }
         let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if flags == [.control] { return .control }
-        if flags == [.command] { return .command }
-        return nil
+            .subtracting([.numericPad, .function, .capsLock])
+        let shortcut = TabControlShortcutSettings.surfaceByNumberShortcut(defaults: defaults)
+        guard flags == shortcut.modifierFlags else { return nil }
+        return TabControlShortcutModifier(
+            modifierFlags: shortcut.modifierFlags,
+            symbol: shortcut.modifierSymbol
+        )
     }
 
     static func isCurrentWindow(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -595,15 +595,29 @@ final class BonsplitTests: XCTestCase {
         XCTAssertNil(resolved)
     }
 
-    func testTabControlShortcutHintPolicyRequiresCommandOrControlOnly() {
+    func testTabControlShortcutHintPolicyMatchesConfiguredModifiers() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
             XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
-            XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [], defaults: defaults))
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control, .shift], defaults: defaults))
-            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command, .option], defaults: defaults))
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
+
+            defaults.set(
+                shortcutData(
+                    key: "1",
+                    command: true,
+                    shift: false,
+                    option: true,
+                    control: false
+                ),
+                forKey: "shortcut.selectSurfaceByNumber"
+            )
+
+            let custom = TabControlShortcutHintPolicy.hintModifier(for: [.command, .option], defaults: defaults)
+            XCTAssertEqual(custom?.symbol, "⌥⌘")
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
         }
     }
 
@@ -611,8 +625,8 @@ final class BonsplitTests: XCTestCase {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
-            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
         }
     }
 
@@ -620,8 +634,8 @@ final class BonsplitTests: XCTestCase {
         withShortcutHintDefaultsSuite { defaults in
             defaults.removeObject(forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
-            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults), .command)
-            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults), .control)
+            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol, "⌃")
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
         }
     }
 
@@ -631,7 +645,7 @@ final class BonsplitTests: XCTestCase {
 
             XCTAssertTrue(
                 TabControlShortcutHintPolicy.shouldShowHints(
-                    for: [.command],
+                    for: [.control],
                     hostWindowNumber: 42,
                     hostWindowIsKey: true,
                     eventWindowNumber: 42,
@@ -642,7 +656,7 @@ final class BonsplitTests: XCTestCase {
 
             XCTAssertFalse(
                 TabControlShortcutHintPolicy.shouldShowHints(
-                    for: [.command],
+                    for: [.control],
                     hostWindowNumber: 42,
                     hostWindowIsKey: true,
                     eventWindowNumber: 7,
@@ -653,7 +667,7 @@ final class BonsplitTests: XCTestCase {
 
             XCTAssertFalse(
                 TabControlShortcutHintPolicy.shouldShowHints(
-                    for: [.command],
+                    for: [.control],
                     hostWindowNumber: 42,
                     hostWindowIsKey: false,
                     eventWindowNumber: 42,
@@ -926,6 +940,23 @@ final class BonsplitTests: XCTestCase {
         defaults.removePersistentDomain(forName: suiteName)
         body(defaults)
         defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func shortcutData(
+        key: String,
+        command: Bool,
+        shift: Bool,
+        option: Bool,
+        control: Bool
+    ) -> Data {
+        let payload: [String: Any] = [
+            "key": key,
+            "command": command,
+            "shift": shift,
+            "option": option,
+            "control": control
+        ]
+        return try! JSONSerialization.data(withJSONObject: payload, options: [])
     }
 
     private func firstDescendant<T: NSView>(ofType type: T.Type, in root: NSView) -> T? {


### PR DESCRIPTION
## Summary
- Passes configurable modifier keys through to bonsplit's TabBarView for numbered surface shortcuts
- Updates surface number shortcut handling to use the configured modifiers instead of hardcoded ones

## Test plan
- [x] BonsplitTests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the configured modifier keys for numbered surface shortcuts in the TabBar and hint UI. Removes hardcoded Command/Control logic so hints and navigation respect the user’s setting.

- **New Features**
  - Read `shortcut.selectSurfaceByNumber` from `UserDefaults` (JSON: key, command, shift, option, control) with a default of Control+number.
  - Match hint display and shortcut handling to the exact configured modifier flags, ignoring unrelated flags.
  - Render the correct modifier symbols (e.g., ⌃, ⌥, ⇧, ⌘) in hints based on the current configuration.

<sup>Written for commit 57394340170e33d24a610bd0c96a0ea03238ca59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab selection keyboard shortcuts are now customizable, supporting multiple modifier key combinations.
  * Shortcut configurations are persisted and recalled across sessions.
  * Hint tooltips now display correctly based on configured shortcuts.

* **Tests**
  * Updated tests to verify customizable modifier handling and configuration persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->