### PR TITLE
Theme color for button backdrop

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -186,23 +186,15 @@ struct TabBarView: View {
                 .overlay(alignment: .trailing) {
                     if showSplitButtons {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
+                        let bg = TabBarColors.barBackground(for: appearance)
                         ZStack(alignment: .trailing) {
-                            // Blur + fade behind buttons
+                            // Theme-colored backdrop with fade edge
                             HStack(spacing: 0) {
-                                LinearGradient(colors: [.clear, .white], startPoint: .leading, endPoint: .trailing)
+                                LinearGradient(colors: [bg.opacity(0), bg], startPoint: .leading, endPoint: .trailing)
                                     .frame(width: 24)
-                                Color.white
-                                    .frame(width: 90)
+                                Rectangle().fill(bg)
                             }
-                            .background(.ultraThinMaterial)
-                            .mask(
-                                HStack(spacing: 0) {
-                                    LinearGradient(colors: [.clear, .black], startPoint: .leading, endPoint: .trailing)
-                                        .frame(width: 24)
-                                    Rectangle().fill(Color.black)
-                                        .frame(width: 90)
-                                }
-                            )
+                            .frame(width: 114)
                             // Buttons on top
                             splitButtons
                                 .saturation(tabBarSaturation)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the theme bar background for the split-buttons backdrop in the tab bar to match light/dark themes and simplify the layer stack for a cleaner look.

- **Refactors**
  - Backdrop now uses `TabBarColors.barBackground(for:)` with a gradient fade and solid fill (114pt width).
  - Removed `.ultraThinMaterial`, white fills, and masking while preserving the fade edge.

<sup>Written for commit 5bcaa0c556def12f3110063ea2d3b992b8478f36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

