### PR TITLE
Terminal bg color + scroll padding

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -125,6 +125,7 @@ struct TabBarView: View {
                             dropZoneAfterTabs
                         }
                         .padding(.horizontal, TabBarMetrics.barPadding)
+                        .padding(.trailing, showSplitButtons ? 114 : 0)
                         .animation(nil, value: pane.tabs.map(\.id))
                         .background(
                             GeometryReader { contentGeo in
@@ -186,7 +187,7 @@ struct TabBarView: View {
                 .overlay(alignment: .trailing) {
                     if showSplitButtons {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
-                        let bg = TabBarColors.barBackground(for: appearance)
+                        let bg = TabBarColors.paneBackground(for: appearance)
                         ZStack(alignment: .trailing) {
                             // Blur + theme tint backdrop with fade edge
                             ZStack {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Match the split-buttons overlay to the terminal/pane background and add trailing scroll padding to the tab bar. This prevents tabs from sitting under the sibling buttons and fixes the background mismatch.

- **Bug Fixes**
  - Use `TabBarColors.paneBackground` for the split-buttons overlay.
  - Add `.padding(.trailing, showSplitButtons ? 114 : 0)` so tab content doesn’t slide under the buttons.

<sup>Written for commit 69f8c51010b22fb9a13a44b10ff54565fc28d2c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

