### PR TITLE
Use regularMaterial for split buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -198,7 +198,7 @@ struct TabBarView: View {
                         .frame(maxHeight: .infinity)
                         .padding(.bottom, 1)
                         .saturation(tabBarSaturation)
-                        .background(barFill)
+                        .background(.regularMaterial)
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)
                         .animation(.easeInOut(duration: 0.14), value: shouldShow)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace custom `barFill` with `regularMaterial` for split button backgrounds, improving visual consistency and contrast in the tab bar.

<sup>Written for commit e372f143202c413f8e2d6b85fab3608b0973795d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

