### PR TITLE
Match tab bar bg for split buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -191,11 +191,14 @@ struct TabBarView: View {
             .overlay(alignment: .trailing) {
                 if showSplitButtons {
                     let shouldShow = presentationMode != "minimal" || isHoveringTabBar
+                    let barFill = isFocused
+                        ? TabBarColors.barBackground(for: appearance)
+                        : TabBarColors.barBackground(for: appearance).opacity(0.95)
                     splitButtons
                         .frame(maxHeight: .infinity)
-                        .saturation(tabBarSaturation)
-                        .background(.ultraThinMaterial)
                         .padding(.bottom, 1)
+                        .saturation(tabBarSaturation)
+                        .background(barFill)
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)
                         .animation(.easeInOut(duration: 0.14), value: shouldShow)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated split buttons to use the tab bar’s background instead of a material blur, so they visually match the bar. Uses full color when focused and 0.95 opacity when unfocused for a consistent look.

<sup>Written for commit a7af530eafcdb9468785c9ee0d91d85cf39bde8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

