### PR TITLE
More tint, less blur

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -191,7 +191,7 @@ struct TabBarView: View {
                             // Blur + theme tint backdrop with fade edge
                             ZStack {
                                 Rectangle().fill(.ultraThinMaterial)
-                                Rectangle().fill(bg.opacity(0.7))
+                                Rectangle().fill(bg.opacity(0.85))
                             }
                             .frame(width: 114)
                             .mask(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase theme tint opacity on the TabBarView backdrop from 0.7 to 0.85 to emphasize tint over blur and improve contrast. This makes sibling buttons crisper and easier to read without changing layout or behavior.

<sup>Written for commit cdb3989188f795f74aaf0c3c844787930f38ca90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

