### PR TITLE
Debug: 5 split button bg styles

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -66,6 +66,7 @@ struct TabBarView: View {
     var showSplitButtons: Bool = true
 
     @AppStorage("workspacePresentationMode") private var presentationMode = "standard"
+    @AppStorage("debugSplitButtonBgStyle") private var splitButtonBgStyle = 0
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
@@ -187,15 +188,11 @@ struct TabBarView: View {
             }
             .frame(height: TabBarMetrics.barHeight)
             .overlay(fadeOverlays)
-            // Floating split buttons on the trailing edge, over the right fade
+            // Floating split buttons on the trailing edge
             .overlay(alignment: .trailing) {
                 if showSplitButtons {
                     let shouldShow = presentationMode != "minimal" || isHoveringTabBar
-                    splitButtons
-                        .saturation(tabBarSaturation)
-                        .opacity(shouldShow ? 1 : 0)
-                        .allowsHitTesting(shouldShow)
-                        .animation(.easeInOut(duration: 0.14), value: shouldShow)
+                    splitButtonsWithBackground(shouldShow: shouldShow)
                         .background(
                             GeometryReader { geo in
                                 Color.clear.onAppear { splitButtonsWidth = geo.size.width }
@@ -521,6 +518,73 @@ struct TabBarView: View {
         .padding(.trailing, 8)
     }
 
+    // MARK: - Split Button Background (debug: `defaults write ... debugSplitButtonBgStyle N`)
+
+    @ViewBuilder
+    private func splitButtonsWithBackground(shouldShow: Bool) -> some View {
+        let bg = TabBarColors.barBackground(for: appearance)
+
+        switch splitButtonBgStyle {
+        case 1:
+            // Style 1: Solid barFill (full opacity)
+            splitButtons
+                .frame(maxHeight: .infinity)
+                .padding(.bottom, 1)
+                .background(bg)
+                .saturation(tabBarSaturation)
+                .opacity(shouldShow ? 1 : 0)
+                .allowsHitTesting(shouldShow)
+                .animation(.easeInOut(duration: 0.14), value: shouldShow)
+
+        case 2:
+            // Style 2: Left fade gradient + solid barFill
+            HStack(spacing: 0) {
+                LinearGradient(colors: [bg.opacity(0), bg], startPoint: .leading, endPoint: .trailing)
+                    .frame(width: 24)
+                splitButtons.background(bg)
+            }
+            .frame(maxHeight: .infinity)
+            .padding(.bottom, 1)
+            .saturation(tabBarSaturation)
+            .opacity(shouldShow ? 1 : 0)
+            .allowsHitTesting(shouldShow)
+            .animation(.easeInOut(duration: 0.14), value: shouldShow)
+
+        case 3:
+            // Style 3: ultraThinMaterial
+            splitButtons
+                .frame(maxHeight: .infinity)
+                .padding(.bottom, 1)
+                .background(.ultraThinMaterial)
+                .saturation(tabBarSaturation)
+                .opacity(shouldShow ? 1 : 0)
+                .allowsHitTesting(shouldShow)
+                .animation(.easeInOut(duration: 0.14), value: shouldShow)
+
+        case 4:
+            // Style 4: windowBackgroundColor + fade
+            HStack(spacing: 0) {
+                LinearGradient(colors: [.clear, Color(nsColor: .windowBackgroundColor)], startPoint: .leading, endPoint: .trailing)
+                    .frame(width: 24)
+                splitButtons.background(Color(nsColor: .windowBackgroundColor))
+            }
+            .frame(maxHeight: .infinity)
+            .padding(.bottom, 1)
+            .saturation(tabBarSaturation)
+            .opacity(shouldShow ? 1 : 0)
+            .allowsHitTesting(shouldShow)
+            .animation(.easeInOut(duration: 0.14), value: shouldShow)
+
+        default:
+            // Style 0: No background (transparent)
+            splitButtons
+                .saturation(tabBarSaturation)
+                .opacity(shouldShow ? 1 : 0)
+                .allowsHitTesting(shouldShow)
+                .animation(.easeInOut(duration: 0.14), value: shouldShow)
+        }
+    }
+
     // MARK: - Fade Overlays
 
     @ViewBuilder
@@ -543,10 +607,7 @@ struct TabBarView: View {
 
             Spacer()
 
-            // Right fade: always visible when split buttons are shown to
-            // provide an opaque backdrop, otherwise only on scroll overflow.
-            let rightFadeWidth: CGFloat = showSplitButtons ? splitButtonsWidth + fadeWidth : fadeWidth
-            let showRightFade = showSplitButtons || canScrollRight
+            // Right fade
             LinearGradient(
                 colors: [
                     TabBarColors.barBackground(for: appearance).opacity(0),
@@ -555,8 +616,8 @@ struct TabBarView: View {
                 startPoint: .leading,
                 endPoint: .trailing
             )
-            .frame(width: rightFadeWidth)
-            .opacity(showRightFade ? 1 : 0)
+            .frame(width: fadeWidth)
+            .opacity(canScrollRight ? 1 : 0)
             .allowsHitTesting(false)
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds 5 debug background styles for the tab bar split buttons and simplifies the right fade so it only shows on scroll overflow. This helps test different visual treatments without affecting normal behavior.

- **New Features**
  - Controlled by `@AppStorage("debugSplitButtonBgStyle")` (0–4).
  - 0: Transparent (no background).
  - 1: Solid bar background.
  - 2: Left fade + solid bar background.
  - 3: `ultraThinMaterial`.
  - 4: `windowBackgroundColor` + left fade.

- **Refactors**
  - Introduced `splitButtonsWithBackground(shouldShow:)` to render buttons with selected background.
  - Right fade width is fixed and only visible when `canScrollRight` (no extra fade for split buttons).

<sup>Written for commit 19869faa659b0bb5319ea084e97bc6f8dca41361. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The floating split button now offers multiple background style options: transparent mode, solid bar fill, gradient variations with different colors, and a frosted glass material effect for enhanced visual customization.

* **Bug Fixes**
  * Fixed trailing edge fade overlay visibility to display based solely on scroll availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->