### PR TITLE
Debug: switchable fade color

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -66,6 +66,7 @@ struct TabBarView: View {
     var showSplitButtons: Bool = true
 
     @AppStorage("workspacePresentationMode") private var presentationMode = "standard"
+    @AppStorage("debugFadeColorStyle") private var fadeColorStyle = 0
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
@@ -518,10 +519,24 @@ struct TabBarView: View {
     @ViewBuilder
     private var fadeOverlays: some View {
         let fadeWidth: CGFloat = 24
-        // Must match tabBarBackground's barFill exactly (including focus opacity).
-        let fadeFill = isFocused
-            ? TabBarColors.barBackground(for: appearance)
-            : TabBarColors.barBackground(for: appearance).opacity(0.95)
+        let fadeFill: Color = {
+            switch fadeColorStyle {
+            case 1: // barBackground (raw, no focus opacity)
+                return TabBarColors.barBackground(for: appearance)
+            case 2: // windowBackgroundColor
+                return Color(nsColor: .windowBackgroundColor)
+            case 3: // controlBackgroundColor
+                return Color(nsColor: .controlBackgroundColor)
+            case 4: // textBackgroundColor
+                return Color(nsColor: .textBackgroundColor)
+            case 5: // underPageBackgroundColor
+                return Color(nsColor: .underPageBackgroundColor)
+            default: // 0: barFill with focus opacity (matches tabBarBackground)
+                return isFocused
+                    ? TabBarColors.barBackground(for: appearance)
+                    : TabBarColors.barBackground(for: appearance).opacity(0.95)
+            }
+        }()
 
         HStack(spacing: 0) {
             // Left fade


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a debug setting to switch the tab bar fade overlay color to verify how the fade blends with different backgrounds. Default behavior stays the same.

- **New Features**
  - Adds `debugFadeColorStyle` to choose fade overlay color (0–5).
  - Options: 0 default (matches bar fill with focus opacity), 1 barBackground, 2 windowBackgroundColor, 3 controlBackgroundColor, 4 textBackgroundColor, 5 underPageBackgroundColor.

<sup>Written for commit 3c78d22f17c4402a69911add8a9e03f02c885929. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

