### PR TITLE
0.9 opacity

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -191,8 +191,7 @@ struct TabBarView: View {
                         ZStack(alignment: .trailing) {
                             // Blur + theme tint backdrop with fade edge
                             ZStack {
-                                Rectangle().fill(bg.opacity(0.75))
-                                Rectangle().fill(bg.opacity(0.2))
+                                Rectangle().fill(bg.opacity(0.9))
                             }
                             .frame(width: 114)
                             .mask(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified the TabBarView pane background to a single rectangle at 0.9 opacity for a cleaner look and more consistent tint. No layout or behavior changes.

- **Refactors**
  - Replaced two stacked rectangle fills (0.75 and 0.2) with one fill at 0.9 in the trailing pane background.

<sup>Written for commit 2850d5b108890035a2f94fcadd2626f0d11e98b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

