### PR TITLE
Fix blur overlapping separator

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -193,12 +193,12 @@ struct TabBarView: View {
                     let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                     splitButtons
                         .frame(maxHeight: .infinity)
-                        .padding(.bottom, 1)
                         .saturation(tabBarSaturation)
+                        .background(.ultraThinMaterial)
+                        .padding(.bottom, 1)
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)
                         .animation(.easeInOut(duration: 0.14), value: shouldShow)
-                        .background(.ultraThinMaterial.opacity(shouldShow ? 1 : 0))
                         .background(
                             GeometryReader { geo in
                                 Color.clear.onAppear { splitButtonsWidth = geo.size.width }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a visual bug where the split buttons’ blur overlapped the tab bar separator. The `ultraThinMaterial` background is now applied before padding so the blur stops above the separator, with hover/visibility behavior unchanged.

<sup>Written for commit 48515611d4df169b83e52b3c5d3b74e478d60839. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual appearance of floating action buttons in the tab bar with enhanced material background rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->