### PR TITLE
Fix command-hold shortcut hints without sidebar truncation

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -904,7 +904,11 @@ enum TabControlShortcutHintPolicy {
         let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
             .subtracting([.numericPad, .function, .capsLock])
         let shortcut = TabControlShortcutSettings.surfaceByNumberShortcut(defaults: defaults)
-        guard flags == shortcut.modifierFlags else { return nil }
+        if flags != shortcut.modifierFlags {
+            // Command-only hold reveals all hints (including pane hints), while
+            // control (or other modifiers) remains strict to the pane shortcut.
+            guard flags == [.command] else { return nil }
+        }
         return TabControlShortcutModifier(
             modifierFlags: shortcut.modifierFlags,
             symbol: shortcut.modifierSymbol

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -600,9 +600,13 @@ final class BonsplitTests: XCTestCase {
             defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
             XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
+                "⌃"
+            )
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [], defaults: defaults))
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control, .shift], defaults: defaults))
-            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command, .option], defaults: defaults))
 
             defaults.set(
                 shortcutData(
@@ -617,6 +621,10 @@ final class BonsplitTests: XCTestCase {
 
             let custom = TabControlShortcutHintPolicy.hintModifier(for: [.command, .option], defaults: defaults)
             XCTAssertEqual(custom?.symbol, "⌥⌘")
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
+                "⌥⌘"
+            )
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
         }
     }
@@ -635,7 +643,7 @@ final class BonsplitTests: XCTestCase {
             defaults.removeObject(forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
 
             XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol, "⌃")
-            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
+            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol, "⌃")
         }
     }
 


### PR DESCRIPTION
## Summary
- allow command-only hold to reveal pane hint pills even when pane number shortcuts use different modifiers
- keep control-specific hold behavior strict to configured pane shortcut modifiers
- update hint-policy tests for command-hold behavior

## Why
Holding Command should reveal all hints without forcing users to hold Control and without changing pane shortcut execution behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Command-only hold to show all pane hint pills without requiring Control, preventing sidebar hint truncation. Shortcut execution remains tied to the configured modifiers.

- **Bug Fixes**
  - Added a Command-only exception in hint detection so hints show even when pane shortcuts use different modifiers.
  - Updated tests to cover Command hold and custom modifier scenarios (symbol expectations and strictness).

<sup>Written for commit 7cd3b5e038e28264c6efc9492d17126e29c8765d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut hint display for modifier key combinations, allowing more accurate representation of command-based shortcuts.

* **Tests**
  * Updated shortcut modifier hint tests to reflect revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->