### PR TITLE
Add tab chrome debug renderer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,11 @@ let package = Package(
                 .process("Resources")
             ]
         ),
+        .executableTarget(
+            name: "BonsplitTabChromeDebugCLI",
+            dependencies: ["Bonsplit"],
+            path: "Sources/BonsplitTabChromeDebugCLI"
+        ),
         .testTarget(
             name: "BonsplitTests",
             dependencies: ["Bonsplit"],

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -6,8 +6,10 @@ enum TabBarColors {
     private enum Constants {
         static let darkTextAlpha: CGFloat = 0.82
         static let darkSecondaryTextAlpha: CGFloat = 0.62
+        static let darkTertiaryTextAlpha: CGFloat = 0.35
         static let lightTextAlpha: CGFloat = 0.82
         static let lightSecondaryTextAlpha: CGFloat = 0.68
+        static let lightTertiaryTextAlpha: CGFloat = 0.35
     }
 
     private static func chromeBackgroundColor(
@@ -46,6 +48,20 @@ enum TabBarColors {
 
         let alpha = secondary ? Constants.lightSecondaryTextAlpha : Constants.lightTextAlpha
         return NSColor.white.withAlphaComponent(alpha)
+    }
+
+    private static func effectiveInactiveSelectedIndicatorColor(
+        for appearance: BonsplitConfiguration.Appearance
+    ) -> NSColor {
+        guard let custom = chromeBackgroundColor(for: appearance) else {
+            return .tertiaryLabelColor
+        }
+
+        if custom.isBonsplitLightColor {
+            return NSColor.black.withAlphaComponent(Constants.darkTertiaryTextAlpha)
+        }
+
+        return NSColor.white.withAlphaComponent(Constants.lightTertiaryTextAlpha)
     }
 
     static func paneBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
@@ -173,6 +189,24 @@ enum TabBarColors {
     static func dropIndicator(for appearance: BonsplitConfiguration.Appearance) -> Color {
         _ = appearance
         return dropIndicator
+    }
+
+    static func selectedIndicator(
+        for appearance: BonsplitConfiguration.Appearance,
+        focused: Bool
+    ) -> Color {
+        Color(nsColor: nsColorSelectedIndicator(for: appearance, focused: focused))
+    }
+
+    static func nsColorSelectedIndicator(
+        for appearance: BonsplitConfiguration.Appearance,
+        focused: Bool
+    ) -> NSColor {
+        if focused {
+            return NSColor.controlAccentColor
+        }
+
+        return effectiveInactiveSelectedIndicatorColor(for: appearance)
     }
 
     static var focusRing: Color {

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -15,7 +15,7 @@ enum TabBarMetrics {
     static let tabCornerRadius: CGFloat = 0
     static let tabHorizontalPadding: CGFloat = 6
     static let tabSpacing: CGFloat = 0
-    static let activeIndicatorHeight: CGFloat = 2
+    static let activeIndicatorHeight: CGFloat = 1.5
 
     // MARK: - Tab Content
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -246,6 +246,7 @@ struct TabBarView: View {
         TabItemView(
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
+            isPaneFocused: isFocused,
             showsZoomIndicator: showsZoomIndicator,
             appearance: appearance,
             saturation: tabBarSaturation,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -39,6 +39,7 @@ enum TabItemStyling {
 struct TabItemView: View {
     let tab: TabItem
     let isSelected: Bool
+    let isPaneFocused: Bool
     let showsZoomIndicator: Bool
     let appearance: BonsplitConfiguration.Appearance
     let saturation: Double
@@ -460,7 +461,7 @@ struct TabItemView: View {
             // Top accent indicator for selected tab
             if isSelected {
                 Rectangle()
-                    .fill(Color.accentColor)
+                    .fill(TabBarColors.selectedIndicator(for: appearance, focused: isPaneFocused))
                     .frame(height: TabBarMetrics.activeIndicatorHeight)
             }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -74,28 +74,7 @@ struct TabItemView: View {
                     : TabBarColors.inactiveText(for: appearance)
                 let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { NSImage(data: $0) }
 
-                Group {
-                    if tab.isLoading {
-                        // Slightly smaller than the icon slot so it reads cleaner at tab scale.
-                        TabLoadingSpinner(size: iconSlotSize * 0.86, color: iconTint)
-                    } else if let image = faviconImage {
-                        FaviconIconView(image: image)
-                            .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
-                            .clipped()
-                    } else if let iconName = tab.icon {
-                        if iconName == "globe", !showGlobeFallback {
-                            // Avoid a distracting "globe -> favicon" flash: show a neutral placeholder
-                            // briefly while the favicon fetch finishes. If no favicon arrives, we
-                            // reveal the globe after a short delay.
-                            RoundedRectangle(cornerRadius: 3)
-                                .stroke(iconTint.opacity(0.25), lineWidth: 1)
-                        } else {
-                            Image(systemName: iconName)
-                                .font(.system(size: glyphSize(for: iconName)))
-                                .foregroundStyle(iconTint)
-                        }
-                    }
-                }
+                iconContent(iconSlotSize: iconSlotSize, iconTint: iconTint, faviconImage: faviconImage)
                 // Keep downloaded favicon bitmaps in full color even for inactive tab bars.
                 .saturation(TabItemStyling.iconSaturation(hasRasterIcon: faviconImage != nil, tabSaturation: saturation))
                 .transaction { tx in
@@ -119,7 +98,7 @@ struct TabItemView: View {
                 .onChange(of: tab.icon) { _ in updateGlobeFallback() }
 
                 Text(tab.title)
-                    .font(.system(size: TabBarMetrics.titleFontSize))
+                    .font(.system(size: appearance.tabTitleFontSize))
                     .lineLimit(1)
                     .foregroundStyle(
                         isSelected
@@ -133,19 +112,20 @@ struct TabItemView: View {
                         onZoomToggle()
                     } label: {
                         Image(systemName: "arrow.up.left.and.arrow.down.right")
-                            .font(.system(size: max(8, TabBarMetrics.titleFontSize - 2), weight: .semibold))
+                            .font(.system(size: accessoryFontSize, weight: .semibold))
                             .foregroundStyle(
-                                isZoomHovered
+                                resolvedIsZoomHovered || resolvedIsZoomPressed
                                     ? TabBarColors.activeText(for: appearance)
                                     : TabBarColors.inactiveText(for: appearance)
                             )
-                            .frame(width: TabBarMetrics.closeButtonSize, height: TabBarMetrics.closeButtonSize)
+                            .frame(width: accessorySlotSize, height: accessorySlotSize)
                             .background(
                                 Circle()
                                     .fill(
-                                        isZoomHovered
-                                            ? TabBarColors.hoveredTabBackground(for: appearance)
-                                            : .clear
+                                        accessoryBackgroundColor(
+                                            isHovered: resolvedIsZoomHovered,
+                                            isPressed: resolvedIsZoomPressed
+                                        )
                                     )
                             )
                     }
@@ -206,6 +186,41 @@ struct TabItemView: View {
         return TabBarMetrics.iconSize
     }
 
+    @ViewBuilder
+    private func iconContent(
+        iconSlotSize: CGFloat,
+        iconTint: Color,
+        faviconImage: NSImage?
+    ) -> some View {
+        let spinnerSize = iconSlotSize * 0.86
+        let spinnerPhaseDegrees = resolvedSpinnerPhaseDegrees
+
+        if tab.isLoading {
+            // Slightly smaller than the icon slot so it reads cleaner at tab scale.
+            TabLoadingSpinner(
+                size: spinnerSize,
+                color: iconTint,
+                fixedPhaseDegrees: spinnerPhaseDegrees
+            )
+        } else if let faviconImage {
+            FaviconIconView(image: faviconImage)
+                .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
+                .clipped()
+        } else if let iconName = tab.icon {
+            if iconName == "globe", !showGlobeFallback {
+                // Avoid a distracting "globe -> favicon" flash: show a neutral placeholder
+                // briefly while the favicon fetch finishes. If no favicon arrives, we
+                // reveal the globe after a short delay.
+                RoundedRectangle(cornerRadius: 3)
+                    .stroke(iconTint.opacity(0.25), lineWidth: 1)
+            } else {
+                Image(systemName: iconName)
+                    .font(.system(size: glyphSize(for: iconName)))
+                    .foregroundStyle(iconTint)
+            }
+        }
+    }
+
     private var shortcutHintLabel: String? {
         guard let controlShortcutDigit else { return nil }
         return "\(shortcutModifierSymbol)\(controlShortcutDigit)"
@@ -217,14 +232,22 @@ struct TabItemView: View {
 
     private var shortcutHintSlotWidth: CGFloat {
         guard let label = shortcutHintLabel else {
-            return TabBarMetrics.closeButtonSize
+            return accessorySlotSize
         }
         let positiveDebugInset = max(0, CGFloat(TabControlShortcutHintDebugSettings.clamped(controlShortcutHintXOffset))) + 2
-        return max(TabBarMetrics.closeButtonSize, shortcutHintWidth(for: label) + positiveDebugInset)
+        return max(accessorySlotSize, shortcutHintWidth(for: label) + positiveDebugInset)
+    }
+
+    private var accessoryFontSize: CGFloat {
+        max(8, appearance.tabTitleFontSize - 2)
+    }
+
+    private var accessorySlotSize: CGFloat {
+        min(TabBarMetrics.tabHeight, max(TabBarMetrics.closeButtonSize, ceil(accessoryFontSize + 4)))
     }
 
     private func shortcutHintWidth(for label: String) -> CGFloat {
-        let font = NSFont.systemFont(ofSize: max(8, TabBarMetrics.titleFontSize - 2), weight: .semibold)
+        let font = NSFont.systemFont(ofSize: accessoryFontSize, weight: .semibold)
         let textWidth = (label as NSString).size(withAttributes: [.font: font]).width
         return ceil(textWidth) + 8
     }
@@ -234,15 +257,15 @@ struct TabItemView: View {
         ZStack(alignment: .center) {
             if let shortcutHintLabel {
                 Text(shortcutHintLabel)
-                    .font(.system(size: max(8, TabBarMetrics.titleFontSize - 2), weight: .semibold, design: .rounded))
+                    .font(.system(size: accessoryFontSize, weight: .semibold, design: .rounded))
                     .monospacedDigit()
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
-                    .foregroundStyle(
-                        isSelected
-                            ? TabBarColors.activeText(for: appearance)
-                            : TabBarColors.inactiveText(for: appearance)
-                    )
+                .foregroundStyle(
+                    isSelected
+                        ? TabBarColors.activeText(for: appearance)
+                        : TabBarColors.inactiveText(for: appearance)
+                )
                     .padding(.horizontal, 4)
                     .padding(.vertical, 1)
                     .background(
@@ -266,7 +289,7 @@ struct TabItemView: View {
                 .opacity(showsShortcutHint ? 0 : 1)
                 .allowsHitTesting(!showsShortcutHint)
         }
-        .frame(width: shortcutHintSlotWidth, height: TabBarMetrics.closeButtonSize, alignment: .center)
+        .frame(width: shortcutHintSlotWidth, height: accessorySlotSize, alignment: .center)
         .animation(.easeInOut(duration: 0.14), value: showsShortcutHint)
     }
 
@@ -427,7 +450,7 @@ struct TabItemView: View {
     private var tabBackground: some View {
         ZStack(alignment: .top) {
             // Background fill (hover)
-            if TabItemStyling.shouldShowHoverBackground(isHovered: isHovered, isSelected: isSelected) {
+            if TabItemStyling.shouldShowHoverBackground(isHovered: resolvedIsHovered, isSelected: isSelected) {
                 Rectangle()
                     .fill(TabBarColors.hoveredTabBackground(for: appearance))
             } else {
@@ -457,7 +480,7 @@ struct TabItemView: View {
     private var closeOrDirtyIndicator: some View {
         ZStack {
             // Dirty indicator (shown when dirty and not hovering, hidden for selected tab)
-            if (!isSelected && !isHovered && !isCloseHovered) && (tab.isDirty || tab.showsNotificationBadge) {
+            if (!isSelected && !resolvedIsHovered && !resolvedIsCloseHovered) && (tab.isDirty || tab.showsNotificationBadge) {
                 HStack(spacing: 2) {
                     if tab.showsNotificationBadge {
                         Circle()
@@ -474,14 +497,14 @@ struct TabItemView: View {
             }
 
             if tab.isPinned {
-                if isSelected || isHovered || isCloseHovered || (!tab.isDirty && !tab.showsNotificationBadge) {
+                if isSelected || resolvedIsHovered || resolvedIsCloseHovered || (!tab.isDirty && !tab.showsNotificationBadge) {
                     Image(systemName: "pin.fill")
                         .font(.system(size: TabBarMetrics.closeIconSize, weight: .semibold))
                         .foregroundStyle(TabBarColors.inactiveText(for: appearance))
-                        .frame(width: TabBarMetrics.closeButtonSize, height: TabBarMetrics.closeButtonSize)
+                        .frame(width: accessorySlotSize, height: accessorySlotSize)
                         .saturation(saturation)
                 }
-            } else if isSelected || isHovered || isCloseHovered {
+            } else if isSelected || resolvedIsHovered || resolvedIsCloseHovered {
                 // Close button (always visible on active tab, shown on hover for others)
                 Button {
                     onClose()
@@ -489,17 +512,18 @@ struct TabItemView: View {
                     Image(systemName: "xmark")
                         .font(.system(size: TabBarMetrics.closeIconSize, weight: .semibold))
                         .foregroundStyle(
-                            isCloseHovered
+                            resolvedIsCloseHovered || resolvedIsClosePressed
                                 ? TabBarColors.activeText(for: appearance)
                                 : TabBarColors.inactiveText(for: appearance)
                         )
-                        .frame(width: TabBarMetrics.closeButtonSize, height: TabBarMetrics.closeButtonSize)
+                        .frame(width: accessorySlotSize, height: accessorySlotSize)
                         .background(
                             Circle()
                                 .fill(
-                                    isCloseHovered
-                                        ? TabBarColors.hoveredTabBackground(for: appearance)
-                                        : .clear
+                                    accessoryBackgroundColor(
+                                        isHovered: resolvedIsCloseHovered,
+                                        isPressed: resolvedIsClosePressed
+                                    )
                                 )
                         )
                 }
@@ -511,28 +535,89 @@ struct TabItemView: View {
             }
         }
         .frame(width: TabBarMetrics.closeButtonSize, height: TabBarMetrics.closeButtonSize)
-        .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: isHovered)
-        .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: isCloseHovered)
+        .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: resolvedIsHovered)
+        .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: resolvedIsCloseHovered)
+    }
+
+    private func accessoryBackgroundColor(isHovered: Bool, isPressed: Bool) -> Color {
+        if isPressed {
+            return TabBarColors.activeTabBackground(for: appearance)
+        }
+        if isHovered {
+            return TabBarColors.hoveredTabBackground(for: appearance)
+        }
+        return .clear
+    }
+
+    private var resolvedIsHovered: Bool {
+#if DEBUG
+        BonsplitTabChromeDebugContext.current?.isHovered ?? isHovered
+#else
+        isHovered
+#endif
+    }
+
+    private var resolvedIsCloseHovered: Bool {
+#if DEBUG
+        BonsplitTabChromeDebugContext.current?.isCloseHovered ?? isCloseHovered
+#else
+        isCloseHovered
+#endif
+    }
+
+    private var resolvedIsClosePressed: Bool {
+#if DEBUG
+        BonsplitTabChromeDebugContext.current?.isClosePressed ?? false
+#else
+        false
+#endif
+    }
+
+    private var resolvedIsZoomHovered: Bool {
+#if DEBUG
+        BonsplitTabChromeDebugContext.current?.isZoomHovered ?? isZoomHovered
+#else
+        isZoomHovered
+#endif
+    }
+
+    private var resolvedIsZoomPressed: Bool {
+#if DEBUG
+        BonsplitTabChromeDebugContext.current?.isZoomPressed ?? false
+#else
+        false
+#endif
+    }
+
+    private var resolvedSpinnerPhaseDegrees: Double? {
+#if DEBUG
+        BonsplitTabChromeDebugContext.current?.fixedSpinnerPhaseDegrees
+#else
+        nil
+#endif
     }
 }
 
 private struct TabLoadingSpinner: View {
     let size: CGFloat
     let color: Color
+    let fixedPhaseDegrees: Double?
+
+    init(size: CGFloat, color: Color, fixedPhaseDegrees: Double? = nil) {
+        self.size = size
+        self.color = color
+        self.fixedPhaseDegrees = fixedPhaseDegrees
+    }
 
     var body: some View {
         TimelineView(.animation) { context in
-            let t = context.date.timeIntervalSinceReferenceDate
-            // 0.9s per revolution feels a bit snappier at tab-icon scale.
-            let angle = (t.truncatingRemainder(dividingBy: 0.9) / 0.9) * 360.0
-
             ZStack {
                 Circle()
                     .stroke(color.opacity(0.20), lineWidth: ringWidth)
                 Circle()
                     .trim(from: 0.0, to: 0.28)
                     .stroke(color, style: StrokeStyle(lineWidth: ringWidth, lineCap: .round))
-                    .rotationEffect(.degrees(angle))
+                    .rotationEffect(.degrees(spinnerAngle(for: context.date)))
             }
             .frame(width: size, height: size)
         }
@@ -540,6 +625,15 @@ private struct TabLoadingSpinner: View {
 
     private var ringWidth: CGFloat {
         max(1.6, size * 0.14)
+    }
+
+    private func spinnerAngle(for date: Date) -> Double {
+        if let fixedPhaseDegrees {
+            return fixedPhaseDegrees
+        }
+        let t = date.timeIntervalSinceReferenceDate
+        // 0.9s per revolution feels a bit snappier at tab-icon scale.
+        return (t.truncatingRemainder(dividingBy: 0.9) / 0.9) * 360.0
     }
 }
 

--- a/Sources/Bonsplit/Public/BonsplitTabChromeDebug.swift
+++ b/Sources/Bonsplit/Public/BonsplitTabChromeDebug.swift
@@ -108,6 +108,7 @@ public enum BonsplitTabChromeDebugRenderer {
         let rootView = TabItemView(
             tab: tab,
             isSelected: scenario.isSelected,
+            isPaneFocused: scenario.saturation > 0.5,
             showsZoomIndicator: scenario.showsZoomIndicator,
             appearance: scenario.appearance,
             saturation: scenario.saturation,

--- a/Sources/Bonsplit/Public/BonsplitTabChromeDebug.swift
+++ b/Sources/Bonsplit/Public/BonsplitTabChromeDebug.swift
@@ -1,0 +1,173 @@
+#if DEBUG
+import AppKit
+import SwiftUI
+
+public struct BonsplitTabChromeDebugScenario: Sendable {
+    public var tab: Tab
+    public var isSelected: Bool
+    public var isHovered: Bool
+    public var isCloseHovered: Bool
+    public var isClosePressed: Bool
+    public var showsZoomIndicator: Bool
+    public var isZoomHovered: Bool
+    public var isZoomPressed: Bool
+    public var appearance: BonsplitConfiguration.Appearance
+    public var saturation: Double
+    public var fixedSpinnerPhaseDegrees: Double?
+
+    public init(
+        tab: Tab,
+        isSelected: Bool,
+        isHovered: Bool,
+        isCloseHovered: Bool,
+        isClosePressed: Bool,
+        showsZoomIndicator: Bool,
+        isZoomHovered: Bool,
+        isZoomPressed: Bool,
+        appearance: BonsplitConfiguration.Appearance = .default,
+        saturation: Double = 1.0,
+        fixedSpinnerPhaseDegrees: Double? = nil
+    ) {
+        self.tab = tab
+        self.isSelected = isSelected
+        self.isHovered = isHovered
+        self.isCloseHovered = isCloseHovered
+        self.isClosePressed = isClosePressed
+        self.showsZoomIndicator = showsZoomIndicator
+        self.isZoomHovered = isZoomHovered
+        self.isZoomPressed = isZoomPressed
+        self.appearance = appearance
+        self.saturation = saturation
+        self.fixedSpinnerPhaseDegrees = fixedSpinnerPhaseDegrees
+    }
+}
+
+struct BonsplitTabChromeDebugInteractionState {
+    let isHovered: Bool
+    let isCloseHovered: Bool
+    let isClosePressed: Bool
+    let isZoomHovered: Bool
+    let isZoomPressed: Bool
+    let fixedSpinnerPhaseDegrees: Double?
+}
+
+enum BonsplitTabChromeDebugContext {
+    @MainActor static var current: BonsplitTabChromeDebugInteractionState?
+}
+
+@MainActor
+public enum BonsplitTabChromeDebugRenderer {
+    public static func renderImage(
+        scenario: BonsplitTabChromeDebugScenario,
+        scale: CGFloat = 2
+    ) -> NSImage? {
+        let tab = TabItem(
+            id: scenario.tab.id.uuid,
+            title: scenario.tab.title,
+            hasCustomTitle: scenario.tab.hasCustomTitle,
+            icon: scenario.tab.icon,
+            iconImageData: scenario.tab.iconImageData,
+            kind: scenario.tab.kind,
+            isDirty: scenario.tab.isDirty,
+            showsNotificationBadge: scenario.tab.showsNotificationBadge,
+            isLoading: scenario.tab.isLoading,
+            isPinned: scenario.tab.isPinned
+        )
+
+        let contextMenuState = TabContextMenuState(
+            isPinned: scenario.tab.isPinned,
+            isUnread: scenario.tab.showsNotificationBadge,
+            isBrowser: scenario.tab.kind == "browser",
+            isTerminal: scenario.tab.kind == "terminal",
+            hasCustomTitle: scenario.tab.hasCustomTitle,
+            canCloseToLeft: false,
+            canCloseToRight: false,
+            canCloseOthers: false,
+            canMoveToLeftPane: false,
+            canMoveToRightPane: false,
+            isZoomed: scenario.showsZoomIndicator,
+            hasSplits: scenario.showsZoomIndicator,
+            shortcuts: [:]
+        )
+
+        let debugInteractionState = BonsplitTabChromeDebugInteractionState(
+            isHovered: scenario.isHovered,
+            isCloseHovered: scenario.isCloseHovered,
+            isClosePressed: scenario.isClosePressed,
+            isZoomHovered: scenario.isZoomHovered,
+            isZoomPressed: scenario.isZoomPressed,
+            fixedSpinnerPhaseDegrees: scenario.fixedSpinnerPhaseDegrees
+        )
+
+        let previousDebugState = BonsplitTabChromeDebugContext.current
+        BonsplitTabChromeDebugContext.current = debugInteractionState
+        defer {
+            BonsplitTabChromeDebugContext.current = previousDebugState
+        }
+
+        let rootView = TabItemView(
+            tab: tab,
+            isSelected: scenario.isSelected,
+            showsZoomIndicator: scenario.showsZoomIndicator,
+            appearance: scenario.appearance,
+            saturation: scenario.saturation,
+            controlShortcutDigit: nil,
+            showsControlShortcutHint: false,
+            shortcutModifierSymbol: "^",
+            contextMenuState: contextMenuState,
+            onSelect: {},
+            onClose: {},
+            onZoomToggle: {},
+            onContextAction: { _ in }
+        )
+        .allowsHitTesting(false)
+
+        let host = NSHostingView(rootView: rootView)
+        let fittingWidth = ceil(host.fittingSize.width)
+        host.frame = CGRect(x: 0, y: 0, width: fittingWidth, height: TabBarMetrics.tabHeight)
+        host.layoutSubtreeIfNeeded()
+        return bonsplitTabChromeSnapshotImage(
+            for: host,
+            scale: scale,
+            backgroundColor: TabBarColors.nsColorPaneBackground(for: scenario.appearance)
+        )
+    }
+}
+
+private func bonsplitTabChromeSnapshotImage(
+    for view: NSView,
+    scale: CGFloat,
+    backgroundColor: NSColor
+) -> NSImage? {
+    guard view.bounds.width > 0, view.bounds.height > 0 else { return nil }
+    let width = max(1, Int(ceil(view.bounds.width * scale)))
+    let height = max(1, Int(ceil(view.bounds.height * scale)))
+    guard let rep = NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: width,
+        pixelsHigh: height,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .deviceRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+    ) else {
+        return nil
+    }
+    rep.size = view.bounds.size
+    if let context = NSGraphicsContext(bitmapImageRep: rep) {
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        backgroundColor.setFill()
+        NSBezierPath(rect: view.bounds).fill()
+        context.flushGraphics()
+        NSGraphicsContext.restoreGraphicsState()
+    }
+    view.cacheDisplay(in: view.bounds, to: rep)
+    let image = NSImage(size: view.bounds.size)
+    image.addRepresentation(rep)
+    return image
+}
+#endif

--- a/Sources/BonsplitTabChromeDebugCLI/main.swift
+++ b/Sources/BonsplitTabChromeDebugCLI/main.swift
@@ -1,0 +1,379 @@
+#if DEBUG
+import AppKit
+import Bonsplit
+import Foundation
+
+private struct ExportManifest: Decodable {
+    let generatedAt: String
+    let scenarioResults: [ExportScenario]
+}
+
+private struct ExportScenario: Decodable {
+    let id: String
+    let title: String
+    let appKitPNG: String
+    let scenario: ScenarioSpec
+}
+
+private struct ScenarioSpec: Decodable {
+    let tab: TabSpec
+    let isSelected: Bool
+    let isHovered: Bool
+    let isCloseHovered: Bool
+    let isClosePressed: Bool
+    let showsZoomIndicator: Bool
+    let isZoomHovered: Bool
+    let isZoomPressed: Bool
+    let appearance: AppearanceSpec
+}
+
+private struct TabSpec: Decodable {
+    let id: UUID
+    let title: String
+    let hasCustomTitle: Bool
+    let icon: String?
+    let iconImageDataBase64: String?
+    let kind: String?
+    let isDirty: Bool
+    let showsNotificationBadge: Bool
+    let isLoading: Bool
+    let isPinned: Bool
+}
+
+private struct AppearanceSpec: Decodable {
+    let tabBarHeight: Double
+    let tabMinWidth: Double
+    let tabMaxWidth: Double
+    let tabTitleFontSize: Double
+    let tabSpacing: Double
+    let minimumPaneWidth: Double
+    let minimumPaneHeight: Double
+    let showSplitButtons: Bool
+    let splitButtonsOnHover: Bool
+    let tabBarLeadingInset: Double
+    let splitButtonTooltips: SplitButtonTooltipsSpec
+    let animationDuration: Double
+    let enableAnimations: Bool
+    let chromeColors: ChromeColorsSpec
+}
+
+private struct SplitButtonTooltipsSpec: Decodable {
+    let newTerminal: String
+    let newBrowser: String
+    let splitRight: String
+    let splitDown: String
+}
+
+private struct ChromeColorsSpec: Decodable {
+    let backgroundHex: String?
+    let borderHex: String?
+}
+
+private struct DiffMetrics: Codable {
+    let width: Int
+    let height: Int
+    let differingPixelCount: Int
+    let totalPixelCount: Int
+    let maxChannelDelta: Int
+    let meanAbsoluteChannelDelta: Double
+    let matchingPixels: Bool
+}
+
+private struct ComparisonScenarioResult: Codable {
+    let id: String
+    let title: String
+    let appKitPNG: String
+    let referencePNG: String
+    let diffPNG: String
+    let metrics: DiffMetrics
+}
+
+private struct ComparisonManifest: Codable {
+    let generatedAt: String
+    let scenarioResults: [ComparisonScenarioResult]
+}
+
+@main
+struct BonsplitTabChromeDebugCLI {
+    @MainActor
+    static func main() throws {
+        _ = NSApplication.shared
+
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        guard arguments.count == 1 else {
+            fputs("usage: BonsplitTabChromeDebugCLI <export-dir>\n", stderr)
+            Foundation.exit(64)
+        }
+
+        let exportDirectory = URL(fileURLWithPath: arguments[0], isDirectory: true)
+        let manifestURL = exportDirectory.appendingPathComponent("manifest.json")
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(ExportManifest.self, from: data)
+
+        var comparisonResults: [ComparisonScenarioResult] = []
+        for scenarioResult in manifest.scenarioResults {
+            let referenceName = "\(scenarioResult.id)-reference.png"
+            let diffName = "\(scenarioResult.id)-diff.png"
+            let appKitURL = exportDirectory.appendingPathComponent(scenarioResult.appKitPNG)
+            let referenceURL = exportDirectory.appendingPathComponent(referenceName)
+            let diffURL = exportDirectory.appendingPathComponent(diffName)
+
+            guard let appKitImage = NSImage(contentsOf: appKitURL),
+                  let referenceImage = BonsplitTabChromeDebugRenderer.renderImage(
+                    scenario: bonsplitScenario(from: scenarioResult.scenario),
+                    scale: 2
+                  ),
+                  let diff = diffImages(appKitImage: appKitImage, referenceImage: referenceImage) else {
+                continue
+            }
+
+            try writePNG(image: referenceImage, to: referenceURL)
+            try writePNG(image: diff.image, to: diffURL)
+            comparisonResults.append(
+                ComparisonScenarioResult(
+                    id: scenarioResult.id,
+                    title: scenarioResult.title,
+                    appKitPNG: scenarioResult.appKitPNG,
+                    referencePNG: referenceName,
+                    diffPNG: diffName,
+                    metrics: diff.metrics
+                )
+            )
+        }
+
+        let formatter = ISO8601DateFormatter()
+        let comparisonManifest = ComparisonManifest(
+            generatedAt: formatter.string(from: Date()),
+            scenarioResults: comparisonResults
+        )
+        let comparisonURL = exportDirectory.appendingPathComponent("comparison-manifest.json")
+        let comparisonData = try JSONEncoder().encode(comparisonManifest)
+        try comparisonData.write(to: comparisonURL, options: .atomic)
+    }
+
+    @MainActor
+    private static func bonsplitScenario(from spec: ScenarioSpec) -> BonsplitTabChromeDebugScenario {
+        BonsplitTabChromeDebugScenario(
+            tab: Tab(
+                id: TabID(uuid: spec.tab.id),
+                title: spec.tab.title,
+                hasCustomTitle: spec.tab.hasCustomTitle,
+                icon: spec.tab.icon,
+                iconImageData: spec.tab.iconImageDataBase64.flatMap { Data(base64Encoded: $0) },
+                kind: spec.tab.kind,
+                isDirty: spec.tab.isDirty,
+                showsNotificationBadge: spec.tab.showsNotificationBadge,
+                isLoading: spec.tab.isLoading,
+                isPinned: spec.tab.isPinned
+            ),
+            isSelected: spec.isSelected,
+            isHovered: spec.isHovered,
+            isCloseHovered: spec.isCloseHovered,
+            isClosePressed: spec.isClosePressed,
+            showsZoomIndicator: spec.showsZoomIndicator,
+            isZoomHovered: spec.isZoomHovered,
+            isZoomPressed: spec.isZoomPressed,
+            appearance: BonsplitConfiguration.Appearance(
+                tabBarHeight: spec.appearance.tabBarHeight,
+                tabMinWidth: spec.appearance.tabMinWidth,
+                tabMaxWidth: spec.appearance.tabMaxWidth,
+                tabTitleFontSize: spec.appearance.tabTitleFontSize,
+                tabSpacing: spec.appearance.tabSpacing,
+                minimumPaneWidth: spec.appearance.minimumPaneWidth,
+                minimumPaneHeight: spec.appearance.minimumPaneHeight,
+                showSplitButtons: spec.appearance.showSplitButtons,
+                splitButtonsOnHover: spec.appearance.splitButtonsOnHover,
+                tabBarLeadingInset: spec.appearance.tabBarLeadingInset,
+                splitButtonTooltips: BonsplitConfiguration.SplitButtonTooltips(
+                    newTerminal: spec.appearance.splitButtonTooltips.newTerminal,
+                    newBrowser: spec.appearance.splitButtonTooltips.newBrowser,
+                    splitRight: spec.appearance.splitButtonTooltips.splitRight,
+                    splitDown: spec.appearance.splitButtonTooltips.splitDown
+                ),
+                animationDuration: spec.appearance.animationDuration,
+                enableAnimations: spec.appearance.enableAnimations,
+                chromeColors: BonsplitConfiguration.Appearance.ChromeColors(
+                    backgroundHex: spec.appearance.chromeColors.backgroundHex,
+                    borderHex: spec.appearance.chromeColors.borderHex
+                )
+            ),
+            saturation: 1.0,
+            fixedSpinnerPhaseDegrees: spec.tab.isLoading ? 0 : nil
+        )
+    }
+
+    private static func diffImages(
+        appKitImage: NSImage,
+        referenceImage: NSImage
+    ) -> (image: NSImage, metrics: DiffMetrics)? {
+        guard let appKitBuffer = rgbaImageBuffer(from: appKitImage),
+              let referenceBuffer = rgbaImageBuffer(from: referenceImage) else {
+            return nil
+        }
+
+        let width = max(appKitBuffer.width, referenceBuffer.width)
+        let height = max(appKitBuffer.height, referenceBuffer.height)
+        guard let resizedAppKit = resizeImageBuffer(appKitBuffer, width: width, height: height),
+              let resizedReference = resizeImageBuffer(referenceBuffer, width: width, height: height) else {
+            return nil
+        }
+
+        var diffBytes = [UInt8](repeating: 0, count: width * height * 4)
+        var differingPixelCount = 0
+        var maxChannelDelta = 0
+        var totalChannelDelta = 0
+
+        for pixelIndex in 0..<(width * height) {
+            let base = pixelIndex * 4
+            let rDelta = abs(Int(resizedAppKit.bytes[base]) - Int(resizedReference.bytes[base]))
+            let gDelta = abs(Int(resizedAppKit.bytes[base + 1]) - Int(resizedReference.bytes[base + 1]))
+            let bDelta = abs(Int(resizedAppKit.bytes[base + 2]) - Int(resizedReference.bytes[base + 2]))
+            let aDelta = abs(Int(resizedAppKit.bytes[base + 3]) - Int(resizedReference.bytes[base + 3]))
+            let pixelMax = max(rDelta, gDelta, bDelta, aDelta)
+            if pixelMax > 0 {
+                differingPixelCount += 1
+            }
+            maxChannelDelta = max(maxChannelDelta, pixelMax)
+            totalChannelDelta += rDelta + gDelta + bDelta + aDelta
+
+            diffBytes[base] = UInt8(clamping: rDelta)
+            diffBytes[base + 1] = UInt8(clamping: gDelta)
+            diffBytes[base + 2] = UInt8(clamping: bDelta)
+            diffBytes[base + 3] = pixelMax == 0 ? 0 : 255
+        }
+
+        guard let diffImage = imageFromRGBABytes(diffBytes, width: width, height: height) else {
+            return nil
+        }
+
+        let totalPixels = width * height
+        let meanAbsoluteChannelDelta = totalPixels == 0
+            ? 0
+            : Double(totalChannelDelta) / Double(totalPixels * 4)
+        let metrics = DiffMetrics(
+            width: width,
+            height: height,
+            differingPixelCount: differingPixelCount,
+            totalPixelCount: totalPixels,
+            maxChannelDelta: maxChannelDelta,
+            meanAbsoluteChannelDelta: meanAbsoluteChannelDelta,
+            matchingPixels: differingPixelCount == 0
+        )
+        return (diffImage, metrics)
+    }
+
+    private struct RGBAImageBuffer {
+        let width: Int
+        let height: Int
+        let bytes: [UInt8]
+    }
+
+    private static func rgbaImageBuffer(from image: NSImage) -> RGBAImageBuffer? {
+        guard let cgImage = cgImage(from: image) else { return nil }
+        return rgbaImageBuffer(from: cgImage)
+    }
+
+    private static func rgbaImageBuffer(from cgImage: CGImage) -> RGBAImageBuffer? {
+        let width = cgImage.width
+        let height = cgImage.height
+        var bytes = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &bytes,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        ) else {
+            return nil
+        }
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return RGBAImageBuffer(width: width, height: height, bytes: bytes)
+    }
+
+    private static func resizeImageBuffer(
+        _ buffer: RGBAImageBuffer,
+        width: Int,
+        height: Int
+    ) -> RGBAImageBuffer? {
+        guard let image = imageFromRGBABytes(buffer.bytes, width: buffer.width, height: buffer.height),
+              let cgImage = cgImage(from: image) else {
+            return nil
+        }
+        var bytes = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &bytes,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue
+        ) else {
+            return nil
+        }
+        context.interpolationQuality = .none
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return RGBAImageBuffer(width: width, height: height, bytes: bytes)
+    }
+
+    private static func imageFromRGBABytes(
+        _ bytes: [UInt8],
+        width: Int,
+        height: Int
+    ) -> NSImage? {
+        let data = Data(bytes)
+        guard let provider = CGDataProvider(data: data as CFData),
+              let cgImage = CGImage(
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bitsPerPixel: 32,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue | CGBitmapInfo.byteOrder32Big.rawValue),
+                provider: provider,
+                decode: nil,
+                shouldInterpolate: false,
+                intent: .defaultIntent
+              ) else {
+            return nil
+        }
+        return NSImage(cgImage: cgImage, size: CGSize(width: width, height: height))
+    }
+
+    private static func cgImage(from image: NSImage) -> CGImage? {
+        var proposed = CGRect(origin: .zero, size: image.size)
+        if let cgImage = image.cgImage(forProposedRect: &proposed, context: nil, hints: nil) {
+            return cgImage
+        }
+        guard let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff) else {
+            return nil
+        }
+        return rep.cgImage
+    }
+
+    private static func writePNG(image: NSImage, to url: URL) throws {
+        guard let cgImage = cgImage(from: image) else {
+            throw NSError(domain: "BonsplitTabChromeDebugCLI", code: 1, userInfo: nil)
+        }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            throw NSError(domain: "BonsplitTabChromeDebugCLI", code: 2, userInfo: nil)
+        }
+        try data.write(to: url, options: .atomic)
+    }
+}
+#else
+import Foundation
+
+@main
+struct BonsplitTabChromeDebugCLI {
+    static func main() {
+        fputs("BonsplitTabChromeDebugCLI requires a DEBUG build.\n", stderr)
+        Foundation.exit(64)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a dedicated tab chrome debug renderer and CLI entrypoint
- expose the debug surface from Bonsplit for exact tab chrome comparisons
- support the AppKit workspace tab migration work in cmux

## Testing
- used from cmux debug/pixel verification tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug utilities for rendering and comparing tab chrome snapshots with difference analysis.

* **Chores**
  * Implemented new CLI tool for automated tab chrome validation and visual regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tab chrome debug renderer and a `BonsplitTabChromeDebugCLI` to generate pixel-accurate snapshots and diffs, enabling AppKit ↔ Bonsplit tab comparison for the cmux AppKit workspace tab migration (issue-2289). Also fixes the inactive-pane selected indicator to match AppKit.

- **New Features**
  - `BonsplitTabChromeDebugRenderer` renders deterministic tab images from a `BonsplitTabChromeDebugScenario` (hover/press states, spinner phase, appearance).
  - `BonsplitTabChromeDebugCLI` ingests an export manifest, renders reference images, writes per-scenario diffs/metrics, and outputs a comparison manifest; executable target added in `Package.swift`.
  - Debug-only hooks in `TabItemView` let tests force hover/press and a fixed spinner phase; icon rendering was extracted and accessory sizing now follows the configured appearance.

- **Bug Fixes**
  - Selected tab indicator now uses accent color only when the pane is focused; inactive panes use a tertiary label color that adapts to light/dark, and the indicator height is 1.5 pt.

<sup>Written for commit ccdc4690914765a6cb988ee43710152dc9a8b576. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

