### PR TITLE
Show pane shortcut hints on control hold too

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1261,7 +1261,9 @@ struct TabControlShortcutModifier: Equatable {
 enum TabControlShortcutHintPolicy {
     static let intentionalHoldDelay: TimeInterval = 0.30
     static let showHintsOnCommandHoldKey = "shortcutHintShowOnCommandHold"
+    static let showHintsOnControlHoldKey = "shortcutHintShowOnControlHold"
     static let defaultShowHintsOnCommandHold = true
+    static let defaultShowHintsOnControlHold = true
 
     static func showHintsOnCommandHoldEnabled(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: showHintsOnCommandHoldKey) != nil else {
@@ -1270,19 +1272,35 @@ enum TabControlShortcutHintPolicy {
         return defaults.bool(forKey: showHintsOnCommandHoldKey)
     }
 
+    static func showHintsOnControlHoldEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: showHintsOnControlHoldKey) != nil else {
+            return defaultShowHintsOnControlHold
+        }
+        return defaults.bool(forKey: showHintsOnControlHoldKey)
+    }
+
+    private static func triggerAllowsHintReveal(
+        for modifierFlags: NSEvent.ModifierFlags,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        switch flags {
+        case [.command]:
+            return showHintsOnCommandHoldEnabled(defaults: defaults)
+        case [.control]:
+            return showHintsOnControlHoldEnabled(defaults: defaults)
+        default:
+            return false
+        }
+    }
+
     static func hintModifier(
         for modifierFlags: NSEvent.ModifierFlags,
         defaults: UserDefaults = .standard
     ) -> TabControlShortcutModifier? {
-        guard showHintsOnCommandHoldEnabled(defaults: defaults) else { return nil }
-        let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
-            .subtracting([.numericPad, .function, .capsLock])
+        guard triggerAllowsHintReveal(for: modifierFlags, defaults: defaults) else { return nil }
         let shortcut = TabControlShortcutSettings.surfaceByNumberShortcut(defaults: defaults)
-        if flags != shortcut.modifierFlags {
-            // Command-only hold reveals all hints (including pane hints), while
-            // control (or other modifiers) remains strict to the pane shortcut.
-            guard flags == [.command] else { return nil }
-        }
         return TabControlShortcutModifier(
             modifierFlags: shortcut.modifierFlags,
             symbol: shortcut.modifierSymbol
@@ -1310,7 +1328,7 @@ enum TabControlShortcutHintPolicy {
         keyWindowNumber: Int?,
         defaults: UserDefaults = .standard
     ) -> Bool {
-        hintModifier(for: modifierFlags, defaults: defaults) != nil &&
+        triggerAllowsHintReveal(for: modifierFlags, defaults: defaults) &&
             isCurrentWindow(
                 hostWindowNumber: hostWindowNumber,
                 hostWindowIsKey: hostWindowIsKey,

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -763,8 +763,12 @@ final class BonsplitTests: XCTestCase {
     func testTabControlShortcutHintPolicyMatchesConfiguredModifiers() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
 
-            XCTAssertNotNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
+                "⌃"
+            )
             XCTAssertEqual(
                 TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
                 "⌃"
@@ -784,28 +788,45 @@ final class BonsplitTests: XCTestCase {
                 forKey: "shortcut.selectSurfaceByNumber"
             )
 
-            let custom = TabControlShortcutHintPolicy.hintModifier(for: [.command, .option], defaults: defaults)
+            let custom = TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)
             XCTAssertEqual(custom?.symbol, "⌥⌘")
             XCTAssertEqual(
                 TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
                 "⌥⌘"
             )
-            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
+                "⌥⌘"
+            )
         }
     }
 
-    func testTabControlShortcutHintPolicyCanDisableHoldHints() {
+    func testTabControlShortcutHintPolicyCanDisableCommandAndControlHoldHintsIndependently() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
 
-            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
+                "⌃"
+            )
+
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
+
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
+                "⌃"
+            )
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
         }
     }
 
     func testTabControlShortcutHintPolicyDefaultsToShowingHoldHints() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.removeObject(forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.removeObject(forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
 
             XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol, "⌃")
             XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol, "⌃")
@@ -815,6 +836,7 @@ final class BonsplitTests: XCTestCase {
     func testTabControlShortcutHintsAreScopedToCurrentKeyWindow() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
 
             XCTAssertTrue(
                 TabControlShortcutHintPolicy.shouldShowHints(
@@ -854,6 +876,7 @@ final class BonsplitTests: XCTestCase {
     func testTabControlShortcutHintsFallbackToKeyWindowWhenEventWindowMissing() {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
 
             XCTAssertTrue(
                 TabControlShortcutHintPolicy.shouldShowHints(


### PR DESCRIPTION
## Summary
- allow pure control hold to reveal pane shortcut hints, matching the existing command-hold reveal path
- keep pane hint pills rendering the actual shortcut modifier glyphs rather than the held trigger key
- cover the new control-hold path in Bonsplit unit tests


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow holding Control to reveal pane shortcut hints, matching Command-hold, to achieve ctrl/cmd parity (issue-2992). Hint pills still show the pane’s actual shortcut modifiers, not the trigger key.

- **New Features**
  - Added `shortcutHintShowOnControlHold` preference (default on), independent from `shortcutHintShowOnCommandHold`.
  - Updated reveal logic to accept pure Control or Command holds only; displayed glyphs remain the configured shortcut modifiers.

<sup>Written for commit afdae99351de0bb14c0cd1ca2492826d4e2489e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Control key modifier support for revealing keyboard shortcut hints, providing users with an additional option alongside the existing Command key functionality for accessing shortcut guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->