### PR TITLE
Force opaque paneBackground

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -187,8 +187,7 @@ struct TabBarView: View {
                 .overlay(alignment: .trailing) {
                     if showSplitButtons {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
-                        let bg = TabBarColors.paneBackground(for: appearance)
-                        let bg = TabBarColors.paneBackground(for: appearance)
+                        let bg = Color(nsColor: TabBarColors.nsColorPaneBackground(for: appearance).withAlphaComponent(1.0))
                         ZStack(alignment: .trailing) {
                             // Backdrop: fade gradient then solid
                             HStack(spacing: 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the Tab Bar split-buttons pane background fully opaque to prevent content bleed-through and ensure consistent contrast in all appearances.

<sup>Written for commit 47edbc4561ed2f6db848bb4335bf9ef1f941aa17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

