### PR TITLE
Add blur behind buttons

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -187,13 +187,22 @@ struct TabBarView: View {
                     if showSplitButtons {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                         ZStack(alignment: .trailing) {
-                            // Fade mask: hides tab content behind buttons
+                            // Blur + fade behind buttons
                             HStack(spacing: 0) {
-                                LinearGradient(colors: [.clear, TabBarColors.barBackground(for: appearance)], startPoint: .leading, endPoint: .trailing)
+                                LinearGradient(colors: [.clear, .white], startPoint: .leading, endPoint: .trailing)
                                     .frame(width: 24)
-                                Rectangle().fill(TabBarColors.barBackground(for: appearance))
+                                Color.white
                                     .frame(width: 90)
                             }
+                            .background(.ultraThinMaterial)
+                            .mask(
+                                HStack(spacing: 0) {
+                                    LinearGradient(colors: [.clear, .black], startPoint: .leading, endPoint: .trailing)
+                                        .frame(width: 24)
+                                    Rectangle().fill(Color.black)
+                                        .frame(width: 90)
+                                }
+                            )
                             // Buttons on top
                             splitButtons
                                 .saturation(tabBarSaturation)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a blurred, masked backdrop behind the split buttons in `TabBarView` to improve contrast and hide content behind the buttons. Replaces the solid gradient with `.ultraThinMaterial` plus a fade mask for a smoother blend.

<sup>Written for commit 87aa97bff6a732f7e7c82850bf91f37e67f3612e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

