### PR TITLE
Less blur, more tint

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -191,7 +191,7 @@ struct TabBarView: View {
                         ZStack(alignment: .trailing) {
                             // Blur + theme tint backdrop with fade edge
                             ZStack {
-                                Rectangle().fill(.ultraThinMaterial)
+                                Rectangle().fill(bg.opacity(0.75))
                                 Rectangle().fill(bg.opacity(0.2))
                             }
                             .frame(width: 114)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the blurred material backdrop in `TabBarView` with a theme-tinted panel using `bg.opacity(0.75)` to reduce visual noise and better match app themes while keeping the fade edge.

<sup>Written for commit a820e42b49c523f222aaf66c9ff1f4813539ea98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

