### PR TITLE
Prevent fade overlays from bleeding into bottom separator

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -586,10 +586,17 @@ struct TabBarView: View {
 
 private struct SplitActionButtonStyle: ButtonStyle {
     let appearance: BonsplitConfiguration.Appearance
+    @State private var isHovered = false
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+            .frame(width: 24, height: 24)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(isHovered || configuration.isPressed ? 0.6 : 0))
+            )
+            .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
Add 1pt bottom padding to fade overlays so they don't overlap the tab bar separator line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hover and pressed background to split action buttons in the tab bar to make the hover state clear and improve affordance. Buttons now use a 24×24 frame with a rounded control background (60% opacity) on hover or press.

<sup>Written for commit 066384a3f56b2e4d42d2657fe549ecc5f3456e39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual feedback to buttons with background highlighting that appears when hovering or pressing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->