### PR TITLE
Always show fades, overlay buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -182,16 +182,15 @@ struct TabBarView: View {
                 }
                 .frame(height: TabBarMetrics.barHeight)
                 .mask(fadeOverlays)
-            }
-
-            // Split buttons as a sibling in the HStack. The scroll view
-            // naturally clips at its trailing edge, so no content bleeds
-            // behind the buttons. Single .background() on the outer HStack
-            // provides the color for both areas with no compositing mismatch.
-            if showSplitButtons && (presentationMode != "minimal" || isHoveringTabBar) {
-                splitButtons
-                    .saturation(tabBarSaturation)
-                    .transition(.opacity.animation(.easeInOut(duration: 0.14)))
+                // Split buttons as overlay: doesn't affect scroll view
+                // layout, so no jump when buttons appear/disappear on hover.
+                .overlay(alignment: .trailing) {
+                    if showSplitButtons && (presentationMode != "minimal" || isHoveringTabBar) {
+                        splitButtons
+                            .saturation(tabBarSaturation)
+                            .transition(.opacity.animation(.easeInOut(duration: 0.14)))
+                    }
+                }
             }
         }
         .frame(height: TabBarMetrics.barHeight)
@@ -519,27 +518,14 @@ struct TabBarView: View {
     @ViewBuilder
     private var fadeOverlays: some View {
         let fadeWidth: CGFloat = 24
-        // In minimal mode, fades only appear on hover (matching split buttons).
-        let fadesActive = presentationMode != "minimal" || isHoveringTabBar
-
         HStack(spacing: 0) {
-            // Left fade mask: transparent → opaque
-            LinearGradient(
-                colors: [.clear, .black],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-            .frame(width: canScrollLeft && fadesActive ? fadeWidth : 0)
+            LinearGradient(colors: [.clear, .black], startPoint: .leading, endPoint: .trailing)
+                .frame(width: canScrollLeft ? fadeWidth : 0)
 
             Rectangle().fill(Color.black)
 
-            // Right fade mask: opaque → transparent
-            LinearGradient(
-                colors: [.black, .clear],
-                startPoint: .leading,
-                endPoint: .trailing
-            )
-            .frame(width: canScrollRight && fadesActive ? fadeWidth : 0)
+            LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)
+                .frame(width: canScrollRight ? fadeWidth : 0)
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Always show left/right fades when the tab list can scroll and render split buttons as an overlay to prevent layout jumps on hover. Improves visual consistency and interaction in `TabBarView`.

- **Bug Fixes**
  - Render split buttons via `.overlay(alignment: .trailing)` so the scroll view doesn’t re-layout when buttons appear/disappear.
  - Show fade masks based on `canScrollLeft`/`canScrollRight` only, removing hover/minimal-mode gating.

<sup>Written for commit d5e289effec44ff8a448747c377e6a50f327332c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Split buttons now positioned to prevent affecting scroll view layout, improving overall responsiveness.

* **Refactor**
  * Streamlined fade overlay masking behavior for more consistent visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->