### PR TITLE
Fix right fade threshold

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -80,10 +80,12 @@ struct TabBarView: View {
     }
 
     private var canScrollRight: Bool {
-        // Subtract the trailing drop zone (30pt) and buffer so the fade
-        // only shows when actual tabs overflow the visible scroll area.
-        let overflow = contentWidth - containerWidth - 32
-        return overflow > 0 && scrollOffset < overflow
+        // contentWidth includes the 30pt drop zone after tabs. Only show
+        // the fade when actual tab content exceeds the visible area.
+        // Use a generous buffer to avoid false positives from rounding.
+        let tabsOnlyWidth = contentWidth - 30
+        guard tabsOnlyWidth > containerWidth + 4 else { return false }
+        return scrollOffset < tabsOnlyWidth - containerWidth
     }
 
     /// Whether this tab bar should show full saturation (focused or drag source)


### PR DESCRIPTION
Subtract 30pt drop zone from content width and require 4pt overflow before showing fade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the right fade from showing early in the tab bar and restore the split action button’s original look.

- **Bug Fixes**
  - Right fade: subtract the 30pt drop zone, add a 4pt tolerance, and only show the fade when tabs-only width exceeds the container and `scrollOffset` is less than `tabsOnlyWidth - containerWidth`.
  - Split action button: removed hover state, background, and fixed frame to revert to the previous styling.

<sup>Written for commit 450a4c8c5d0bad27392a99951da726eb2c07ebc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

