### PR TITLE
Add configurable tab title typography

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarTypography.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarTypography.swift
@@ -7,7 +7,9 @@ enum TabBarTypography {
     }
 
     static func resolvedTitleNSFont(for appearance: BonsplitConfiguration.Appearance) -> NSFont {
-        let scaledSize = max(0.5, appearance.tabTitleFontScale) * TabBarMetrics.titleFontSize
+        let rawScale = appearance.tabTitleFontScale
+        let sanitizedScale = rawScale.isFinite ? max(0.5, rawScale) : 1.0
+        let scaledSize = sanitizedScale * TabBarMetrics.titleFontSize
         return resolvedFont(
             family: appearance.tabTitleFontFamily,
             size: scaledSize,
@@ -44,12 +46,6 @@ enum TabBarTypography {
             return font.fontName
         }
 
-        let systemDescriptor = NSFont.systemFont(ofSize: size, weight: weight).fontDescriptor
-        let familyDescriptor = systemDescriptor.withFamily(family)
-        if let font = NSFont(descriptor: familyDescriptor, size: size),
-           fontMatchesRequestedFamily(font, family: family) {
-            return font.fontName
-        }
         if let font = NSFont(name: family, size: size),
            fontMatchesRequestedFamily(font, family: family) || font.fontName.caseInsensitiveCompare(family) == .orderedSame {
             return font.fontName

--- a/Sources/Bonsplit/Internal/Styling/TabBarTypography.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarTypography.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import AppKit
+
+enum TabBarTypography {
+    static func titleFont(for appearance: BonsplitConfiguration.Appearance) -> Font {
+        Font(resolvedTitleNSFont(for: appearance))
+    }
+
+    static func resolvedTitleNSFont(for appearance: BonsplitConfiguration.Appearance) -> NSFont {
+        let scaledSize = max(0.5, appearance.tabTitleFontScale) * TabBarMetrics.titleFontSize
+        return resolvedFont(
+            family: appearance.tabTitleFontFamily,
+            size: scaledSize,
+            weight: .regular
+        ) ?? NSFont.systemFont(ofSize: scaledSize)
+    }
+
+    private static func resolvedFont(
+        family rawValue: String?,
+        size: CGFloat,
+        weight: NSFont.Weight
+    ) -> NSFont? {
+        guard let fontName = resolvedPostScriptFontName(family: rawValue, size: size, weight: weight) else {
+            return nil
+        }
+        return NSFont(name: fontName, size: size)
+    }
+
+    private static func resolvedPostScriptFontName(
+        family rawValue: String?,
+        size: CGFloat,
+        weight: NSFont.Weight
+    ) -> String? {
+        guard let family = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines), !family.isEmpty else {
+            return nil
+        }
+
+        if let font = NSFontManager.shared.font(
+            withFamily: family,
+            traits: [],
+            weight: fontManagerWeight(for: weight),
+            size: size
+        ), fontMatchesRequestedFamily(font, family: family) {
+            return font.fontName
+        }
+
+        let systemDescriptor = NSFont.systemFont(ofSize: size, weight: weight).fontDescriptor
+        let familyDescriptor = systemDescriptor.withFamily(family)
+        if let font = NSFont(descriptor: familyDescriptor, size: size),
+           fontMatchesRequestedFamily(font, family: family) {
+            return font.fontName
+        }
+        if let font = NSFont(name: family, size: size),
+           fontMatchesRequestedFamily(font, family: family) || font.fontName.caseInsensitiveCompare(family) == .orderedSame {
+            return font.fontName
+        }
+        return nil
+    }
+
+    private static func fontMatchesRequestedFamily(_ font: NSFont, family: String) -> Bool {
+        let requestedFamily = family.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !requestedFamily.isEmpty else { return false }
+        guard let actualFamily = font.familyName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !actualFamily.isEmpty else {
+            return false
+        }
+        return actualFamily.caseInsensitiveCompare(requestedFamily) == .orderedSame
+    }
+
+    private static func fontManagerWeight(for weight: NSFont.Weight) -> Int {
+        switch weight {
+        case .ultraLight:
+            return 2
+        case .thin:
+            return 3
+        case .light:
+            return 4
+        case .regular:
+            return 5
+        case .medium:
+            return 6
+        case .semibold:
+            return 8
+        case .bold:
+            return 9
+        case .heavy:
+            return 11
+        case .black:
+            return 13
+        default:
+            return 5
+        }
+    }
+}

--- a/Sources/Bonsplit/Internal/Views/TabDragPreview.swift
+++ b/Sources/Bonsplit/Internal/Views/TabDragPreview.swift
@@ -14,7 +14,7 @@ struct TabDragPreview: View {
             }
 
             Text(tab.title)
-                .font(.system(size: TabBarMetrics.titleFontSize))
+                .font(TabBarTypography.titleFont(for: appearance))
                 .lineLimit(1)
                 .foregroundStyle(TabBarColors.activeText(for: appearance))
         }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -119,7 +119,7 @@ struct TabItemView: View {
                 .onChange(of: tab.icon) { _ in updateGlobeFallback() }
 
                 Text(tab.title)
-                    .font(.system(size: TabBarMetrics.titleFontSize))
+                    .font(TabBarTypography.titleFont(for: appearance))
                     .lineLimit(1)
                     .foregroundStyle(
                         isSelected

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -190,7 +190,7 @@ extension BonsplitConfiguration {
         public var tabTitleFontFamily: String?
 
         /// Multiplier applied to pane tab title size.
-        /// `1.0` preserves the current size.
+        /// `1.0` preserves the current size. Values below `0.5` are clamped to `0.5`.
         public var tabTitleFontScale: CGFloat
 
         // MARK: - Presets

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -185,6 +185,14 @@ extension BonsplitConfiguration {
         /// Optional color overrides for tab/pane chrome.
         public var chromeColors: ChromeColors
 
+        /// Optional font family for pane tab titles.
+        /// When unset, Bonsplit uses the system UI font.
+        public var tabTitleFontFamily: String?
+
+        /// Multiplier applied to pane tab title size.
+        /// `1.0` preserves the current size.
+        public var tabTitleFontScale: CGFloat
+
         // MARK: - Presets
 
         public static let `default` = Appearance()
@@ -215,7 +223,9 @@ extension BonsplitConfiguration {
             splitButtonTooltips: SplitButtonTooltips = .default,
             animationDuration: Double = 0.15,
             enableAnimations: Bool = true,
-            chromeColors: ChromeColors = .init()
+            chromeColors: ChromeColors = .init(),
+            tabTitleFontFamily: String? = nil,
+            tabTitleFontScale: CGFloat = 1.0
         ) {
             self.tabBarHeight = tabBarHeight
             self.tabMinWidth = tabMinWidth
@@ -228,6 +238,8 @@ extension BonsplitConfiguration {
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations
             self.chromeColors = chromeColors
+            self.tabTitleFontFamily = tabTitleFontFamily
+            self.tabTitleFontScale = tabTitleFontScale
         }
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -76,6 +76,14 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    private func preferredTabTitleTestFontFamily() throws -> String {
+        let candidates = ["Helvetica", "Avenir", "Menlo", "Courier", "Times New Roman"]
+        if let family = candidates.first(where: { NSFontManager.shared.availableFontFamilies.contains($0) }) {
+            return family
+        }
+        throw XCTSkip("No stable tab title test font family available on this machine")
+    }
+
     @MainActor
     func testControllerCreation() {
         let controller = BonsplitController()
@@ -200,6 +208,53 @@ final class BonsplitTests: XCTestCase {
         let controller = BonsplitController(configuration: config)
 
         XCTAssertEqual(controller.configuration.appearance.splitButtonTooltips, customTooltips)
+    }
+
+    @MainActor
+    func testAppearanceDefaultsLeaveTabTitleTypographyUnchanged() {
+        let appearance = BonsplitConfiguration.Appearance()
+
+        XCTAssertNil(appearance.tabTitleFontFamily)
+        XCTAssertEqual(appearance.tabTitleFontScale, 1.0, accuracy: 0.0001)
+    }
+
+    @MainActor
+    func testDefaultTabTitleTypographyResolvesToSystemFont() {
+        let resolved = TabBarTypography.resolvedTitleNSFont(for: .init())
+        let expected = NSFont.systemFont(ofSize: TabBarMetrics.titleFontSize)
+
+        XCTAssertEqual(resolved.fontName, expected.fontName)
+        XCTAssertEqual(resolved.familyName, expected.familyName)
+        XCTAssertEqual(resolved.pointSize, expected.pointSize, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testAppearanceStoresTabTitleTypographyOverrides() {
+        let appearance = BonsplitConfiguration.Appearance(
+            tabTitleFontFamily: "Helvetica",
+            tabTitleFontScale: 1.25
+        )
+
+        XCTAssertEqual(appearance.tabTitleFontFamily, "Helvetica")
+        XCTAssertEqual(appearance.tabTitleFontScale, 1.25, accuracy: 0.0001)
+    }
+
+    @MainActor
+    func testTitleFontScaleChangesResolvedPointSize() {
+        let baseFont = TabBarTypography.resolvedTitleNSFont(for: .init())
+        let scaledFont = TabBarTypography.resolvedTitleNSFont(for: .init(tabTitleFontScale: 1.5))
+
+        XCTAssertEqual(scaledFont.pointSize, baseFont.pointSize * 1.5, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testTitleFontFamilyUsesRequestedFamilyWhenAvailable() throws {
+        let requestedFamily = try preferredTabTitleTestFontFamily()
+        let font = TabBarTypography.resolvedTitleNSFont(
+            for: .init(tabTitleFontFamily: requestedFamily)
+        )
+
+        XCTAssertEqual(font.familyName, requestedFamily)
     }
 
     func testChromeBackgroundHexOverrideParsesForPaneBackground() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -248,6 +248,18 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTitleFontScaleFallsBackToDefaultForNonFiniteValues() {
+        let expected = NSFont.systemFont(ofSize: TabBarMetrics.titleFontSize)
+        let infinityFont = TabBarTypography.resolvedTitleNSFont(for: .init(tabTitleFontScale: .infinity))
+        let negativeInfinityFont = TabBarTypography.resolvedTitleNSFont(for: .init(tabTitleFontScale: -.infinity))
+        let nanFont = TabBarTypography.resolvedTitleNSFont(for: .init(tabTitleFontScale: .nan))
+
+        XCTAssertEqual(infinityFont.pointSize, expected.pointSize, accuracy: 0.001)
+        XCTAssertEqual(negativeInfinityFont.pointSize, expected.pointSize, accuracy: 0.001)
+        XCTAssertEqual(nanFont.pointSize, expected.pointSize, accuracy: 0.001)
+    }
+
+    @MainActor
     func testTitleFontFamilyUsesRequestedFamilyWhenAvailable() throws {
         let requestedFamily = try preferredTabTitleTestFontFamily()
         let font = TabBarTypography.resolvedTitleNSFont(


### PR DESCRIPTION
Add configurable tab title typography

## Summary
Add configurable pane tab title typography to Bonsplit so host apps can override tab title family and scale without changing the default system font behavior.

## Why
Host apps need a supported way to style pane tab titles to match their UI typography. Bonsplit previously hardcoded the system font for tab titles and drag previews, which made host-level font customization impossible without patching internal views.

## Changes
- add `tabTitleFontFamily` and `tabTitleFontScale` to `BonsplitConfiguration.Appearance`
- route pane tab titles and drag previews through a shared `TabBarTypography` helper instead of hardcoded system font calls
- resolve requested font families through AppKit and reject silent fallbacks that return the system font instead of the requested family
- add tests covering default system-font behavior, override storage, point-size scaling, and requested-family resolution

## Validation
- `swift test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable typography for pane tab titles so host apps can set a font family and scale while keeping the system font as the default. Updates tab titles and drag previews to use a shared resolver and hardens scale handling.

- **New Features**
  - `BonsplitConfiguration.Appearance` adds `tabTitleFontFamily` and `tabTitleFontScale`.
  - New `TabBarTypography` resolves fonts via `AppKit`, enforces the requested family, clamps scale to 0.5+, and falls back to the system font when missing or non-finite.
  - Tab titles and drag previews now use `TabBarTypography`.
  - Tests cover defaults, overrides, scaling (including non-finite), and family resolution.

<sup>Written for commit 0d0ce6e91cfcd06138154aaedf614b92fb08e668. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added appearance options to customize tab bar title typography: selectable font family and adjustable scale.
  * Tab bar titles now use the configured typography and scale instead of a fixed font size.

* **Tests**
  * Added tests covering typography configuration, font resolution, scaling behavior, and handling of invalid scale values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->