### PR TITLE
Add hover fade mask behind split buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -182,6 +182,21 @@ struct TabBarView: View {
                 }
                 .frame(height: TabBarMetrics.barHeight)
                 .mask(fadeOverlays)
+                // Extra mask: fade content behind the buttons area on hover.
+                .mask {
+                    let showButtonFade = showSplitButtons && (presentationMode != "minimal" || isHoveringTabBar)
+                    HStack(spacing: 0) {
+                        Rectangle().fill(Color.black)
+                        if showButtonFade {
+                            LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)
+                                .frame(width: 24)
+                                .transition(.opacity.animation(.easeInOut(duration: 0.14)))
+                            Color.clear
+                                .frame(width: 120)
+                                .transition(.opacity.animation(.easeInOut(duration: 0.14)))
+                        }
+                    }
+                }
                 // Split buttons as overlay: doesn't affect scroll view
                 // layout, so no jump when buttons appear/disappear on hover.
                 .overlay(alignment: .trailing) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a hover-only gradient mask behind the split buttons in `TabBarView` to fade underlying content and improve focus when buttons appear. It shows when split buttons are enabled; in minimal mode it appears only on hover.

- **New Features**
  - Condition: `showSplitButtons && (presentationMode != "minimal" || isHoveringTabBar)`.
  - 24px leading gradient + 120px clear gap behind the buttons.
  - Smooth opacity transition with `.easeInOut(duration: 0.14)`.

<sup>Written for commit bbb699b60afe4260f83ea591f9e1c1dcc46ec0d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

