### PR TITLE
Use barBackground

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -187,7 +187,7 @@ struct TabBarView: View {
                 .overlay(alignment: .trailing) {
                     if showSplitButtons {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
-                        let bg = Color(nsColor: TabBarColors.nsColorPaneBackground(for: appearance).withAlphaComponent(1.0))
+                        let bg = TabBarColors.barBackground(for: appearance)
                         ZStack(alignment: .trailing) {
                             // Backdrop: fade gradient then solid
                             HStack(spacing: 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use TabBarColors.barBackground(for: appearance) for the split-button backdrop in the tab bar. This aligns the overlay with the bar’s theme across appearances and removes the hard-coded color/alpha path.

<sup>Written for commit 7a0b7528a31331ae7a92171d3f7b32e399f643d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

