### PR TITLE
Localize tab context menu items (en/ja)

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -323,24 +323,24 @@ struct TabItemView: View {
 
     @ViewBuilder
     private var contextMenuContent: some View {
-        contextButton("Rename Tab…", action: .rename)
+        localizedContextButton("tab.contextMenu.rename", defaultValue: "Rename Tab…", action: .rename)
 
         if contextMenuState.hasCustomTitle {
-            contextButton("Remove Custom Tab Name", action: .clearName)
+            localizedContextButton("tab.contextMenu.removeCustomName", defaultValue: "Remove Custom Tab Name", action: .clearName)
         }
 
         Divider()
 
-        contextButton("Close Tabs to Left", action: .closeToLeft)
+        localizedContextButton("tab.contextMenu.closeToLeft", defaultValue: "Close Tabs to Left", action: .closeToLeft)
             .disabled(!contextMenuState.canCloseToLeft)
 
-        contextButton("Close Tabs to Right", action: .closeToRight)
+        localizedContextButton("tab.contextMenu.closeToRight", defaultValue: "Close Tabs to Right", action: .closeToRight)
             .disabled(!contextMenuState.canCloseToRight)
 
-        contextButton("Close Other Tabs", action: .closeOthers)
+        localizedContextButton("tab.contextMenu.closeOthers", defaultValue: "Close Other Tabs", action: .closeOthers)
             .disabled(!contextMenuState.canCloseOthers)
 
-        contextButton("Move Tab…", action: .move)
+        localizedContextButton("tab.contextMenu.move", defaultValue: "Move Tab…", action: .move)
 
         if contextMenuState.isTerminal {
             localizedContextButton(
@@ -360,37 +360,39 @@ struct TabItemView: View {
 
         Divider()
 
-        contextButton("New Terminal Tab to Right", action: .newTerminalToRight)
+        localizedContextButton("tab.contextMenu.newTerminalToRight", defaultValue: "New Terminal Tab to Right", action: .newTerminalToRight)
 
-        contextButton("New Browser Tab to Right", action: .newBrowserToRight)
+        localizedContextButton("tab.contextMenu.newBrowserToRight", defaultValue: "New Browser Tab to Right", action: .newBrowserToRight)
 
         if contextMenuState.isBrowser {
             Divider()
 
-            contextButton("Reload Tab", action: .reload)
+            localizedContextButton("tab.contextMenu.reload", defaultValue: "Reload Tab", action: .reload)
 
-            contextButton("Duplicate Tab", action: .duplicate)
+            localizedContextButton("tab.contextMenu.duplicate", defaultValue: "Duplicate Tab", action: .duplicate)
         }
 
         Divider()
 
         if contextMenuState.hasSplits {
-            contextButton(
-                contextMenuState.isZoomed ? "Exit Zoom" : "Zoom Pane",
+            localizedContextButton(
+                contextMenuState.isZoomed ? "tab.contextMenu.exitZoom" : "tab.contextMenu.zoomPane",
+                defaultValue: contextMenuState.isZoomed ? "Exit Zoom" : "Zoom Pane",
                 action: .toggleZoom
             )
         }
 
-        contextButton(
-            contextMenuState.isPinned ? "Unpin Tab" : "Pin Tab",
+        localizedContextButton(
+            contextMenuState.isPinned ? "tab.contextMenu.unpinTab" : "tab.contextMenu.pinTab",
+            defaultValue: contextMenuState.isPinned ? "Unpin Tab" : "Pin Tab",
             action: .togglePin
         )
 
         if contextMenuState.isUnread {
-            contextButton("Mark Tab as Read", action: .markAsRead)
+            localizedContextButton("tab.contextMenu.markAsRead", defaultValue: "Mark Tab as Read", action: .markAsRead)
                 .disabled(!contextMenuState.canMarkAsRead)
         } else {
-            contextButton("Mark Tab as Unread", action: .markAsUnread)
+            localizedContextButton("tab.contextMenu.markAsUnread", defaultValue: "Mark Tab as Unread", action: .markAsUnread)
                 .disabled(!contextMenuState.canMarkAsUnread)
         }
     }

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -1,2 +1,21 @@
+/* Tab context menu */
+"tab.contextMenu.rename" = "Rename Tab…";
+"tab.contextMenu.removeCustomName" = "Remove Custom Tab Name";
+"tab.contextMenu.closeToLeft" = "Close Tabs to Left";
+"tab.contextMenu.closeToRight" = "Close Tabs to Right";
+"tab.contextMenu.closeOthers" = "Close Other Tabs";
+"tab.contextMenu.move" = "Move Tab…";
+"tab.contextMenu.newTerminalToRight" = "New Terminal Tab to Right";
+"tab.contextMenu.newBrowserToRight" = "New Browser Tab to Right";
+"tab.contextMenu.reload" = "Reload Tab";
+"tab.contextMenu.duplicate" = "Duplicate Tab";
+"tab.contextMenu.zoomPane" = "Zoom Pane";
+"tab.contextMenu.exitZoom" = "Exit Zoom";
+"tab.contextMenu.pinTab" = "Pin Tab";
+"tab.contextMenu.unpinTab" = "Unpin Tab";
+"tab.contextMenu.markAsRead" = "Mark Tab as Read";
+"tab.contextMenu.markAsUnread" = "Mark Tab as Unread";
+
+/* Move to pane */
 "command.moveTabToLeftPane.title" = "Move to Left Pane";
 "command.moveTabToRightPane.title" = "Move to Right Pane";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -1,2 +1,21 @@
+/* Tab context menu */
+"tab.contextMenu.rename" = "タブ名を変更…";
+"tab.contextMenu.removeCustomName" = "カスタムタブ名を削除";
+"tab.contextMenu.closeToLeft" = "左側のタブを閉じる";
+"tab.contextMenu.closeToRight" = "右側のタブを閉じる";
+"tab.contextMenu.closeOthers" = "他のタブを閉じる";
+"tab.contextMenu.move" = "タブを移動…";
+"tab.contextMenu.newTerminalToRight" = "右にターミナルタブを追加";
+"tab.contextMenu.newBrowserToRight" = "右にブラウザタブを追加";
+"tab.contextMenu.reload" = "タブを再読み込み";
+"tab.contextMenu.duplicate" = "タブを複製";
+"tab.contextMenu.zoomPane" = "ペインをズーム";
+"tab.contextMenu.exitZoom" = "ズームを解除";
+"tab.contextMenu.pinTab" = "タブを固定";
+"tab.contextMenu.unpinTab" = "タブの固定を解除";
+"tab.contextMenu.markAsRead" = "タブを既読にする";
+"tab.contextMenu.markAsUnread" = "タブを未読にする";
+
+/* Move to pane */
 "command.moveTabToLeftPane.title" = "左のペインへ移動";
 "command.moveTabToRightPane.title" = "右のペインへ移動";

--- a/Sources/Bonsplit/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,21 @@
+/* Tab context menu */
+"tab.contextMenu.rename" = "重命名标签页…";
+"tab.contextMenu.removeCustomName" = "移除自定义标签页名称";
+"tab.contextMenu.closeToLeft" = "关闭左侧标签页";
+"tab.contextMenu.closeToRight" = "关闭右侧标签页";
+"tab.contextMenu.closeOthers" = "关闭其他标签页";
+"tab.contextMenu.move" = "移动标签页…";
+"tab.contextMenu.newTerminalToRight" = "在右侧新建终端标签页";
+"tab.contextMenu.newBrowserToRight" = "在右侧新建浏览器标签页";
+"tab.contextMenu.reload" = "重新加载标签页";
+"tab.contextMenu.duplicate" = "复制标签页";
+"tab.contextMenu.zoomPane" = "缩放面板";
+"tab.contextMenu.exitZoom" = "退出缩放";
+"tab.contextMenu.pinTab" = "固定标签页";
+"tab.contextMenu.unpinTab" = "取消固定标签页";
+"tab.contextMenu.markAsRead" = "标记标签页为已读";
+"tab.contextMenu.markAsUnread" = "标记标签页为未读";
+
+/* Move to pane */
+"command.moveTabToLeftPane.title" = "移动到左侧面板";
+"command.moveTabToRightPane.title" = "移动到右侧面板";

--- a/Sources/Bonsplit/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,21 @@
+/* Tab context menu */
+"tab.contextMenu.rename" = "重新命名標籤頁…";
+"tab.contextMenu.removeCustomName" = "移除自訂標籤頁名稱";
+"tab.contextMenu.closeToLeft" = "關閉左側標籤頁";
+"tab.contextMenu.closeToRight" = "關閉右側標籤頁";
+"tab.contextMenu.closeOthers" = "關閉其他標籤頁";
+"tab.contextMenu.move" = "移動標籤頁…";
+"tab.contextMenu.newTerminalToRight" = "在右側新增終端標籤頁";
+"tab.contextMenu.newBrowserToRight" = "在右側新增瀏覽器標籤頁";
+"tab.contextMenu.reload" = "重新載入標籤頁";
+"tab.contextMenu.duplicate" = "複製標籤頁";
+"tab.contextMenu.zoomPane" = "縮放面板";
+"tab.contextMenu.exitZoom" = "退出縮放";
+"tab.contextMenu.pinTab" = "固定標籤頁";
+"tab.contextMenu.unpinTab" = "取消固定標籤頁";
+"tab.contextMenu.markAsRead" = "標記標籤頁為已讀";
+"tab.contextMenu.markAsUnread" = "標記標籤頁為未讀";
+
+/* Move to pane */
+"command.moveTabToLeftPane.title" = "移動到左側面板";
+"command.moveTabToRightPane.title" = "移動到右側面板";


### PR DESCRIPTION
## Summary
- Replace all hardcoded English strings in the tab context menu with `localizedContextButton` calls that load translations from `Bundle.module`
- Add 16 new localization entries in `en.lproj/Localizable.strings` and `ja.lproj/Localizable.strings`
- Covers: Rename Tab, Remove Custom Tab Name, Close Tabs to Left/Right, Close Other Tabs, Move Tab, New Terminal/Browser Tab to Right, Reload/Duplicate Tab, Zoom Pane/Exit Zoom, Pin/Unpin Tab, Mark Tab as Read/Unread

## Test plan
- [ ] Verify tab context menu displays correctly in English
- [ ] Switch system language to Japanese and verify all menu items show Japanese translations
- [ ] Verify keyboard shortcuts still appear next to menu items
- [ ] Verify disabled states (e.g., Close Tabs to Left when tab is first) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the tab context menu and added English, Japanese, and Chinese (Simplified/Traditional) translations. Shortcuts and disabled states are unchanged.

- **New Features**
  - Replaced context menu labels with `localizedContextButton` via `Bundle.module`.
  - Added 16 keys to `en.lproj` and `ja.lproj`; added `zh-Hans.lproj` and `zh-Hant.lproj` with matching translations.
  - Covers: Rename/Remove name, Close to left/right/others, Move, New Terminal/Browser to right, Reload/Duplicate (browser), Zoom/Exit Zoom, Pin/Unpin, Mark as Read/Unread.

<sup>Written for commit b70ba50ea1c94cd277c18ac85898ba416addc5b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Tab context menu labels are now localized (English, Japanese, Simplified Chinese, Traditional Chinese).
  * Menu actions display in the user’s language for rename/remove custom name, close (left/right/others), move, new terminal/browser to right, reload, duplicate, zoom/exit zoom, pin/unpin, and mark read/unread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->