### PR TITLE
Blur + theme tint backdrop

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -188,13 +188,19 @@ struct TabBarView: View {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                         let bg = TabBarColors.barBackground(for: appearance)
                         ZStack(alignment: .trailing) {
-                            // Theme-colored backdrop with fade edge
-                            HStack(spacing: 0) {
-                                LinearGradient(colors: [bg.opacity(0), bg], startPoint: .leading, endPoint: .trailing)
-                                    .frame(width: 24)
-                                Rectangle().fill(bg)
+                            // Blur + theme tint backdrop with fade edge
+                            ZStack {
+                                Rectangle().fill(.ultraThinMaterial)
+                                Rectangle().fill(bg.opacity(0.7))
                             }
                             .frame(width: 114)
+                            .mask(
+                                HStack(spacing: 0) {
+                                    LinearGradient(colors: [.clear, .black], startPoint: .leading, endPoint: .trailing)
+                                        .frame(width: 24)
+                                    Color.black
+                                }
+                            )
                             // Buttons on top
                             splitButtons
                                 .saturation(tabBarSaturation)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the Tab Bar split-button backdrop with a layered blur (`.ultraThinMaterial`) tinted by the theme to improve legibility and blend with app themes. Preserves the fade edge via a mask and the 114 width; buttons remain unchanged.

<sup>Written for commit 995ee8a9ddda35347ea280deaabee95f77af8413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the split-buttons backdrop in the tab bar with an enhanced blur and tint effect for a more refined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->