### PR TITLE
Test: red backdrop

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -189,18 +189,9 @@ struct TabBarView: View {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                         let bg = TabBarColors.paneBackground(for: appearance)
                         ZStack(alignment: .trailing) {
-                            // Blur + theme tint backdrop with fade edge
-                            ZStack {
-                                Rectangle().fill(bg)  // fully opaque to verify color
-                            }
-                            .frame(width: 114)
-                            .mask(
-                                HStack(spacing: 0) {
-                                    LinearGradient(colors: [.clear, .black], startPoint: .leading, endPoint: .trailing)
-                                        .frame(width: 24)
-                                    Color.black
-                                }
-                            )
+                            // Test: solid red to verify coverage
+                            Color.red
+                                .frame(width: 114)
                             // Buttons on top
                             splitButtons
                                 .saturation(tabBarSaturation)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the tab bar backdrop with a solid red block to verify width and coverage during testing. This makes the right-side pane behind the split buttons visibly red to confirm layering and hit area.

<sup>Written for commit 53bb2d7094a97ba5fe0d99927ed28cae5a4185e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

