### PR TITLE
Minimal mode: split buttons on hover, drag-from-empty-space, traffic light inset

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -102,6 +102,9 @@ struct TabBarView: View {
 
     var body: some View {
         HStack(spacing: 0) {
+            if appearance.tabBarLeadingInset > 0 {
+                Spacer().frame(width: appearance.tabBarLeadingInset)
+            }
             // Scrollable tabs with fade overlays
             GeometryReader { containerGeo in
                 ScrollViewReader { proxy in

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -627,6 +627,9 @@ private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
         let coordinator = context.coordinator
         coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak coordinator] event in
             guard event.clickCount >= 2 else { return event }
+            // In minimal mode, double-click should zoom the window, not create a tab.
+            // Let the TabBarWindowDragView handle it instead.
+            if UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" { return event }
             guard let coordinator, let view = coordinator.view, let window = view.window else { return event }
             guard event.window === window else { return event }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -65,6 +65,7 @@ struct TabBarView: View {
     let isFocused: Bool
     var showSplitButtons: Bool = true
 
+    @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
     @State private var scrollOffset: CGFloat = 0
@@ -185,13 +186,18 @@ struct TabBarView: View {
 
             // Split buttons
             if showSplitButtons {
+                let shouldShow = !appearance.splitButtonsOnHover || isHoveringTabBar
                 splitButtons
                     .saturation(tabBarSaturation)
+                    .opacity(shouldShow ? 1 : 0)
+                    .allowsHitTesting(shouldShow)
+                    .animation(.easeInOut(duration: 0.14), value: shouldShow)
             }
         }
         .frame(height: TabBarMetrics.barHeight)
         .coordinateSpace(name: "tabBar")
         .contentShape(Rectangle())
+        .onHover { isHoveringTabBar = $0 }
         .background(tabBarBackground)
         .background(
             TabBarHostWindowReader { window in

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -200,6 +200,7 @@ struct TabBarView: View {
         .contentShape(Rectangle())
         .onHover { isHoveringTabBar = $0 }
         .background(tabBarBackground)
+        .background(TabBarWindowDragView())
         .background(
             TabBarHostWindowReader { window in
                 controlKeyMonitor.setHostWindow(window)
@@ -639,6 +640,35 @@ private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {
         context.coordinator.view = nsView
         context.coordinator.onDoubleClick = onDoubleClick
+    }
+}
+
+/// Transparent view that enables window dragging from the tab bar background.
+/// Only active when the presentation mode is minimal.
+private struct TabBarWindowDragView: NSViewRepresentable {
+    func makeNSView(context: Context) -> DraggableTabBarView {
+        DraggableTabBarView()
+    }
+
+    func updateNSView(_ nsView: DraggableTabBarView, context: Context) {}
+
+    final class DraggableTabBarView: NSView {
+        override var mouseDownCanMoveWindow: Bool { false }
+
+        override func mouseDown(with event: NSEvent) {
+            guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else {
+                super.mouseDown(with: event)
+                return
+            }
+            guard let window else {
+                super.mouseDown(with: event)
+                return
+            }
+            let wasMovable = window.isMovable
+            window.isMovable = true
+            window.performDrag(with: event)
+            window.isMovable = wasMovable
+        }
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -103,14 +103,20 @@ struct TabBarView: View {
     @State private var needsTrafficLightInset = false
 
     private func updateTrafficLightInset(frame: CGRect) {
-        // Only the top-left tab bar (near leading edge and near screen top) needs
-        // traffic light clearance. In global coordinates, minX near 0 means
-        // leftmost, and maxY near screen top means topmost.
-        let isNearLeading = frame.minX < 120
-        // Check if this is the topmost tab bar by seeing if the top edge is
-        // near the window's top. Use a generous threshold since we can't easily
-        // get the window frame from here.
-        let isNearTop = frame.maxY > (NSScreen.main?.frame.maxY ?? 0) - 100
+        // In minimal mode with no sidebar, the leftmost panes need traffic
+        // light clearance. Check if this tab bar is near the leading edge
+        // of the window by comparing its global x position to the window's.
+        guard let window = NSApp.windows.first(where: { $0.isMainWindow || $0.isKeyWindow }) else {
+            let needs = presentationMode == "minimal" && frame.minX < 120
+            if needsTrafficLightInset != needs { needsTrafficLightInset = needs }
+            return
+        }
+        let windowMinX = window.frame.minX
+        let isNearLeading = frame.minX - windowMinX < 20
+        // Only the topmost row needs the inset. Check if the tab bar's top
+        // edge is near the window's top edge.
+        let windowMaxY = window.frame.maxY
+        let isNearTop = windowMaxY - frame.maxY < 60
         let needs = presentationMode == "minimal" && isNearLeading && isNearTop
         if needsTrafficLightInset != needs {
             needsTrafficLightInset = needs

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -200,7 +200,7 @@ struct TabBarView: View {
         .contentShape(Rectangle())
         .onHover { isHoveringTabBar = $0 }
         .background(tabBarBackground)
-        .background(TabBarWindowDragView())
+        .overlay(TabBarWindowDragView())
         .background(
             TabBarHostWindowReader { window in
                 controlKeyMonitor.setHostWindow(window)
@@ -643,8 +643,9 @@ private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
     }
 }
 
-/// Transparent view that enables window dragging from the tab bar background.
-/// Only active when the presentation mode is minimal.
+/// Transparent overlay that enables window dragging from empty tab bar space.
+/// Only active when the presentation mode is minimal. Passes through clicks
+/// on interactive elements (buttons, tab items) below.
 private struct TabBarWindowDragView: NSViewRepresentable {
     func makeNSView(context: Context) -> DraggableTabBarView {
         DraggableTabBarView()
@@ -655,11 +656,28 @@ private struct TabBarWindowDragView: NSViewRepresentable {
     final class DraggableTabBarView: NSView {
         override var mouseDownCanMoveWindow: Bool { false }
 
-        override func mouseDown(with event: NSEvent) {
-            guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else {
-                super.mouseDown(with: event)
-                return
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            guard NSApp.currentEvent?.type == .leftMouseDown else { return nil }
+            guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else { return nil }
+            guard bounds.contains(point) else { return nil }
+            // Check if an interactive element (button, tab) is under this point.
+            // If so, pass through so the user can click tabs/buttons normally.
+            if let superview {
+                for sibling in superview.subviews.reversed() where sibling !== self {
+                    guard !sibling.isHidden, sibling.alphaValue > 0 else { continue }
+                    let siblingPoint = convert(point, to: sibling)
+                    if let hit = sibling.hitTest(siblingPoint) {
+                        // If the hit view is a button or has an action, pass through.
+                        if hit is NSButton || hit.responds(to: #selector(NSControl.sendAction(_:to:))) {
+                            return nil
+                        }
+                    }
+                }
             }
+            return self
+        }
+
+        override func mouseDown(with event: NSEvent) {
             guard let window else {
                 super.mouseDown(with: event)
                 return

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -114,7 +114,7 @@ struct TabBarView: View {
     var body: some View {
         HStack(spacing: 0) {
             if needsTrafficLightInset {
-                Spacer().frame(width: 72)
+                Spacer().frame(width: 80)
             }
             // Scrollable tabs with fade overlays
             GeometryReader { containerGeo in

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -688,15 +688,13 @@ private struct TabBarWindowDragView: NSViewRepresentable {
             guard NSApp.currentEvent?.type == .leftMouseDown else { return nil }
             guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else { return nil }
             guard bounds.contains(point) else { return nil }
-            // Pass through if any sibling view has a hit (tabs, buttons, etc.).
+            // Check the full window content view for a hit at this point.
+            // If any other view claims the hit, pass through (tabs, buttons).
             // Only capture truly empty space for window drag.
-            if let superview {
-                for sibling in superview.subviews.reversed() where sibling !== self {
-                    guard !sibling.isHidden, sibling.alphaValue > 0 else { continue }
-                    let siblingPoint = convert(point, to: sibling)
-                    if sibling.hitTest(siblingPoint) != nil {
-                        return nil
-                    }
+            if let window, let contentView = window.contentView {
+                let windowPoint = convert(point, to: contentView)
+                if let hit = contentView.hitTest(windowPoint), hit !== self {
+                    return nil
                 }
             }
             return self

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -110,7 +110,7 @@ struct TabBarView: View {
         // Check if this is the topmost tab bar by seeing if the top edge is
         // near the window's top. Use a generous threshold since we can't easily
         // get the window frame from here.
-        let isNearTop = frame.maxY > NSScreen.main?.frame.maxY ?? 0 - 100
+        let isNearTop = frame.maxY > (NSScreen.main?.frame.maxY ?? 0) - 100
         let needs = presentationMode == "minimal" && isNearLeading && isNearTop
         if needsTrafficLightInset != needs {
             needsTrafficLightInset = needs

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -103,7 +103,7 @@ struct TabBarView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            if appearance.tabBarLeadingInset > 0 {
+            if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
                 TabBarDragZoneView { return false }
                     .frame(width: appearance.tabBarLeadingInset)
             }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -682,6 +682,16 @@ private struct TabBarWindowDragView: NSViewRepresentable {
                 super.mouseDown(with: event)
                 return
             }
+            if event.clickCount >= 2 {
+                // Standard macOS titlebar double-click action (zoom or minimize
+                // based on System Settings > Desktop & Dock).
+                let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
+                switch action {
+                case "Minimize": window.miniaturize(nil)
+                default: window.zoom(nil)
+                }
+                return
+            }
             let wasMovable = window.isMovable
             window.isMovable = true
             window.performDrag(with: event)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -100,34 +100,12 @@ struct TabBarView: View {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
 
-    @State private var needsTrafficLightInset = false
-
-    private func updateTrafficLightInset(frame: CGRect) {
-        // In minimal mode with no sidebar, the leftmost panes need traffic
-        // light clearance. Check if this tab bar is near the leading edge
-        // of the window by comparing its global x position to the window's.
-        guard let window = NSApp.windows.first(where: { $0.isMainWindow || $0.isKeyWindow }) else {
-            let needs = presentationMode == "minimal" && frame.minX < 120
-            if needsTrafficLightInset != needs { needsTrafficLightInset = needs }
-            return
-        }
-        let windowMinX = window.frame.minX
-        let isNearLeading = frame.minX - windowMinX < 20
-        // Only the topmost row needs the inset. Check if the tab bar's top
-        // edge is near the window's top edge.
-        let windowMaxY = window.frame.maxY
-        let isNearTop = windowMaxY - frame.maxY < 60
-        let needs = presentationMode == "minimal" && isNearLeading && isNearTop
-        if needsTrafficLightInset != needs {
-            needsTrafficLightInset = needs
-        }
-    }
 
     var body: some View {
         HStack(spacing: 0) {
-            if needsTrafficLightInset {
+            if appearance.tabBarLeadingInset > 0 {
                 TabBarDragZoneView { return false }
-                    .frame(width: 80)
+                    .frame(width: appearance.tabBarLeadingInset)
             }
             // Scrollable tabs with fade overlays
             GeometryReader { containerGeo in
@@ -225,18 +203,6 @@ struct TabBarView: View {
             isMinimalMode: presentationMode == "minimal",
             onHoverChanged: { isHoveringTabBar = $0 }
         ))
-        .background(
-            GeometryReader { geo in
-                Color.clear
-                    .onAppear { updateTrafficLightInset(frame: geo.frame(in: .global)) }
-                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
-                        updateTrafficLightInset(frame: newFrame)
-                    }
-                    .onChange(of: presentationMode) { _, _ in
-                        updateTrafficLightInset(frame: geo.frame(in: .global))
-                    }
-            }
-        )
         .background(
             TabBarHostWindowReader { window in
                 controlKeyMonitor.setHostWindow(window)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -102,6 +102,20 @@ struct TabBarView: View {
 
     @State private var needsTrafficLightInset = false
 
+    private func updateTrafficLightInset(frame: CGRect) {
+        // Only the top-left tab bar (near leading edge and near screen top) needs
+        // traffic light clearance. In global coordinates, minX near 0 means
+        // leftmost, and maxY near screen top means topmost.
+        let isNearLeading = frame.minX < 120
+        // Check if this is the topmost tab bar by seeing if the top edge is
+        // near the window's top. Use a generous threshold since we can't easily
+        // get the window frame from here.
+        let isNearTop = frame.maxY > NSScreen.main?.frame.maxY ?? 0 - 100
+        let needs = presentationMode == "minimal" && isNearLeading && isNearTop
+        if needsTrafficLightInset != needs {
+            needsTrafficLightInset = needs
+        }
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -203,9 +217,20 @@ struct TabBarView: View {
         .background(tabBarBackground)
         .background(TabBarDragAndHoverView(
             isMinimalMode: presentationMode == "minimal",
-            onHoverChanged: { isHoveringTabBar = $0 },
-            onLeadingEdgeChanged: { needsTrafficLightInset = $0 }
+            onHoverChanged: { isHoveringTabBar = $0 }
         ))
+        .background(
+            GeometryReader { geo in
+                Color.clear
+                    .onAppear { updateTrafficLightInset(frame: geo.frame(in: .global)) }
+                    .onChange(of: geo.frame(in: .global)) { _, newFrame in
+                        updateTrafficLightInset(frame: newFrame)
+                    }
+                    .onChange(of: presentationMode) { _, _ in
+                        updateTrafficLightInset(frame: geo.frame(in: .global))
+                    }
+            }
+        )
         .background(
             TabBarHostWindowReader { window in
                 controlKeyMonitor.setHostWindow(window)
@@ -603,26 +628,22 @@ private struct SplitActionButtonStyle: ButtonStyle {
 private struct TabBarDragAndHoverView: NSViewRepresentable {
     let isMinimalMode: Bool
     let onHoverChanged: (Bool) -> Void
-    let onLeadingEdgeChanged: (Bool) -> Void
 
     func makeNSView(context: Context) -> TabBarBackgroundNSView {
         let view = TabBarBackgroundNSView()
         view.isMinimalMode = isMinimalMode
         view.onHoverChanged = onHoverChanged
-        view.onLeadingEdgeChanged = onLeadingEdgeChanged
         return view
     }
 
     func updateNSView(_ nsView: TabBarBackgroundNSView, context: Context) {
         nsView.isMinimalMode = isMinimalMode
         nsView.onHoverChanged = onHoverChanged
-        nsView.onLeadingEdgeChanged = onLeadingEdgeChanged
     }
 
     final class TabBarBackgroundNSView: NSView {
         var isMinimalMode = false
         var onHoverChanged: ((Bool) -> Void)?
-        var onLeadingEdgeChanged: ((Bool) -> Void)?
         private var hoverTrackingArea: NSTrackingArea?
 
         override var mouseDownCanMoveWindow: Bool { false }
@@ -647,27 +668,6 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
         override func mouseExited(with event: NSEvent) {
             onHoverChanged?(false)
-        }
-
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            updateLeadingEdge()
-        }
-
-        override func layout() {
-            super.layout()
-            updateLeadingEdge()
-        }
-
-        private func updateLeadingEdge() {
-            guard let window, let contentView = window.contentView else { return }
-            let windowPoint = convert(NSPoint.zero, to: contentView)
-            // Only the top-left pane needs the traffic light inset. Check both
-            // that we're near the leading edge (x < 20) and near the top of
-            // the window (within ~40pt of the content view top).
-            let distFromTop = contentView.bounds.height - (windowPoint.y + bounds.height)
-            let needsInset = isMinimalMode && windowPoint.x < 20 && distFromTop < 40
-            onLeadingEdgeChanged?(needsInset)
         }
 
         override func mouseDown(with event: NSEvent) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -65,6 +65,7 @@ struct TabBarView: View {
     let isFocused: Bool
     var showSplitButtons: Bool = true
 
+    @AppStorage("workspacePresentationMode") private var presentationMode = "standard"
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
@@ -186,7 +187,7 @@ struct TabBarView: View {
 
             // Split buttons
             if showSplitButtons {
-                let shouldShow = !appearance.splitButtonsOnHover || isHoveringTabBar
+                let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                 splitButtons
                     .saturation(tabBarSaturation)
                     .opacity(shouldShow ? 1 : 0)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -660,9 +660,13 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         }
 
         private func updateLeadingEdge() {
-            guard let window else { return }
-            let windowPoint = convert(NSPoint.zero, to: window.contentView)
-            let needsInset = isMinimalMode && windowPoint.x < 20
+            guard let window, let contentView = window.contentView else { return }
+            let windowPoint = convert(NSPoint.zero, to: contentView)
+            // Only the top-left pane needs the traffic light inset. Check both
+            // that we're near the leading edge (x < 20) and near the top of
+            // the window (within ~40pt of the content view top).
+            let distFromTop = contentView.bounds.height - (windowPoint.y + bounds.height)
+            let needsInset = isMinimalMode && windowPoint.x < 20 && distFromTop < 40
             onLeadingEdgeChanged?(needsInset)
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -683,19 +683,24 @@ private struct TabBarWindowDragView: NSViewRepresentable {
 
     final class DraggableTabBarView: NSView {
         override var mouseDownCanMoveWindow: Bool { false }
+        private var isResolvingUnderlying = false
 
         override func hitTest(_ point: NSPoint) -> NSView? {
+            // Reentrancy guard: when checking what's underneath, the
+            // contentView.hitTest traversal reaches us again. Return nil
+            // so the hit test finds the view below instead.
+            guard !isResolvingUnderlying else { return nil }
             guard NSApp.currentEvent?.type == .leftMouseDown else { return nil }
             guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else { return nil }
             guard bounds.contains(point) else { return nil }
-            // Check the full window content view for a hit at this point.
-            // If any other view claims the hit, pass through (tabs, buttons).
-            // Only capture truly empty space for window drag.
+            // Check if any interactive view is under this point. Hide self
+            // from the traversal via the reentrancy guard.
             if let window, let contentView = window.contentView {
                 let windowPoint = convert(point, to: contentView)
-                if let hit = contentView.hitTest(windowPoint), hit !== self {
-                    return nil
-                }
+                isResolvingUnderlying = true
+                let hit = contentView.hitTest(windowPoint)
+                isResolvingUnderlying = false
+                if hit != nil { return nil }
             }
             return self
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -710,13 +710,18 @@ private struct TabBarWindowDragView: NSViewRepresentable {
         }
 
         private static func isInteractiveControl(_ view: NSView) -> Bool {
-            if view is NSButton || view is NSControl { return true }
-            // SwiftUI buttons are rendered inside hosting views whose class
-            // name contains "Button" or "PlatformButton".
-            let className = String(describing: type(of: view))
-            if className.contains("Button") || className.contains("Segmented") { return true }
-            // Check the accessibility role for button-like elements.
-            if view.accessibilityRole() == .button { return true }
+            // Walk up the view hierarchy (up to 10 levels) to check if the
+            // hit view or any ancestor is a button or control. SwiftUI buttons
+            // are nested inside several wrapper views.
+            var current: NSView? = view
+            for _ in 0..<10 {
+                guard let v = current else { break }
+                if v is NSButton || v is NSControl { return true }
+                let className = String(describing: type(of: v))
+                if className.contains("Button") || className.contains("Segmented") { return true }
+                if v.accessibilityRole() == .button { return true }
+                current = v.superview
+            }
             return false
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -693,16 +693,31 @@ private struct TabBarWindowDragView: NSViewRepresentable {
             guard NSApp.currentEvent?.type == .leftMouseDown else { return nil }
             guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else { return nil }
             guard bounds.contains(point) else { return nil }
-            // Check if any interactive view is under this point. Hide self
-            // from the traversal via the reentrancy guard.
+            // Check if a real interactive control is under this point. Hide
+            // self from the traversal via the reentrancy guard. SwiftUI hosting
+            // views always claim hits (due to .contentShape), so check if the
+            // hit is a concrete control vs a generic hosting/layout view.
             if let window, let contentView = window.contentView {
                 let windowPoint = convert(point, to: contentView)
                 isResolvingUnderlying = true
                 let hit = contentView.hitTest(windowPoint)
                 isResolvingUnderlying = false
-                if hit != nil { return nil }
+                if let hit, Self.isInteractiveControl(hit) {
+                    return nil
+                }
             }
             return self
+        }
+
+        private static func isInteractiveControl(_ view: NSView) -> Bool {
+            if view is NSButton || view is NSControl { return true }
+            // SwiftUI buttons are rendered inside hosting views whose class
+            // name contains "Button" or "PlatformButton".
+            let className = String(describing: type(of: view))
+            if className.contains("Button") || className.contains("Segmented") { return true }
+            // Check the accessibility role for button-like elements.
+            if view.accessibilityRole() == .button { return true }
+            return false
         }
 
         override func mouseDown(with event: NSEvent) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -100,10 +100,21 @@ struct TabBarView: View {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
 
+    @State private var needsTrafficLightInset = false
+
+    private func updateTrafficLightInset(geo: GeometryProxy) {
+        // In minimal mode, if this tab bar is near the window's leading edge
+        // (no sidebar to the left), add space for the traffic light buttons.
+        let needs = presentationMode == "minimal" && geo.frame(in: .global).minX < 20
+        if needsTrafficLightInset != needs {
+            needsTrafficLightInset = needs
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
-            if appearance.tabBarLeadingInset > 0 {
-                Spacer().frame(width: appearance.tabBarLeadingInset)
+            if needsTrafficLightInset {
+                Spacer().frame(width: 72)
             }
             // Scrollable tabs with fade overlays
             GeometryReader { containerGeo in
@@ -204,6 +215,17 @@ struct TabBarView: View {
         .onHover { isHoveringTabBar = $0 }
         .background(tabBarBackground)
         .overlay(TabBarWindowDragView())
+        .background(
+            GeometryReader { geo in
+                Color.clear.onChange(of: presentationMode) { _, _ in
+                    updateTrafficLightInset(geo: geo)
+                }
+                .onChange(of: geo.frame(in: .global).minX) { _, _ in
+                    updateTrafficLightInset(geo: geo)
+                }
+                .onAppear { updateTrafficLightInset(geo: geo) }
+            }
+        )
         .background(
             TabBarHostWindowReader { window in
                 controlKeyMonitor.setHostWindow(window)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -688,17 +688,14 @@ private struct TabBarWindowDragView: NSViewRepresentable {
             guard NSApp.currentEvent?.type == .leftMouseDown else { return nil }
             guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else { return nil }
             guard bounds.contains(point) else { return nil }
-            // Check if an interactive element (button, tab) is under this point.
-            // If so, pass through so the user can click tabs/buttons normally.
+            // Pass through if any sibling view has a hit (tabs, buttons, etc.).
+            // Only capture truly empty space for window drag.
             if let superview {
                 for sibling in superview.subviews.reversed() where sibling !== self {
                     guard !sibling.isHidden, sibling.alphaValue > 0 else { continue }
                     let siblingPoint = convert(point, to: sibling)
-                    if let hit = sibling.hitTest(siblingPoint) {
-                        // If the hit view is a button or has an action, pass through.
-                        if hit is NSButton || hit.responds(to: #selector(NSControl.sendAction(_:to:))) {
-                            return nil
-                        }
+                    if sibling.hitTest(siblingPoint) != nil {
+                        return nil
                     }
                 }
             }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -102,19 +102,12 @@ struct TabBarView: View {
 
     @State private var needsTrafficLightInset = false
 
-    private func updateTrafficLightInset(geo: GeometryProxy) {
-        // In minimal mode, if this tab bar is near the window's leading edge
-        // (no sidebar to the left), add space for the traffic light buttons.
-        let needs = presentationMode == "minimal" && geo.frame(in: .global).minX < 20
-        if needsTrafficLightInset != needs {
-            needsTrafficLightInset = needs
-        }
-    }
 
     var body: some View {
         HStack(spacing: 0) {
             if needsTrafficLightInset {
-                Spacer().frame(width: 80)
+                TabBarDragZoneView { return false }
+                    .frame(width: 80)
             }
             // Scrollable tabs with fade overlays
             GeometryReader { containerGeo in
@@ -155,24 +148,20 @@ struct TabBarView: View {
                     .overlay(alignment: .trailing) {
                         let trailing = max(0, containerGeo.size.width - contentWidth)
                         if trailing >= 1 {
-                            Color.clear
-                                .frame(width: trailing, height: TabBarMetrics.tabHeight)
-                                .contentShape(Rectangle())
-                                .background(
-                                    EmptyTabBarDoubleClickMonitorView {
-                                        guard splitViewController.isInteractive else { return false }
-                                        controller.requestNewTab(kind: "terminal", inPane: pane.id)
-                                        return true
-                                    }
-                                )
-                                .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
-                                    targetIndex: pane.tabs.count,
-                                    pane: pane,
-                                    bonsplitController: controller,
-                                    controller: splitViewController,
-                                    dropTargetIndex: $dropTargetIndex,
-                                    dropLifecycle: $dropLifecycle
-                                ))
+                            TabBarDragZoneView {
+                                guard splitViewController.isInteractive else { return false }
+                                controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                                return true
+                            }
+                            .frame(width: trailing, height: TabBarMetrics.tabHeight)
+                            .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+                                targetIndex: pane.tabs.count,
+                                pane: pane,
+                                bonsplitController: controller,
+                                controller: splitViewController,
+                                dropTargetIndex: $dropTargetIndex,
+                                dropLifecycle: $dropLifecycle
+                            ))
                         }
                     }
                     .coordinateSpace(name: "tabScroll")
@@ -211,21 +200,12 @@ struct TabBarView: View {
         }
         .frame(height: TabBarMetrics.barHeight)
         .coordinateSpace(name: "tabBar")
-        .contentShape(Rectangle())
-        .onHover { isHoveringTabBar = $0 }
         .background(tabBarBackground)
-        .overlay(TabBarWindowDragView())
-        .background(
-            GeometryReader { geo in
-                Color.clear.onChange(of: presentationMode) { _, _ in
-                    updateTrafficLightInset(geo: geo)
-                }
-                .onChange(of: geo.frame(in: .global).minX) { _, _ in
-                    updateTrafficLightInset(geo: geo)
-                }
-                .onAppear { updateTrafficLightInset(geo: geo) }
-            }
-        )
+        .background(TabBarDragAndHoverView(
+            isMinimalMode: presentationMode == "minimal",
+            onHoverChanged: { isHoveringTabBar = $0 },
+            onLeadingEdgeChanged: { needsTrafficLightInset = $0 }
+        ))
         .background(
             TabBarHostWindowReader { window in
                 controlKeyMonitor.setHostWindow(window)
@@ -455,31 +435,26 @@ struct TabBarView: View {
 
     @ViewBuilder
     private var dropZoneAfterTabs: some View {
-        Rectangle()
-            .fill(Color.clear)
-            .frame(width: 30, height: TabBarMetrics.tabHeight)
-            .contentShape(Rectangle())
-            .background(
-                EmptyTabBarDoubleClickMonitorView {
-                    guard splitViewController.isInteractive else { return false }
-                    controller.requestNewTab(kind: "terminal", inPane: pane.id)
-                    return true
-                }
-            )
-            .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
-                targetIndex: pane.tabs.count,
-                pane: pane,
-                bonsplitController: controller,
-                controller: splitViewController,
-                dropTargetIndex: $dropTargetIndex,
-                dropLifecycle: $dropLifecycle
-            ))
-            .overlay(alignment: .leading) {
-                if dropTargetIndex == pane.tabs.count {
-                    dropIndicator
-                        .saturation(tabBarSaturation)
-                }
+        TabBarDragZoneView {
+            guard splitViewController.isInteractive else { return false }
+            controller.requestNewTab(kind: "terminal", inPane: pane.id)
+            return true
+        }
+        .frame(width: 30, height: TabBarMetrics.tabHeight)
+        .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+            targetIndex: pane.tabs.count,
+            pane: pane,
+            bonsplitController: controller,
+            controller: splitViewController,
+            dropTargetIndex: $dropTargetIndex,
+            dropLifecycle: $dropLifecycle
+        ))
+        .overlay(alignment: .leading) {
+            if dropTargetIndex == pane.tabs.count {
+                dropIndicator
+                    .saturation(tabBarSaturation)
             }
+        }
     }
 
     // MARK: - Drop Indicator
@@ -621,118 +596,82 @@ private struct SplitActionButtonStyle: ButtonStyle {
     }
 }
 
-private struct EmptyTabBarDoubleClickMonitorView: NSViewRepresentable {
-    let onDoubleClick: () -> Bool
+/// Background view that provides window-drag-from-empty-space in minimal mode
+/// and hover tracking via NSTrackingArea (replacing .contentShape + .onHover).
+/// As a .background(), AppKit routes clicks to tabs/buttons in front first;
+/// this view only receives hits in truly empty space.
+private struct TabBarDragAndHoverView: NSViewRepresentable {
+    let isMinimalMode: Bool
+    let onHoverChanged: (Bool) -> Void
+    let onLeadingEdgeChanged: (Bool) -> Void
 
-    final class Coordinator {
-        var onDoubleClick: (() -> Bool)?
-        weak var view: NSView?
-        var monitor: Any?
-
-        deinit {
-            if let monitor {
-                NSEvent.removeMonitor(monitor)
-            }
-        }
-    }
-
-    func makeCoordinator() -> Coordinator { Coordinator() }
-
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView(frame: .zero)
-        view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.clear.cgColor
-
-        context.coordinator.view = view
-        context.coordinator.onDoubleClick = onDoubleClick
-
-        let coordinator = context.coordinator
-        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { [weak coordinator] event in
-            guard event.clickCount >= 2 else { return event }
-            // In minimal mode, double-click should zoom the window, not create a tab.
-            // Let the TabBarWindowDragView handle it instead.
-            if UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" { return event }
-            guard let coordinator, let view = coordinator.view, let window = view.window else { return event }
-            guard event.window === window else { return event }
-
-            let point = view.convert(event.locationInWindow, from: nil)
-            guard view.bounds.contains(point) else { return event }
-
-            guard coordinator.onDoubleClick?() == true else { return event }
-            return nil
-        }
-
+    func makeNSView(context: Context) -> TabBarBackgroundNSView {
+        let view = TabBarBackgroundNSView()
+        view.isMinimalMode = isMinimalMode
+        view.onHoverChanged = onHoverChanged
+        view.onLeadingEdgeChanged = onLeadingEdgeChanged
         return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.view = nsView
-        context.coordinator.onDoubleClick = onDoubleClick
-    }
-}
-
-/// Transparent overlay that enables window dragging from empty tab bar space.
-/// Only active when the presentation mode is minimal. Passes through clicks
-/// on interactive elements (buttons, tab items) below.
-private struct TabBarWindowDragView: NSViewRepresentable {
-    func makeNSView(context: Context) -> DraggableTabBarView {
-        DraggableTabBarView()
+    func updateNSView(_ nsView: TabBarBackgroundNSView, context: Context) {
+        nsView.isMinimalMode = isMinimalMode
+        nsView.onHoverChanged = onHoverChanged
+        nsView.onLeadingEdgeChanged = onLeadingEdgeChanged
     }
 
-    func updateNSView(_ nsView: DraggableTabBarView, context: Context) {}
+    final class TabBarBackgroundNSView: NSView {
+        var isMinimalMode = false
+        var onHoverChanged: ((Bool) -> Void)?
+        var onLeadingEdgeChanged: ((Bool) -> Void)?
+        private var hoverTrackingArea: NSTrackingArea?
 
-    final class DraggableTabBarView: NSView {
         override var mouseDownCanMoveWindow: Bool { false }
-        private var isResolvingUnderlying = false
 
-        override func hitTest(_ point: NSPoint) -> NSView? {
-            // Reentrancy guard: when checking what's underneath, the
-            // contentView.hitTest traversal reaches us again. Return nil
-            // so the hit test finds the view below instead.
-            guard !isResolvingUnderlying else { return nil }
-            guard NSApp.currentEvent?.type == .leftMouseDown else { return nil }
-            guard UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" else { return nil }
-            guard bounds.contains(point) else { return nil }
-            // Check if a real interactive control is under this point. Hide
-            // self from the traversal via the reentrancy guard. SwiftUI hosting
-            // views always claim hits (due to .contentShape), so check if the
-            // hit is a concrete control vs a generic hosting/layout view.
-            if let window, let contentView = window.contentView {
-                let windowPoint = convert(point, to: contentView)
-                isResolvingUnderlying = true
-                let hit = contentView.hitTest(windowPoint)
-                isResolvingUnderlying = false
-                if let hit, Self.isInteractiveControl(hit) {
-                    return nil
-                }
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let existing = hoverTrackingArea {
+                removeTrackingArea(existing)
             }
-            return self
+            let area = NSTrackingArea(
+                rect: bounds,
+                options: [.mouseEnteredAndExited, .activeInActiveApp],
+                owner: self
+            )
+            addTrackingArea(area)
+            hoverTrackingArea = area
         }
 
-        private static func isInteractiveControl(_ view: NSView) -> Bool {
-            // Walk up the view hierarchy (up to 10 levels) to check if the
-            // hit view or any ancestor is a button or control. SwiftUI buttons
-            // are nested inside several wrapper views.
-            var current: NSView? = view
-            for _ in 0..<10 {
-                guard let v = current else { break }
-                if v is NSButton || v is NSControl { return true }
-                let className = String(describing: type(of: v))
-                if className.contains("Button") || className.contains("Segmented") { return true }
-                if v.accessibilityRole() == .button { return true }
-                current = v.superview
-            }
-            return false
+        override func mouseEntered(with event: NSEvent) {
+            onHoverChanged?(true)
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            onHoverChanged?(false)
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            updateLeadingEdge()
+        }
+
+        override func layout() {
+            super.layout()
+            updateLeadingEdge()
+        }
+
+        private func updateLeadingEdge() {
+            guard let window else { return }
+            let windowPoint = convert(NSPoint.zero, to: window.contentView)
+            let needsInset = isMinimalMode && windowPoint.x < 20
+            onLeadingEdgeChanged?(needsInset)
         }
 
         override func mouseDown(with event: NSEvent) {
-            guard let window else {
+            guard isMinimalMode, let window else {
                 super.mouseDown(with: event)
                 return
             }
             if event.clickCount >= 2 {
-                // Standard macOS titlebar double-click action (zoom or minimize
-                // based on System Settings > Desktop & Dock).
                 let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
                 switch action {
                 case "Minimize": window.miniaturize(nil)
@@ -744,6 +683,65 @@ private struct TabBarWindowDragView: NSViewRepresentable {
             window.isMovable = true
             window.performDrag(with: event)
             window.isMovable = wasMovable
+        }
+    }
+}
+
+private struct TabBarDragZoneView: NSViewRepresentable {
+    let onDoubleClick: () -> Bool
+
+    func makeNSView(context: Context) -> DragNSView {
+        let view = DragNSView()
+        view.onDoubleClick = onDoubleClick
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.clear.cgColor
+        return view
+    }
+
+    func updateNSView(_ nsView: DragNSView, context: Context) {
+        nsView.onDoubleClick = onDoubleClick
+    }
+
+    final class DragNSView: NSView {
+        var onDoubleClick: (() -> Bool)?
+
+        override var mouseDownCanMoveWindow: Bool {
+            return UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal"
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            return bounds.contains(point) ? self : nil
+        }
+
+        override func mouseDown(with event: NSEvent) {
+            guard let window = self.window else {
+                super.mouseDown(with: event)
+                return
+            }
+
+            if event.clickCount >= 2 {
+                if UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" {
+                    let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
+                    switch action {
+                    case "Minimize": window.miniaturize(nil)
+                    default: window.zoom(nil)
+                    }
+                    return
+                } else {
+                    if onDoubleClick?() == true {
+                        return
+                    }
+                }
+            }
+
+            if UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" {
+                let wasMovable = window.isMovable
+                window.isMovable = true
+                window.performDrag(with: event)
+                window.isMovable = wasMovable
+            } else {
+                super.mouseDown(with: event)
+            }
         }
     }
 }

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -172,6 +172,9 @@ extension BonsplitConfiguration {
         /// When true, split buttons are only visible on hover
         public var splitButtonsOnHover: Bool
 
+        /// Extra leading inset for the tab bar (e.g. for traffic light buttons when sidebar is collapsed)
+        public var tabBarLeadingInset: CGFloat
+
         /// Tooltip text for the tab bar's right-side action buttons
         public var splitButtonTooltips: SplitButtonTooltips
 
@@ -216,6 +219,7 @@ extension BonsplitConfiguration {
             minimumPaneHeight: CGFloat = 100,
             showSplitButtons: Bool = true,
             splitButtonsOnHover: Bool = false,
+            tabBarLeadingInset: CGFloat = 0,
             splitButtonTooltips: SplitButtonTooltips = .default,
             animationDuration: Double = 0.15,
             enableAnimations: Bool = true,
@@ -229,6 +233,7 @@ extension BonsplitConfiguration {
             self.minimumPaneHeight = minimumPaneHeight
             self.showSplitButtons = showSplitButtons
             self.splitButtonsOnHover = splitButtonsOnHover
+            self.tabBarLeadingInset = tabBarLeadingInset
             self.splitButtonTooltips = splitButtonTooltips
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -169,6 +169,9 @@ extension BonsplitConfiguration {
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
 
+        /// When true, split buttons are only visible on hover
+        public var splitButtonsOnHover: Bool
+
         /// Tooltip text for the tab bar's right-side action buttons
         public var splitButtonTooltips: SplitButtonTooltips
 
@@ -212,6 +215,7 @@ extension BonsplitConfiguration {
             minimumPaneWidth: CGFloat = 100,
             minimumPaneHeight: CGFloat = 100,
             showSplitButtons: Bool = true,
+            splitButtonsOnHover: Bool = false,
             splitButtonTooltips: SplitButtonTooltips = .default,
             animationDuration: Double = 0.15,
             enableAnimations: Bool = true,
@@ -224,6 +228,7 @@ extension BonsplitConfiguration {
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.showSplitButtons = showSplitButtons
+            self.splitButtonsOnHover = splitButtonsOnHover
             self.splitButtonTooltips = splitButtonTooltips
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations


### PR DESCRIPTION
Changes for cmux minimal mode support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add minimal mode support to the tab bar: split buttons appear on hover, you can drag the window from empty tab-bar space, and the bar can reserve leading space for traffic lights.

- **New Features**
  - `TabBarView`: split buttons fade in on hover in minimal mode; reads `@AppStorage("workspacePresentationMode")`.
  - Window drag-from-empty-space in minimal mode; double-click zoom/minimize per system setting; tabs/buttons still receive hits.
  - `BonsplitConfiguration.Appearance`: new `splitButtonsOnHover` and `tabBarLeadingInset` (applied only to the top-left pane); defaults preserve current behavior.

<sup>Written for commit debc3fe32177f50fe48173d2a6f2bf853a768045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `splitButtonsOnHover` configuration option to control split button visibility based on hover state.
  * Added `tabBarLeadingInset` configuration option for customizing tab bar spacing.

* **Improvements**
  * Enhanced tab bar interactions with improved empty space drag zones and hover state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->