### PR TITLE
Use blur material for floating split buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -196,7 +196,7 @@ struct TabBarView: View {
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)
                         .animation(.easeInOut(duration: 0.14), value: shouldShow)
-                        .background(tabBarBackground.opacity(shouldShow ? 1 : 0))
+                        .background(.ultraThinMaterial.opacity(shouldShow ? 1 : 0))
                         .background(
                             GeometryReader { geo in
                                 Color.clear.onAppear { splitButtonsWidth = geo.size.width }


### PR DESCRIPTION
Replace opaque tabBarBackground with .ultraThinMaterial for glass effect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the floating split buttons to a blur (`.ultraThinMaterial`) background for a glass look and moved them to float over a full-width tab scroll area. Tabs now take the full width and overflow fades behave correctly.

- **New Features**
  - Floating split buttons use `.ultraThinMaterial` for a glass effect that respects saturation and opacity.

- **Refactors**
  - Made the tab scroll view span the full bar and rendered split buttons as a trailing overlay with their own background.
  - Reserved trailing space for buttons with `.padding(.trailing, splitButtonsWidth)` measured via `GeometryReader`.
  - Updated `canScrollRight` to subtract both the drop zone (30pt) and split button width from `contentWidth`.

<sup>Written for commit 76d627680c872212e6a9eac35723f3ef05aadf2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

