### PR TITLE
Remove buttons from layout when hidden

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -188,13 +188,10 @@ struct TabBarView: View {
             // naturally clips at its trailing edge, so no content bleeds
             // behind the buttons. Single .background() on the outer HStack
             // provides the color for both areas with no compositing mismatch.
-            if showSplitButtons {
-                let shouldShow = presentationMode != "minimal" || isHoveringTabBar
+            if showSplitButtons && (presentationMode != "minimal" || isHoveringTabBar) {
                 splitButtons
                     .saturation(tabBarSaturation)
-                    .opacity(shouldShow ? 1 : 0)
-                    .allowsHitTesting(shouldShow)
-                    .animation(.easeInOut(duration: 0.14), value: shouldShow)
+                    .transition(.opacity.animation(.easeInOut(duration: 0.14)))
             }
         }
         .frame(height: TabBarMetrics.barHeight)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove split buttons from the tab bar layout when hidden in minimal mode (no hover). This prevents layout gaps and stray hit areas, while keeping a smooth fade via an opacity transition.

<sup>Written for commit 2ce82c58bb62321a733c29d15667b64a259562bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized split-button animation logic in the tab bar for improved performance and smoother visual transitions when hovering over navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->