### PR TITLE
Tahoe 26 Liquid Glass: hide tab bar when tabBarHeight is 0; fix split divider position

### DIFF
--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -169,12 +169,14 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Tab bar
-            TabBarView(
-                pane: pane,
-                isFocused: isFocused,
-                showSplitButtons: showSplitButtons
-            )
+            // Tab bar: hidden when tabBarHeight is 0 AND only one tab in pane
+            if bonsplitController.configuration.appearance.tabBarHeight > 0 || pane.tabs.count > 1 {
+                TabBarView(
+                    pane: pane,
+                    isFocused: isFocused,
+                    showSplitButtons: showSplitButtons
+                )
+            }
 
             // Content area with drop zones
             contentAreaWithDropZones

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -225,8 +225,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             context.coordinator.initialDividerApplyAttempts = 0
 
             if animationOrigin != nil {
-                let targetPosition = availableSize * 0.5
-                splitState.dividerPosition = 0.5
+                let targetPosition = availableSize * splitState.dividerPosition
 
                 if shouldAnimate {
                     // Position at edge while new pane is hidden
@@ -253,9 +252,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                             duration: duration
                         ) {
                             context.coordinator.isAnimating = false
-                            // Re-assert exact 0.5 ratio to prevent pixel-rounding drift
-                            splitState.dividerPosition = 0.5
-                            context.coordinator.lastAppliedPosition = 0.5
+                            // Sync coordinator with the configured position
+                            context.coordinator.lastAppliedPosition = splitState.dividerPosition
 #if DEBUG
                             dlog(
                                 "split.entry.complete split=\(splitDebugToken) orientation=\(orientationToken) " +


### PR DESCRIPTION
Companion to [cmux #2647](https://github.com/manaflow-ai/cmux/pull/2647) (Adopt macOS 26 Liquid Glass design). cmux #2647 pins to this bonsplit SHA; merging here lets it bump pointer back to manaflow-ai/bonsplit#main.

## Summary
- **Fix split divider ignoring configured position** — split divider was snapping to the default position instead of the value supplied via `setDividerPosition`, visible when restoring a split from saved state
- **Hide tab bar when tabBarHeight is 0, show only when 2+ tabs** — on macOS 26, cmux hides the tab bar on single-tab panes for the cleaner Liquid Glass look, then re-shows it when a second tab is added. Previously the tab bar was forced on regardless of pane tab count

## Test plan
- [ ] Open a split, save layout, relaunch — divider lands at the saved position
- [ ] On macOS 26 with `tabBarHeight = 0`, single-tab pane shows no tab bar; opening a second tab in that pane restores the tab bar
- [ ] Single-tab pane on macOS ≤ 15 (default `tabBarHeight`) still shows the tab bar as before
- [ ] cmux PR #2647 green after pointer bumps to merged SHA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements macOS 26 Liquid Glass behavior by hiding the tab bar when `tabBarHeight` is 0 and only one tab is present. Fixes split divider to honor the configured position during animations and on restore.

- New Features
  - Hide the tab bar when `tabBarHeight = 0` and the pane has a single tab; show it once there are 2+ tabs.

- Bug Fixes
  - Use the configured `splitState.dividerPosition` instead of a hardcoded 0.5, so restored layouts and animated inserts land at the correct position.

<sup>Written for commit cfff8a9318f8131604681e4cb86c11925e01bf1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

