### PR TITLE
Fix fade color to match tab bar background

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -518,14 +518,15 @@ struct TabBarView: View {
     @ViewBuilder
     private var fadeOverlays: some View {
         let fadeWidth: CGFloat = 24
+        // Must match tabBarBackground's barFill exactly (including focus opacity).
+        let fadeFill = isFocused
+            ? TabBarColors.barBackground(for: appearance)
+            : TabBarColors.barBackground(for: appearance).opacity(0.95)
 
         HStack(spacing: 0) {
             // Left fade
             LinearGradient(
-                colors: [
-                    TabBarColors.barBackground(for: appearance),
-                    TabBarColors.barBackground(for: appearance).opacity(0),
-                ],
+                colors: [fadeFill, fadeFill.opacity(0)],
                 startPoint: .leading,
                 endPoint: .trailing
             )
@@ -537,10 +538,7 @@ struct TabBarView: View {
 
             // Right fade
             LinearGradient(
-                colors: [
-                    TabBarColors.barBackground(for: appearance).opacity(0),
-                    TabBarColors.barBackground(for: appearance),
-                ],
+                colors: [fadeFill.opacity(0), fadeFill],
                 startPoint: .leading,
                 endPoint: .trailing
             )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Match tab bar fade overlays to the tab bar background (including the 0.95 unfocused opacity) to remove visible seams at the left/right edges.
The fades now reuse the same bar fill as `tabBarBackground`, preventing color shifts during focus changes.

<sup>Written for commit b472c5c3e4a0d5d25a0bc567bf8883a198a5dd66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tab bar fade overlay rendering logic for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->