### PR TITLE
Fix duplicate bg

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -189,9 +189,13 @@ struct TabBarView: View {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
                         let bg = TabBarColors.paneBackground(for: appearance)
                         ZStack(alignment: .trailing) {
-                            // Test: solid red to verify coverage
-                            Color.red
-                                .frame(width: 114)
+                            // Backdrop: fade gradient then solid
+                            HStack(spacing: 0) {
+                                LinearGradient(colors: [bg.opacity(0), bg], startPoint: .leading, endPoint: .trailing)
+                                    .frame(width: 24)
+                                Rectangle().fill(bg)
+                            }
+                            .frame(width: 114)
                             // Buttons on top
                             splitButtons
                                 .saturation(tabBarSaturation)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate background behind the tab bar split buttons by replacing the red test fill with a 24px fade gradient into a solid pane background (114px total), ensuring a single, consistent backdrop.

<sup>Written for commit 8b23d9cf14256df8d9559827018ffc4a00c9f2fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the split-button overlay's visual design with an elegant themed backdrop featuring gradient effects and improved color theming. The update replaces the previous placeholder styling with proper theme-aware colors while maintaining all existing functionality, including width specifications, button rendering, opacity levels, and smooth animation controls for a more polished experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->