### PR TITLE
Make ThemedSplitView non-draggable for minimal mode

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -11,6 +11,18 @@ private class ThemedSplitView: NSSplitView {
     }
 
     override var isOpaque: Bool { false }
+
+    // NSSplitView's default `mouseDownCanMoveWindow` reports `true` whenever it
+    // appears opaque to AppKit, and even with `isOpaque=false` AppKit can
+    // promote it back to draggable when nested inside a non-titlebar window.
+    // In `presentationMode == "minimal"` (no titlebar drag region), AppKit was
+    // treating mouseDowns inside the LEFT pane of a horizontal split as window
+    // drag intents and consuming the mouseUp before SwiftUI's tap gesture
+    // could fire on tab items. Forcing `false` here keeps the entire pane
+    // hosting chain non-draggable so SwiftUI gestures get every click.
+    // See `NonDraggableHostingView` in SplitNodeView.swift for the rest of
+    // the chain.
+    override var mouseDownCanMoveWindow: Bool { false }
 }
 
 #if DEBUG


### PR DESCRIPTION
## Summary
NSSplitView's default `mouseDownCanMoveWindow` can promote back to `true` even with `isOpaque=false` when nested in a non-titlebar window. In `presentationMode "minimal"` (no titlebar drag region), AppKit was treating mouseDowns inside the LEFT pane of a horizontal split as window drag intents and consuming the mouseUp before SwiftUI's tap gesture could fire on tab items. Override to `false` to keep the entire pane hosting chain non-draggable.

## Test plan
- [ ] Verify on Intel mac that left pane tab clicks work in minimal mode after switching from right pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented accidental window dragging in minimal mode so tab clicks in the left pane register every time. We now force the split view to be non-draggable.

- **Bug Fixes**
  - Override `mouseDownCanMoveWindow` to `false` in `ThemedSplitView`.
  - Stops AppKit from treating left-pane clicks as drag intents in minimal presentation mode, fixing missed SwiftUI tap gestures.

<sup>Written for commit 0e5c7f9fc6999860da1a75a9926dfc550b3b4304. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mouse-down events in split pane areas were interfering with SwiftUI tap gestures on tab items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->