### PR TITLE
Full-height split button blur background

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -192,6 +192,7 @@ struct TabBarView: View {
                 if showSplitButtons {
                     let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                     splitButtons
+                        .frame(maxHeight: .infinity)
                         .saturation(tabBarSaturation)
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)
@@ -518,7 +519,6 @@ struct TabBarView: View {
             .buttonStyle(SplitActionButtonStyle(appearance: appearance))
             .safeHelp(tooltips.splitDown)
         }
-        .frame(maxHeight: .infinity)
         .padding(.leading, 6)
         .padding(.trailing, 8)
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the split button overlay fill the full height so its blur background covers the entire tab bar. Moves `.frame(maxHeight: .infinity)` to the overlay and removes the inner frame to avoid layout conflicts.

<sup>Written for commit bc6d265066fd2737788346b7559f295a8c125fd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

