### PR TITLE
Make split buttons full height

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -518,6 +518,7 @@ struct TabBarView: View {
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
             .safeHelp(tooltips.splitDown)
         }
+        .frame(maxHeight: .infinity)
         .padding(.leading, 6)
         .padding(.trailing, 8)
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Made the split buttons in the tab bar full height to match the tab bar and improve the hit area.
Applied `.frame(maxHeight: .infinity)` to the split button group in TabBarView.

<sup>Written for commit c80f195472030ac98a51b96fc7e181a9d86f5ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

