### PR TITLE
Hide fades in minimal mode unless hovering

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -522,6 +522,8 @@ struct TabBarView: View {
     @ViewBuilder
     private var fadeOverlays: some View {
         let fadeWidth: CGFloat = 24
+        // In minimal mode, fades only appear on hover (matching split buttons).
+        let fadesActive = presentationMode != "minimal" || isHoveringTabBar
 
         HStack(spacing: 0) {
             // Left fade mask: transparent → opaque
@@ -530,7 +532,7 @@ struct TabBarView: View {
                 startPoint: .leading,
                 endPoint: .trailing
             )
-            .frame(width: canScrollLeft ? fadeWidth : 0)
+            .frame(width: canScrollLeft && fadesActive ? fadeWidth : 0)
 
             Rectangle().fill(Color.black)
 
@@ -540,7 +542,7 @@ struct TabBarView: View {
                 startPoint: .leading,
                 endPoint: .trailing
             )
-            .frame(width: canScrollRight ? fadeWidth : 0)
+            .frame(width: canScrollRight && fadesActive ? fadeWidth : 0)
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide tab bar scroll fades in minimal mode unless the tab bar is hovered, matching split-button behavior and reducing visual noise. Fades still appear when scrolling is possible and the bar is hovered, and remain unchanged in non-minimal modes.

<sup>Written for commit 9f051840a05f315abe3f5e0ce6752b7c2e905091. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fade overlay behavior in minimal mode—overlays now intelligently appear only when hovering over the tab bar, reducing visual clutter while maintaining full functionality in other presentation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->