### PR TITLE
0.97 opacity

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -191,7 +191,7 @@ struct TabBarView: View {
                         ZStack(alignment: .trailing) {
                             // Blur + theme tint backdrop with fade edge
                             ZStack {
-                                Rectangle().fill(bg.opacity(0.9))
+                                Rectangle().fill(bg.opacity(0.97))
                             }
                             .frame(width: 114)
                             .mask(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the tab bar backdrop opacity from 0.9 to 0.97 in TabBarView to improve contrast and reduce content bleed-through, making buttons and labels easier to read.

<sup>Written for commit dc2438eb75bbc2916c7cc68d9f97dace7e08650b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

