### PR TITLE
Animate button mask smoothly

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -185,17 +185,16 @@ struct TabBarView: View {
                 // Extra mask: fade content behind the buttons area on hover.
                 .mask {
                     let showButtonFade = showSplitButtons && (presentationMode != "minimal" || isHoveringTabBar)
+                    let clearWidth: CGFloat = showButtonFade ? 90 : 0
+                    let fadeWidth: CGFloat = showButtonFade ? 24 : 0
                     HStack(spacing: 0) {
                         Rectangle().fill(Color.black)
-                        if showButtonFade {
-                            LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)
-                                .frame(width: 24)
-                                .transition(.opacity.animation(.easeInOut(duration: 0.14)))
-                            Color.clear
-                                .frame(width: 90)
-                                .transition(.opacity.animation(.easeInOut(duration: 0.14)))
-                        }
+                        LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)
+                            .frame(width: fadeWidth)
+                        Color.clear
+                            .frame(width: clearWidth)
                     }
+                    .animation(.easeInOut(duration: 0.14), value: showButtonFade)
                 }
                 // Split buttons as overlay: doesn't affect scroll view
                 // layout, so no jump when buttons appear/disappear on hover.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Animate the TabBar button fade mask by changing width instead of adding/removing views. This removes flicker and prevents layout jumps when hovering.

- **Bug Fixes**
  - Replace conditional gradient/clear mask with animated `fadeWidth`/`clearWidth` tied to `showButtonFade`.
  - Apply `.easeInOut(0.14)` animation via `value: showButtonFade` for smooth width transitions.

<sup>Written for commit b18b4c8db84d4102d010ab726ccbf97361c027c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

