### PR TITLE
Test opaque

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -191,7 +191,7 @@ struct TabBarView: View {
                         ZStack(alignment: .trailing) {
                             // Blur + theme tint backdrop with fade edge
                             ZStack {
-                                Rectangle().fill(bg.opacity(0.97))
+                                Rectangle().fill(bg)  // fully opaque to verify color
                             }
                             .frame(width: 114)
                             .mask(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the TabBar pane background fully opaque to verify color rendering and eliminate subtle translucency.
Replaces `bg.opacity(0.97)` with `bg` in the TabBarView backdrop rectangle.

<sup>Written for commit 43c1057b9d5e043dfb23bfedb47fee7e6298ffc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

