### PR TITLE
Fix minimal mode pane tab clicks and sizing

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2,6 +2,51 @@ import SwiftUI
 import AppKit
 import UniformTypeIdentifiers
 
+public enum BonsplitTabBarHitRegionRegistry {
+    private static let lock = NSLock()
+    private static let registeredViews = NSHashTable<NSView>.weakObjects()
+
+    static func register(_ view: NSView) {
+        lock.lock()
+        registeredViews.add(view)
+        lock.unlock()
+    }
+
+    static func unregister(_ view: NSView) {
+        lock.lock()
+        registeredViews.remove(view)
+        lock.unlock()
+    }
+
+    private static func snapshot() -> [NSView] {
+        lock.lock()
+        let views = registeredViews.allObjects
+        lock.unlock()
+        return views
+    }
+
+    private static func isVisibleInHierarchy(_ view: NSView) -> Bool {
+        var current: NSView? = view
+        while let candidate = current {
+            guard !candidate.isHidden, candidate.alphaValue > 0 else { return false }
+            current = candidate.superview
+        }
+        return true
+    }
+
+    public static func containsWindowPoint(_ windowPoint: CGPoint, in window: NSWindow) -> Bool {
+        let epsilon = max(0.5, 1.0 / max(1.0, window.backingScaleFactor))
+        for view in snapshot() {
+            guard view.window === window, isVisibleInHierarchy(view) else { continue }
+            let frameInWindow = view.convert(view.bounds, to: nil).insetBy(dx: -epsilon, dy: -epsilon)
+            if frameInWindow.contains(windowPoint) {
+                return true
+            }
+        }
+        return false
+    }
+}
+
 private struct SelectedTabFramePreferenceKey: PreferenceKey {
     static let defaultValue: CGRect? = nil
 
@@ -12,7 +57,122 @@ private struct SelectedTabFramePreferenceKey: PreferenceKey {
     }
 }
 
+@MainActor
+private final class TabBarScrollViewBridge: ObservableObject {
+    private struct ScrollMetrics {
+        let offset: CGFloat
+        let documentWidth: CGFloat
+        let viewportWidth: CGFloat
+    }
+
+    weak var scrollView: NSScrollView?
+
+    func attach(_ scrollView: NSScrollView?) {
+        self.scrollView = scrollView
+        enforceLeadingEdgeIfContentFits(reason: "attach")
+    }
+
+    private func currentMetrics() -> ScrollMetrics? {
+        guard let scrollView else { return nil }
+
+        let clipView = scrollView.contentView
+        let documentWidth = max(
+            scrollView.documentView?.frame.width ?? 0,
+            scrollView.documentView?.bounds.width ?? 0
+        )
+        let viewportWidth = clipView.bounds.width
+        return ScrollMetrics(
+            offset: clipView.bounds.origin.x,
+            documentWidth: documentWidth,
+            viewportWidth: viewportWidth
+        )
+    }
+
+    func shouldPreferLeadingTarget(
+        selectedTabId: UUID?,
+        fallbackContentWidth: CGFloat,
+        fallbackContainerWidth: CGFloat
+    ) -> Bool {
+        guard selectedTabId != nil else { return true }
+
+        if let metrics = currentMetrics(), metrics.viewportWidth > 0 {
+            return TabBarStyling.shouldKeepLeadingAligned(
+                contentWidth: metrics.documentWidth,
+                containerWidth: metrics.viewportWidth
+            )
+        }
+
+        return TabBarStyling.shouldKeepLeadingAligned(
+            contentWidth: fallbackContentWidth,
+            containerWidth: fallbackContainerWidth
+        )
+    }
+
+    func enforceLeadingEdgeIfContentFits(reason: String) {
+        guard let metrics = currentMetrics(), metrics.viewportWidth > 0 else { return }
+        guard TabBarStyling.shouldKeepLeadingAligned(
+            contentWidth: metrics.documentWidth,
+            containerWidth: metrics.viewportWidth
+        ) else {
+            return
+        }
+
+        resetToLeadingEdgeIfNeeded(reason: reason)
+    }
+
+    func resetToLeadingEdgeIfNeeded(reason: String) {
+        guard let metrics = currentMetrics() else { return }
+
+        let currentOffset = metrics.offset
+        guard abs(currentOffset) > 0.5 else { return }
+
+        guard let scrollView else { return }
+        #if DEBUG
+        dlog(
+            "tab.bar.resetLeading reason=\(reason) " +
+            "offset=\(Int(currentOffset.rounded())) " +
+            "doc=\(Int(metrics.documentWidth.rounded())) " +
+            "viewport=\(Int(metrics.viewportWidth.rounded()))"
+        )
+#endif
+        let clipView = scrollView.contentView
+        clipView.scroll(to: NSPoint(x: 0, y: clipView.bounds.origin.y))
+        scrollView.reflectScrolledClipView(clipView)
+
+        // SwiftUI's ScrollView can briefly restore the stale offset during the same
+        // layout cycle. Re-apply the correction on the next turn to keep split-pane
+        // tab bars pinned to the leading edge once they stop overflowing.
+        DispatchQueue.main.async { [weak scrollView] in
+            guard let scrollView else { return }
+            let clipView = scrollView.contentView
+            let asyncOffset = clipView.bounds.origin.x
+            guard abs(asyncOffset) > 0.5 else { return }
+#if DEBUG
+            let documentWidth = max(
+                scrollView.documentView?.frame.width ?? 0,
+                scrollView.documentView?.bounds.width ?? 0
+            )
+            dlog(
+                "tab.bar.resetLeading.async reason=\(reason) " +
+                "offset=\(Int(asyncOffset.rounded())) " +
+                "doc=\(Int(documentWidth.rounded())) " +
+                "viewport=\(Int(clipView.bounds.width.rounded()))"
+            )
+#endif
+            clipView.scroll(to: NSPoint(x: 0, y: clipView.bounds.origin.y))
+            scrollView.reflectScrolledClipView(clipView)
+        }
+    }
+}
+
 enum TabBarStyling {
+    static let splitButtonsBackdropWidth: CGFloat = 114
+
+    enum ScrollTarget: Equatable {
+        case leading
+        case selectedTab(UUID)
+    }
+
     static func separatorSegments(
         totalWidth: CGFloat,
         gap: ClosedRange<CGFloat>?
@@ -29,6 +189,56 @@ enum TabBarStyling {
         let left = max(0, normalizedStart)
         let right = max(0, clampedTotal - normalizedEnd)
         return (left: left, right: right)
+    }
+
+    static func trailingTabContentInset(
+        showSplitButtons: Bool,
+        isMinimalMode: Bool
+    ) -> CGFloat {
+        guard showSplitButtons else { return 0 }
+
+        // In minimal mode the split buttons fade in on hover as an overlay. Reserving that
+        // width in the scroll content leaves a dead NSClipView strip when the buttons are
+        // hidden, so clicks there never reach the tab-bar chrome.
+        return isMinimalMode ? 0 : splitButtonsBackdropWidth
+    }
+
+    static func preferredScrollTarget(
+        selectedTabId: UUID?,
+        contentWidth: CGFloat,
+        containerWidth: CGFloat
+    ) -> ScrollTarget {
+        guard let selectedTabId else { return .leading }
+
+        // When the tab strip fits without horizontal scrolling, centering the selected tab
+        // can strand empty NSClipView space at the leading edge in split panes. Keep the
+        // content snapped to the leading edge until it actually overflows.
+        guard !shouldKeepLeadingAligned(contentWidth: contentWidth, containerWidth: containerWidth) else {
+            return .leading
+        }
+
+        return .selectedTab(selectedTabId)
+    }
+
+    static func shouldKeepLeadingAligned(
+        contentWidth: CGFloat,
+        containerWidth: CGFloat
+    ) -> Bool {
+        let overflowThreshold: CGFloat = 1
+        return contentWidth <= containerWidth + overflowThreshold
+    }
+
+    static func shouldForceResetToLeading(
+        scrollOffset: CGFloat,
+        contentWidth: CGFloat,
+        containerWidth: CGFloat
+    ) -> Bool {
+        guard shouldKeepLeadingAligned(contentWidth: contentWidth, containerWidth: containerWidth) else {
+            return false
+        }
+
+        let overflowThreshold: CGFloat = 1
+        return abs(scrollOffset) > overflowThreshold
     }
 }
 
@@ -75,6 +285,7 @@ struct TabBarView: View {
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
     @StateObject private var controlKeyMonitor = TabControlShortcutKeyMonitor()
+    @StateObject private var scrollViewBridge = TabBarScrollViewBridge()
 
     private var canScrollLeft: Bool {
         scrollOffset > 1
@@ -104,11 +315,73 @@ struct TabBarView: View {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
 
+    private var isMinimalMode: Bool {
+        presentationMode == "minimal"
+    }
+
+    private var trailingTabContentInset: CGFloat {
+        TabBarStyling.trailingTabContentInset(
+            showSplitButtons: showSplitButtons,
+            isMinimalMode: isMinimalMode
+        )
+    }
+
+    private var leadingScrollAnchorId: String {
+        "tab-bar-leading-\(pane.id.id.uuidString)"
+    }
+
+    private func focusPaneFromTabBarChrome() -> Bool {
+        guard !isFocused else { return false }
+        withTransaction(Transaction(animation: nil)) {
+            controller.focusPane(pane.id)
+        }
+        return true
+    }
+
+    private func scrollToPreferredTarget(_ proxy: ScrollViewProxy, selectedTabId: UUID?) {
+        let target: TabBarStyling.ScrollTarget
+        if scrollViewBridge.shouldPreferLeadingTarget(
+            selectedTabId: selectedTabId,
+            fallbackContentWidth: contentWidth,
+            fallbackContainerWidth: containerWidth
+        ) {
+            target = .leading
+        } else if let selectedTabId {
+            target = .selectedTab(selectedTabId)
+        } else {
+            target = .leading
+        }
+
+        withTransaction(Transaction(animation: nil)) {
+            switch target {
+            case .leading:
+                proxy.scrollTo(leadingScrollAnchorId, anchor: .leading)
+            case .selectedTab(let tabId):
+                proxy.scrollTo(tabId, anchor: .center)
+            }
+        }
+
+        if target == .leading,
+           TabBarStyling.shouldForceResetToLeading(
+                scrollOffset: scrollOffset,
+                contentWidth: contentWidth,
+                containerWidth: containerWidth
+           ) {
+            scrollViewBridge.resetToLeadingEdgeIfNeeded(reason: "scrollToPreferredTarget")
+        } else if target == .leading {
+            scrollViewBridge.enforceLeadingEdgeIfContentFits(reason: "scrollToPreferredTarget")
+        }
+    }
+
 
     var body: some View {
         HStack(spacing: 0) {
             if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
-                TabBarDragZoneView { return false }
+                TabBarDragZoneView(
+                    isMinimalMode: isMinimalMode,
+                    isFocusedPane: isFocused,
+                    onSingleClick: focusPaneFromTabBarChrome
+                ) { return false }
                     .frame(width: appearance.tabBarLeadingInset)
             }
             // Scrollable tabs with fade overlays
@@ -116,6 +389,10 @@ struct TabBarView: View {
                 ScrollViewReader { proxy in
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: TabBarMetrics.tabSpacing) {
+                            Color.clear
+                                .frame(width: 0, height: TabBarMetrics.tabHeight)
+                                .id(leadingScrollAnchorId)
+
                             ForEach(Array(pane.tabs.enumerated()), id: \.element.id) { index, tab in
                                 tabItem(for: tab, at: index)
                                     .id(tab.id)
@@ -125,7 +402,7 @@ struct TabBarView: View {
                             dropZoneAfterTabs
                         }
                         .padding(.horizontal, TabBarMetrics.barPadding)
-                        .padding(.trailing, showSplitButtons ? 114 : 0)
+                        .padding(.trailing, trailingTabContentInset)
                         .animation(nil, value: pane.tabs.map(\.id))
                         .background(
                             GeometryReader { contentGeo in
@@ -142,12 +419,22 @@ struct TabBarView: View {
                             }
                         )
                     }
+                    .background(
+                        TabBarScrollViewResolver { scrollView in
+                            scrollViewBridge.attach(scrollView)
+                        }
+                        .frame(width: 0, height: 0)
+                    )
                     // When the tab strip is shorter than the visible area, allow dropping in the
                     // empty trailing space without forcing tabs to stretch.
                     .overlay(alignment: .trailing) {
                         let trailing = max(0, containerGeo.size.width - contentWidth)
                         if trailing >= 1 {
-                            TabBarDragZoneView {
+                            TabBarDragZoneView(
+                                isMinimalMode: isMinimalMode,
+                                isFocusedPane: isFocused,
+                                onSingleClick: focusPaneFromTabBarChrome
+                            ) {
                                 guard splitViewController.isInteractive else { return false }
                                 controller.requestNewTab(kind: "terminal", inPane: pane.id)
                                 return true
@@ -166,19 +453,17 @@ struct TabBarView: View {
                     .coordinateSpace(name: "tabScroll")
                     .onAppear {
                         containerWidth = containerGeo.size.width
-                        if let tabId = pane.selectedTabId {
-                            proxy.scrollTo(tabId, anchor: .center)
-                        }
+                        scrollToPreferredTarget(proxy, selectedTabId: pane.selectedTabId)
                     }
                     .onChange(of: containerGeo.size.width) { _, newWidth in
                         containerWidth = newWidth
+                        scrollToPreferredTarget(proxy, selectedTabId: pane.selectedTabId)
+                    }
+                    .onChange(of: contentWidth) { _, _ in
+                        scrollToPreferredTarget(proxy, selectedTabId: pane.selectedTabId)
                     }
                     .onChange(of: pane.selectedTabId) { _, newTabId in
-                        if let tabId = newTabId {
-                            withTransaction(Transaction(animation: nil)) {
-                                proxy.scrollTo(tabId, anchor: .center)
-                            }
-                        }
+                        scrollToPreferredTarget(proxy, selectedTabId: newTabId)
                     }
                 }
                 .frame(height: TabBarMetrics.barHeight)
@@ -192,7 +477,7 @@ struct TabBarView: View {
                 // window drag in minimal mode).
                 .overlay(alignment: .trailing) {
                     if showSplitButtons {
-                        let shouldShow = presentationMode != "minimal" || isHoveringTabBar
+                        let shouldShow = !isMinimalMode || isHoveringTabBar
                         let backdropColor = Color(nsColor: Self.buttonBackdropColor(
                             for: appearance,
                             focused: isFocused,
@@ -208,7 +493,7 @@ struct TabBarView: View {
                                 .frame(width: 24)
                                 Rectangle().fill(backdropColor)
                             }
-                            .frame(width: 114)
+                            .frame(width: TabBarStyling.splitButtonsBackdropWidth)
 
                             splitButtons
                                 .saturation(tabBarSaturation)
@@ -225,7 +510,7 @@ struct TabBarView: View {
         .coordinateSpace(name: "tabBar")
         .background(tabBarBackground)
         .background(TabBarDragAndHoverView(
-            isMinimalMode: presentationMode == "minimal",
+            isMinimalMode: isMinimalMode,
             onHoverChanged: { isHoveringTabBar = $0 }
         ))
         .background(
@@ -457,7 +742,11 @@ struct TabBarView: View {
 
     @ViewBuilder
     private var dropZoneAfterTabs: some View {
-        TabBarDragZoneView {
+        TabBarDragZoneView(
+            isMinimalMode: isMinimalMode,
+            isFocusedPane: isFocused,
+            onSingleClick: focusPaneFromTabBarChrome
+        ) {
             guard splitViewController.isInteractive else { return false }
             controller.requestNewTab(kind: "terminal", inPane: pane.id)
             return true
@@ -711,6 +1000,25 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
         override var mouseDownCanMoveWindow: Bool { false }
 
+        deinit {
+            BonsplitTabBarHitRegionRegistry.unregister(self)
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            BonsplitTabBarHitRegionRegistry.unregister(self)
+            if window != nil {
+                BonsplitTabBarHitRegionRegistry.register(self)
+            }
+        }
+
+        override func viewDidMoveToSuperview() {
+            super.viewDidMoveToSuperview()
+            if superview == nil {
+                BonsplitTabBarHitRegionRegistry.unregister(self)
+            }
+        }
+
         override func updateTrackingAreas() {
             super.updateTrackingAreas()
             if let existing = hoverTrackingArea {
@@ -757,11 +1065,17 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
     }
 }
 
-private struct TabBarDragZoneView: NSViewRepresentable {
+struct TabBarDragZoneView: NSViewRepresentable {
+    let isMinimalMode: Bool
+    let isFocusedPane: Bool
+    let onSingleClick: () -> Bool
     let onDoubleClick: () -> Bool
 
     func makeNSView(context: Context) -> DragNSView {
         let view = DragNSView()
+        view.isMinimalMode = isMinimalMode
+        view.isFocusedPane = isFocusedPane
+        view.onSingleClick = onSingleClick
         view.onDoubleClick = onDoubleClick
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.clear.cgColor
@@ -769,14 +1083,21 @@ private struct TabBarDragZoneView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: DragNSView, context: Context) {
+        nsView.isMinimalMode = isMinimalMode
+        nsView.isFocusedPane = isFocusedPane
+        nsView.onSingleClick = onSingleClick
         nsView.onDoubleClick = onDoubleClick
     }
 
     final class DragNSView: NSView {
+        var isMinimalMode = false
+        var isFocusedPane = false
+        var onSingleClick: (() -> Bool)?
         var onDoubleClick: (() -> Bool)?
+        var performWindowDrag: ((NSEvent) -> Bool)?
 
         override var mouseDownCanMoveWindow: Bool {
-            return UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal"
+            isMinimalMode && isFocusedPane
         }
 
         override func hitTest(_ point: NSPoint) -> NSView? {
@@ -785,8 +1106,10 @@ private struct TabBarDragZoneView: NSViewRepresentable {
 
         override func mouseDown(with event: NSEvent) {
 #if DEBUG
-            let isMinimal = UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal"
-            dlog("tab.bar.dragZone.mouseDown isMinimal=\(isMinimal ? 1 : 0) clickCount=\(event.clickCount)")
+            dlog(
+                "tab.bar.dragZone.mouseDown isMinimal=\(isMinimalMode ? 1 : 0) " +
+                "focused=\(isFocusedPane ? 1 : 0) clickCount=\(event.clickCount)"
+            )
 #endif
             guard let window = self.window else {
                 super.mouseDown(with: event)
@@ -794,7 +1117,7 @@ private struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if event.clickCount >= 2 {
-                if UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" {
+                if isMinimalMode {
                     let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
                     switch action {
                     case "Minimize": window.miniaturize(nil)
@@ -808,13 +1131,64 @@ private struct TabBarDragZoneView: NSViewRepresentable {
                 }
             }
 
-            if UserDefaults.standard.string(forKey: "workspacePresentationMode") == "minimal" {
+            if isMinimalMode, !isFocusedPane, onSingleClick?() == true {
+#if DEBUG
+                dlog("tab.bar.dragZone.focusPane")
+#endif
+                return
+            }
+
+            if isMinimalMode {
+                if let performWindowDrag, performWindowDrag(event) {
+                    return
+                }
                 let wasMovable = window.isMovable
                 window.isMovable = true
                 window.performDrag(with: event)
                 window.isMovable = wasMovable
             } else {
                 super.mouseDown(with: event)
+            }
+        }
+    }
+}
+
+private struct TabBarScrollViewResolver: NSViewRepresentable {
+    let onResolve: (NSScrollView?) -> Void
+
+    func makeNSView(context: Context) -> ResolverView {
+        let view = ResolverView()
+        view.onResolve = onResolve
+        return view
+    }
+
+    func updateNSView(_ nsView: ResolverView, context: Context) {
+        nsView.onResolve = onResolve
+        nsView.resolveScrollView()
+    }
+
+    final class ResolverView: NSView {
+        var onResolve: ((NSScrollView?) -> Void)?
+
+        override func viewDidMoveToSuperview() {
+            super.viewDidMoveToSuperview()
+            resolveScrollView()
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            resolveScrollView()
+        }
+
+        override func layout() {
+            super.layout()
+            resolveScrollView()
+        }
+
+        func resolveScrollView() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                onResolve?(self.enclosingScrollView)
             }
         }
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -5,6 +5,28 @@ import SwiftUI
 
 final class BonsplitTests: XCTestCase {
     @MainActor
+    private final class FakeTabBarHitRegionView: NSView {
+        deinit {
+            BonsplitTabBarHitRegionRegistry.unregister(self)
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            BonsplitTabBarHitRegionRegistry.unregister(self)
+            if window != nil {
+                BonsplitTabBarHitRegionRegistry.register(self)
+            }
+        }
+
+        override func viewDidMoveToSuperview() {
+            super.viewDidMoveToSuperview()
+            if superview == nil {
+                BonsplitTabBarHitRegionRegistry.unregister(self)
+            }
+        }
+    }
+
+    @MainActor
     private final class LayoutProbeView: NSView {
         private(set) var sizeChangeCount = 0
         private(set) var originChangeCount = 0
@@ -182,6 +204,149 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(defaults.newBrowser, "New Browser")
         XCTAssertEqual(defaults.splitRight, "Split Right")
         XCTAssertEqual(defaults.splitDown, "Split Down")
+    }
+
+    func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
+        XCTAssertEqual(
+            TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),
+            0,
+            "Minimal mode should let the tab strip fill the full width until the hover-only split buttons are actually shown"
+        )
+        XCTAssertEqual(
+            TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: false),
+            TabBarStyling.splitButtonsBackdropWidth,
+            "Standard mode should keep reserving space for the always-visible split buttons"
+        )
+        XCTAssertEqual(
+            TabBarStyling.trailingTabContentInset(showSplitButtons: false, isMinimalMode: false),
+            0,
+            "No split-button strip should be reserved when split buttons are disabled"
+        )
+    }
+
+    func testTabBarKeepsNonOverflowingTabsLeadingAligned() {
+        let tabId = UUID()
+
+        XCTAssertEqual(
+            TabBarStyling.preferredScrollTarget(
+                selectedTabId: tabId,
+                contentWidth: 132,
+                containerWidth: 349
+            ),
+            .leading,
+            "When the tab strip fits in the pane, it should stay leading-aligned instead of creating a dead leading clip-view band"
+        )
+
+        XCTAssertEqual(
+            TabBarStyling.preferredScrollTarget(
+                selectedTabId: tabId,
+                contentWidth: 420,
+                containerWidth: 349
+            ),
+            .selectedTab(tabId),
+            "Overflowing tab strips should still auto-scroll the selected tab into view"
+        )
+    }
+
+    func testTabBarForcesLeadingResetWhenNonOverflowingStripStaysScrolled() {
+        XCTAssertTrue(
+            TabBarStyling.shouldForceResetToLeading(
+                scrollOffset: 28,
+                contentWidth: 180,
+                containerWidth: 349
+            ),
+            "A non-overflowing tab strip with a stale horizontal offset should be snapped back to x=0"
+        )
+
+        XCTAssertTrue(
+            TabBarStyling.shouldForceResetToLeading(
+                scrollOffset: -30,
+                contentWidth: 180,
+                containerWidth: 349
+            ),
+            "The leading reset must correct both left and right stale offsets"
+        )
+
+        XCTAssertFalse(
+            TabBarStyling.shouldForceResetToLeading(
+                scrollOffset: 0.2,
+                contentWidth: 180,
+                containerWidth: 349
+            ),
+            "Tiny floating-point drift should not trigger redundant clip-view resets"
+        )
+
+        XCTAssertFalse(
+            TabBarStyling.shouldForceResetToLeading(
+                scrollOffset: 28,
+                contentWidth: 420,
+                containerWidth: 349
+            ),
+            "Overflowing tab strips are allowed to stay horizontally scrolled"
+        )
+    }
+
+    @MainActor
+    func testTabBarHitRegionRegistryTracksVisibleWindowPoint() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let tabBar = FakeTabBarHitRegionView(frame: NSRect(x: 20, y: 132, width: 180, height: 30))
+        contentView.addSubview(tabBar)
+
+        let hitPoint = tabBar.convert(NSPoint(x: 24, y: 12), to: nil)
+        XCTAssertTrue(
+            BonsplitTabBarHitRegionRegistry.containsWindowPoint(hitPoint, in: window),
+            "The registry should expose visible tab-bar hit regions in window coordinates"
+        )
+
+        let missPoint = tabBar.convert(NSPoint(x: 24, y: -18), to: nil)
+        XCTAssertFalse(
+            BonsplitTabBarHitRegionRegistry.containsWindowPoint(missPoint, in: window),
+            "The registry should ignore points outside the registered tab-bar region"
+        )
+    }
+
+    @MainActor
+    func testTabBarHitRegionRegistryIgnoresViewsHiddenByAncestors() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let container = NSView(frame: contentView.bounds)
+        contentView.addSubview(container)
+
+        let tabBar = FakeTabBarHitRegionView(frame: NSRect(x: 32, y: contentView.bounds.maxY + 6, width: 180, height: 30))
+        container.addSubview(tabBar)
+
+        let hitPoint = tabBar.convert(NSPoint(x: 20, y: 14), to: nil)
+        XCTAssertTrue(
+            BonsplitTabBarHitRegionRegistry.containsWindowPoint(hitPoint, in: window),
+            "The registry should use the actual registered tab-bar frame even when it extends outside its immediate container bounds"
+        )
+
+        container.isHidden = true
+        XCTAssertFalse(
+            BonsplitTabBarHitRegionRegistry.containsWindowPoint(hitPoint, in: window),
+            "Ancestor-hidden tab-bar regions must not keep stealing portal hit testing"
+        )
     }
 
     @MainActor
@@ -936,6 +1101,84 @@ final class BonsplitTests: XCTestCase {
             accuracy: 0.03,
             "Split mode should render the same content alpha as single-pane mode"
         )
+    }
+
+    @MainActor
+    func testTabBarDragZoneFocusesInactivePaneInMinimalMode() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+        view.isMinimalMode = true
+        view.isFocusedPane = false
+
+        var focused = false
+        var dragged = false
+        view.onSingleClick = {
+            focused = true
+            return true
+        }
+        view.performWindowDrag = { _ in
+            dragged = true
+            return true
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
+        view.mouseDown(with: event)
+
+        XCTAssertTrue(focused, "Inactive-pane drag zone should focus the pane before starting a window drag")
+        XCTAssertFalse(dragged, "Inactive-pane focus click should not immediately begin a window drag")
+        XCTAssertFalse(view.mouseDownCanMoveWindow, "Inactive-pane drag zone should not advertise window dragging to AppKit")
+    }
+
+    @MainActor
+    func testTabBarDragZoneKeepsFocusedPaneWindowDragInMinimalMode() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+        view.isMinimalMode = true
+        view.isFocusedPane = true
+
+        var focused = false
+        var dragged = false
+        view.onSingleClick = {
+            focused = true
+            return true
+        }
+        view.performWindowDrag = { _ in
+            dragged = true
+            return true
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
+        view.mouseDown(with: event)
+
+        XCTAssertFalse(focused, "Focused-pane drag zone should not bounce through first-click focus")
+        XCTAssertTrue(dragged, "Focused-pane drag zone should continue to start window drags in minimal mode")
+        XCTAssertTrue(view.mouseDownCanMoveWindow, "Focused-pane drag zone should continue advertising window dragging to AppKit")
     }
 
     private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {


### PR DESCRIPTION
## Summary
- stop reserving hidden split-button width in minimal mode so pane tab hits land on live tab chrome
- keep non-overflowing pane tab strips leading-aligned and reset stale scroll offsets instead of leaving dead clip-view bands
- focus inactive panes on first drag-zone click while preserving minimal-mode window drag on the focused pane

## Notes
- adds runtime tests for hit-region registration, leading-edge reset behavior, and drag-zone focus/drag routing
- follow-up for cmux issue #2633 parent PR updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes minimal mode tab-bar hit targets and sizing so clicks land on real tabs, and improves scroll behavior to avoid dead space in split panes. Also updates drag-zone behavior to focus inactive panes without breaking window drag, addressing issue #2633.

- **Bug Fixes**
  - Minimal mode: stop reserving hidden split-button width so the tab strip fills the bar; split buttons still show on hover.
  - Tab strip: keep non-overflowing tabs leading-aligned and reset stale horizontal offsets to remove dead NSClipView bands.
  - Drag zone: first click focuses an inactive pane; window drag remains on the focused pane in minimal mode; adds a tab-bar hit-region registry and tests for hit registration, leading reset, and drag routing.

<sup>Written for commit 58d8f9617fc7377bd809a86ff648b24766a414ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Single-click tab bar panes in minimal mode to focus them.

* **Bug Fixes**
  * Improved tab bar scroll positioning with intelligent reset logic.
  * Enhanced hit region detection for tab bar interactions.

* **Tests**
  * Added comprehensive test coverage for tab bar scrolling and interaction behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->