### PR TITLE
Tint 0.2, clear border

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -191,7 +191,7 @@ struct TabBarView: View {
                             // Blur + theme tint backdrop with fade edge
                             ZStack {
                                 Rectangle().fill(.ultraThinMaterial)
-                                Rectangle().fill(bg.opacity(0.85))
+                                Rectangle().fill(bg.opacity(0.2))
                             }
                             .frame(width: 114)
                             .mask(
@@ -205,6 +205,7 @@ struct TabBarView: View {
                             splitButtons
                                 .saturation(tabBarSaturation)
                         }
+                        .padding(.bottom, 1)
                         .opacity(shouldShow ? 1 : 0)
                         .allowsHitTesting(shouldShow)
                         .animation(.easeInOut(duration: 0.14), value: shouldShow)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lightened the tab bar backdrop tint to 0.2 and added a 1pt bottom padding to clear the bottom border. This cleans up the tab bar and removes the faint edge.

<sup>Written for commit 8c3900d0fcd763e9f6a53a2e2b7ac2ca6a8ded2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

