### PR TITLE
Try thickMaterial

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -198,7 +198,7 @@ struct TabBarView: View {
                         .frame(maxHeight: .infinity)
                         .padding(.bottom, 1)
                         .saturation(tabBarSaturation)
-                        .background(.regularMaterial)
+                        .background(.thickMaterial)
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)
                         .animation(.easeInOut(duration: 0.14), value: shouldShow)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch tab bar background from .regularMaterial to .thickMaterial for higher contrast and better readability over content. Improves clarity of the floating buttons in the reworked tab bar.

<sup>Written for commit 3194fa045a67ba1eb855ce9cfd3f59fc831bb565. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

