### PR TITLE
Exclude drop zone from scroll fade threshold

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -586,10 +586,17 @@ struct TabBarView: View {
 
 private struct SplitActionButtonStyle: ButtonStyle {
     let appearance: BonsplitConfiguration.Appearance
+    @State private var isHovered = false
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+            .frame(width: 24, height: 24)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(isHovered || configuration.isPressed ? 0.6 : 0))
+            )
+            .onHover { isHovered = $0 }
     }
 }
 


### PR DESCRIPTION
The 30pt drop zone after the last tab was included in contentWidth, making the right fade show prematurely when tabs didn't actually overflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hover/press background to the tab bar split action buttons for clearer feedback and better discoverability. Buttons now have a 24x24 frame and show a subtle rounded background on hover or press.

<sup>Written for commit 066384a3f56b2e4d42d2657fe549ecc5f3456e39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button hover effects with visual feedback. Action buttons now display a rounded background when hovered or pressed for better visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->