### PR TITLE
Add hover background to split action buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -586,10 +586,17 @@ struct TabBarView: View {
 
 private struct SplitActionButtonStyle: ButtonStyle {
     let appearance: BonsplitConfiguration.Appearance
+    @State private var isHovered = false
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+            .frame(width: 24, height: 24)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(isHovered || configuration.isPressed ? 0.6 : 0))
+            )
+            .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
Split buttons show a subtle background highlight on hover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subtle hover and pressed background to tab bar split action buttons for clearer feedback. Also sets a 24x24 hit area to improve clickability and consistency with macOS controls.

<sup>Written for commit 066384a3f56b2e4d42d2657fe549ecc5f3456e39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Split action buttons now feature enhanced visual feedback with dynamic background styling that responds to hover and press interactions, providing clearer visual cues during user engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->