### PR TITLE
Terminal bg forced opaque

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -187,7 +187,7 @@ struct TabBarView: View {
                 .overlay(alignment: .trailing) {
                     if showSplitButtons {
                         let shouldShow = presentationMode != "minimal" || isHoveringTabBar
-                        let bg = TabBarColors.barBackground(for: appearance)
+                        let bg = Color(nsColor: TabBarColors.nsColorPaneBackground(for: appearance).withAlphaComponent(1.0))
                         ZStack(alignment: .trailing) {
                             // Backdrop: fade gradient then solid
                             HStack(spacing: 0) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the pane (terminal) background with full opacity for the tab bar split-button overlay to remove transparency artifacts and match the terminal color. This keeps the bar consistent in minimal mode and on hover.

<sup>Written for commit 5a5f9d93730c49428068aa6885acd028bc9b1531. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

