### PR TITLE
Render bottom separator above fade overlays

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -586,10 +586,17 @@ struct TabBarView: View {
 
 private struct SplitActionButtonStyle: ButtonStyle {
     let appearance: BonsplitConfiguration.Appearance
+    @State private var isHovered = false
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+            .frame(width: 24, height: 24)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(isHovered || configuration.isPressed ? 0.6 : 0))
+            )
+            .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
Move the tab bar bottom separator from tabBarBackground to an overlay on the main HStack. This renders it above the fade gradients so they can't bleed into the separator line.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hover and pressed feedback to the tab bar split action buttons. This fixes the missing hover state in minimal mode and makes the buttons easier to see and click.

- **UI Improvements**
  - Show a rounded-rect background on hover/press using `.controlBackgroundColor` at 0.6 opacity.
  - Set a fixed 24×24 frame for a consistent hit area.

<sup>Written for commit 066384a3f56b2e4d42d2657fe549ecc5f3456e39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

