### PR TITLE
Inset split buttons from bottom separator

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -193,6 +193,7 @@ struct TabBarView: View {
                     let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                     splitButtons
                         .frame(maxHeight: .infinity)
+                        .padding(.bottom, 1)
                         .saturation(tabBarSaturation)
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Inset split buttons by 1pt from the bottom to clear the tab bar separator and prevent visual overlap.

<sup>Written for commit 6bd30d1aee1503601ccb9e203852831b2322caeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

