### PR TITLE
fix: clamp tab title font size

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabDragPreview.swift
+++ b/Sources/Bonsplit/Internal/Views/TabDragPreview.swift
@@ -5,6 +5,10 @@ struct TabDragPreview: View {
     let tab: TabItem
     let appearance: BonsplitConfiguration.Appearance
 
+    private var titleFontSize: CGFloat {
+        TabItemStyling.clampedTitleFontSize(appearance.tabTitleFontSize)
+    }
+
     var body: some View {
         HStack(spacing: TabBarMetrics.contentSpacing) {
             if let iconName = tab.icon {
@@ -14,7 +18,7 @@ struct TabDragPreview: View {
             }
 
             Text(tab.title)
-                .font(.system(size: appearance.tabTitleFontSize))
+                .font(.system(size: titleFontSize))
                 .lineLimit(1)
                 .foregroundStyle(TabBarColors.activeText(for: appearance))
         }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -20,6 +20,10 @@ enum TabItemStyling {
         hasRasterIcon ? 1.0 : tabSaturation
     }
 
+    static func clampedTitleFontSize(_ size: CGFloat) -> CGFloat {
+        max(8, size)
+    }
+
     static func shouldShowHoverBackground(isHovered: Bool, isSelected: Bool) -> Bool {
         isHovered && !isSelected
     }
@@ -119,7 +123,7 @@ struct TabItemView: View {
                 .onChange(of: tab.icon) { _ in updateGlobeFallback() }
 
                 Text(tab.title)
-                    .font(.system(size: appearance.tabTitleFontSize))
+                    .font(.system(size: titleFontSize))
                     .lineLimit(1)
                     .foregroundStyle(
                         isSelected
@@ -223,8 +227,12 @@ struct TabItemView: View {
         return max(accessorySlotSize, shortcutHintWidth(for: label) + positiveDebugInset)
     }
 
+    private var titleFontSize: CGFloat {
+        TabItemStyling.clampedTitleFontSize(appearance.tabTitleFontSize)
+    }
+
     private var accessoryFontSize: CGFloat {
-        max(8, appearance.tabTitleFontSize - 2)
+        max(8, titleFontSize - 2)
     }
 
     private var accessorySlotSize: CGFloat {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -567,6 +567,12 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
+    func testClampedTitleFontSizeUsesMinimumReadableSize() {
+        XCTAssertEqual(TabItemStyling.clampedTitleFontSize(3), 8)
+        XCTAssertEqual(TabItemStyling.clampedTitleFontSize(8), 8)
+        XCTAssertEqual(TabItemStyling.clampedTitleFontSize(13), 13)
+    }
+
     func testResolvedFaviconImageUsesIncomingDataWhenDecodable() {
         let existing = NSImage(size: NSSize(width: 12, height: 12))
         let incoming = NSImage(size: NSSize(width: 16, height: 16))


### PR DESCRIPTION
## Summary
- clamp tab title font size to a minimum readable size for tab items
- apply the same clamp to drag previews so the dragged label matches the live tab
- add unit coverage for the clamping helper

## Testing
- Not run locally (per repo policy)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp tab title font size to a minimum of 8pt so small labels stay readable and match drag previews. Accessory text now scales from the clamped title size.

- **Bug Fixes**
  - Apply clamped title size in TabItemView and TabDragPreview
  - Base accessory font size on the clamped title size
  - Add unit tests for the clamping helper

<sup>Written for commit 5d6b10bedefbe2b997ab04dffb27efefe4e53836. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tab titles now enforce a minimum readable font size, preventing text from becoming too small in tab views.

* **Tests**
  * Added test coverage to verify font size clamping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->