### PR TITLE
Tighten button mask width

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -192,7 +192,7 @@ struct TabBarView: View {
                                 .frame(width: 24)
                                 .transition(.opacity.animation(.easeInOut(duration: 0.14)))
                             Color.clear
-                                .frame(width: 120)
+                                .frame(width: 90)
                                 .transition(.opacity.animation(.easeInOut(duration: 0.14)))
                         }
                     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened the tab bar button mask width from 120pt to 90pt to better match sibling button spacing. This reduces overlap and makes taps more accurate.

<sup>Written for commit a3843b37b01842b27e15cf206247995a06706fba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

