### PR TITLE
Add leading padding to split buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -513,6 +513,7 @@ struct TabBarView: View {
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
             .safeHelp(tooltips.splitDown)
         }
+        .padding(.leading, 6)
         .padding(.trailing, 8)
     }
 


### PR DESCRIPTION
6pt leading padding on split buttons for spacing from tab content/fade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 6pt leading padding to the split buttons group to separate it from the tab content/fade. Also fixes the right fade so it only shows when tabs actually overflow.

- **Bug Fixes**
  - Ignore the 30pt trailing drop zone when checking overflow.
  - Add a 4pt tolerance to prevent false positives from rounding.
  - Use tabs-only width to compute when the fade should appear.

<sup>Written for commit 4e79f3302e9911e861c42292bd0214d41b9429a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

