### PR TITLE
feat: configurable close button position

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -130,6 +130,17 @@ struct TabItemView: View {
                     updateGlobeFallback()
                 }
                 .onChange(of: tab.icon) { _ in updateGlobeFallback() }
+                // In leading-close mode the favicon slot doubles as the
+                // close-button slot (Safari 15+/Finder/Xcode style): the
+                // favicon fades out and × overlays on hover/select so there's
+                // no layout shift. Both modifiers are no-ops in trailing mode
+                // (`showsLeadingCloseOverlay` is always false there).
+                .opacity(showsLeadingCloseOverlay ? 0 : 1)
+                .overlay(alignment: .center) {
+                    if showsLeadingCloseOverlay {
+                        leadingCloseOverlayButton
+                    }
+                }
 
                 Text(tab.title)
                     .font(.system(size: appearance.tabTitleFontSize))
@@ -171,10 +182,16 @@ struct TabItemView: View {
                 }
             }
 
-            Spacer(minLength: 0)
-
-            // Close button / dirty indicator / shortcut hint share the same trailing slot.
-            trailingAccessory
+            // In leading-close mode the close × is rendered as an overlay over
+            // the favicon. The trailing slot is dropped when nothing else needs
+            // to render there (no dirty/notification dot, no pin glyph, no
+            // shortcut-hint pill) so the tab doesn't show a phantom
+            // close-button-sized gap on the right edge. When any of those
+            // affordances are active the slot is kept so they remain visible.
+            if rendersTrailingAccessorySlot {
+                Spacer(minLength: 0)
+                closeAccessory
+            }
         }
         .padding(.horizontal, TabBarMetrics.tabHorizontalPadding)
         .frame(
@@ -229,6 +246,60 @@ struct TabItemView: View {
         allowsShortcutHints && (showsControlShortcutHint || alwaysShowShortcutHints) && shortcutHintLabel != nil
     }
 
+    /// In leading-close mode, the close × renders as an overlay on top of the
+    /// favicon slot (and the favicon fades out underneath) whenever the user
+    /// hovers the tab or the tab is selected. Matches Safari 15+ / Xcode: no
+    /// layout shift because the close button occupies the same slot the
+    /// favicon already owns.
+    private var showsLeadingCloseOverlay: Bool {
+        appearance.closeButtonPosition == .leading
+            && !tab.isPinned
+            && (isSelected || isHovered || isCloseHovered)
+    }
+
+    /// Whether the trailing accessory slot is rendered. In trailing-close mode
+    /// it is always present so the close × can fade in/out without layout
+    /// shift. In leading-close mode it is rendered only when there is content
+    /// to show (dirty / notification dot, pin glyph, or shortcut-hint pill);
+    /// otherwise the slot is dropped so the tab does not gain a phantom
+    /// close-button-sized gap on the right edge.
+    private var rendersTrailingAccessorySlot: Bool {
+        if appearance.closeButtonPosition == .trailing { return true }
+        if showsShortcutHint { return true }
+        if tab.isPinned { return true }
+        if tab.isDirty || tab.showsNotificationBadge { return true }
+        return false
+    }
+
+    @ViewBuilder
+    private var leadingCloseOverlayButton: some View {
+        Button {
+            onClose()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: TabBarMetrics.closeIconSize, weight: .semibold))
+                .foregroundStyle(
+                    isCloseHovered
+                        ? TabBarColors.activeText(for: appearance)
+                        : TabBarColors.inactiveText(for: appearance)
+                )
+                .frame(width: TabBarMetrics.iconSize, height: TabBarMetrics.iconSize)
+                .background(
+                    Circle()
+                        .fill(
+                            isCloseHovered
+                                ? TabBarColors.hoveredTabBackground(for: appearance)
+                                : .clear
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isCloseHovered = hovering
+        }
+        .saturation(saturation)
+    }
+
     private var shortcutHintSlotWidth: CGFloat {
         guard let label = shortcutHintLabel else {
             return accessorySlotSize
@@ -257,7 +328,7 @@ struct TabItemView: View {
     }
 
     @ViewBuilder
-    private var trailingAccessory: some View {
+    private var closeAccessory: some View {
         ZStack(alignment: .center) {
             if let shortcutHintLabel {
                 Text(shortcutHintLabel)
@@ -402,8 +473,10 @@ struct TabItemView: View {
                         .frame(width: accessorySlotSize, height: accessorySlotSize)
                         .saturation(saturation)
                 }
-            } else if isSelected || isHovered || isCloseHovered {
-                // Close button (always visible on active tab, shown on hover for others)
+            } else if appearance.closeButtonPosition == .trailing && (isSelected || isHovered || isCloseHovered) {
+                // Close button (always visible on active tab, shown on hover for others).
+                // Only rendered here in trailing-close mode — leading mode puts
+                // the close × over the favicon slot instead (see body).
                 Button {
                     onClose()
                 } label: {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -283,7 +283,14 @@ struct TabItemView: View {
                         ? TabBarColors.activeText(for: appearance)
                         : TabBarColors.inactiveText(for: appearance)
                 )
-                .frame(width: TabBarMetrics.iconSize, height: TabBarMetrics.iconSize)
+                // Match the trailing-close hit area so the affordance scales
+                // with `tabTitleFontSize` (via `accessorySlotSize`). Falls back
+                // to at least the favicon slot width so the hover circle never
+                // shrinks below the icon it overlays.
+                .frame(
+                    width: max(TabBarMetrics.iconSize, accessorySlotSize),
+                    height: max(TabBarMetrics.iconSize, accessorySlotSize)
+                )
                 .background(
                     Circle()
                         .fill(
@@ -446,6 +453,14 @@ struct TabItemView: View {
     // MARK: - Close Button / Dirty Indicator
 
     @ViewBuilder
+    // Hover-transition semantics in leading-close mode for an unpinned + dirty
+    // tab: the trailing slot is kept (`rendersTrailingAccessorySlot` returns
+    // true for `tab.isDirty`), so the dirty dot renders while idle. On hover or
+    // selection the dirty branch above goes false and the trailing-close branch
+    // below is guarded by `closeButtonPosition == .trailing`, so the slot
+    // becomes empty space while × overlays the favicon. This is intentional —
+    // it mirrors Safari's transition from dirty dot to close × without
+    // re-flowing tab content width.
     private var closeOrDirtyIndicator: some View {
         ZStack {
             // Dirty indicator (shown when dirty and not hovering, hidden for selected tab)

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -336,6 +336,16 @@ extension BonsplitConfiguration {
         ]
     }
 
+    /// Controls which edge of a tab renders the close (×) affordance.
+    public enum CloseButtonPosition: String, Sendable, Codable, CaseIterable {
+        /// Render the close button at the leading edge of the tab content.
+        /// Matches the macOS Safari/Finder tab convention.
+        case leading
+
+        /// Render the close button at the trailing edge of the tab content.
+        case trailing
+    }
+
     public struct SplitButtonTooltips: Sendable, Equatable {
         public var newTerminal: String
         public var newBrowser: String
@@ -523,6 +533,9 @@ extension BonsplitConfiguration {
         /// that would create visibly different translucent layers.
         public var usesSharedBackdrop: Bool
 
+        /// Edge of the tab where the close (×) affordance renders.
+        public var closeButtonPosition: CloseButtonPosition
+
         // MARK: - Presets
 
         public static let `default` = Appearance()
@@ -562,7 +575,8 @@ extension BonsplitConfiguration {
             animationDuration: Double = 0.15,
             enableAnimations: Bool = true,
             chromeColors: ChromeColors = .init(),
-            usesSharedBackdrop: Bool = false
+            usesSharedBackdrop: Bool = false,
+            closeButtonPosition: CloseButtonPosition = .trailing
         ) {
             self.tabBarHeight = tabBarHeight
             self.tabMinWidth = tabMinWidth
@@ -582,6 +596,7 @@ extension BonsplitConfiguration {
             self.enableAnimations = enableAnimations
             self.chromeColors = chromeColors
             self.usesSharedBackdrop = usesSharedBackdrop
+            self.closeButtonPosition = closeButtonPosition
         }
 
         private static func uniqueSplitButtons(_ buttons: [SplitActionButton]) -> [SplitActionButton] {

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -337,12 +337,23 @@ extension BonsplitConfiguration {
     }
 
     /// Controls which edge of a tab renders the close (×) affordance.
+    ///
+    /// Edges are locale-aware: `.leading` and `.trailing` follow SwiftUI's
+    /// `LayoutDirection` environment, so a `.leading` close button renders on
+    /// the visual left in left-to-right locales (en, ja, ko, …) and on the
+    /// visual right in right-to-left locales (ar, he, …). The position is
+    /// inherited from standard `HStack` ordering rather than hard-coded sides.
+    /// With `.leading`, the close × shares the favicon slot via overlay
+    /// (Safari 15+/Finder/Xcode style) rather than occupying a separate slot,
+    /// so toggling the value does not change tab content width.
     public enum CloseButtonPosition: String, Sendable, Codable, CaseIterable {
-        /// Render the close button at the leading edge of the tab content.
-        /// Matches the macOS Safari/Finder tab convention.
+        /// Render the close button at the leading edge of the tab content
+        /// (visual left in LTR, visual right in RTL). Matches the macOS
+        /// Safari/Finder tab convention.
         case leading
 
-        /// Render the close button at the trailing edge of the tab content.
+        /// Render the close button at the trailing edge of the tab content
+        /// (visual right in LTR, visual left in RTL).
         case trailing
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3582,4 +3582,28 @@ final class BonsplitTests: XCTestCase {
         }
         return event
     }
+
+    func testCloseButtonPositionDefaultsToTrailing() {
+        let appearance = BonsplitConfiguration.Appearance()
+        XCTAssertEqual(appearance.closeButtonPosition, .trailing)
+    }
+
+    func testCloseButtonPositionRoundTripsThroughInit() {
+        let leading = BonsplitConfiguration.Appearance(closeButtonPosition: .leading)
+        XCTAssertEqual(leading.closeButtonPosition, .leading)
+
+        let trailing = BonsplitConfiguration.Appearance(closeButtonPosition: .trailing)
+        XCTAssertEqual(trailing.closeButtonPosition, .trailing)
+    }
+
+    func testCloseButtonPositionEnumIsCodable() throws {
+        for position in BonsplitConfiguration.CloseButtonPosition.allCases {
+            let encoded = try JSONEncoder().encode(position)
+            let decoded = try JSONDecoder().decode(
+                BonsplitConfiguration.CloseButtonPosition.self,
+                from: encoded
+            )
+            XCTAssertEqual(decoded, position)
+        }
+    }
 }


### PR DESCRIPTION
Adds `BonsplitConfiguration.CloseButtonPosition` (`leading` / `trailing`, library default `.trailing` for backward compatibility) so hosts can align the tab close (×) affordance with either edge.

## Final design: Safari 15+ favicon-slot overlay

In leading mode the favicon slot doubles as the close-button slot — matching Safari 15+ / Xcode:

- Inactive unhovered tab: favicon visible; no × rendered; layout identical to the upstream Bonsplit body.
- Hovered / selected tab: favicon fades to `opacity: 0`; × renders centered in the same slot.

No separate slot, no layout shift, tab geometry unchanged regardless of close-button position. Trailing mode is unchanged (library default).

### Trailing accessory slot in leading mode

The trailing slot is **rendered conditionally** in leading mode via `rendersTrailingAccessorySlot`:

- Dropped (zero width) when nothing else needs it — avoids a phantom close-button-sized gap on the right edge of the tab.
- Kept when there is content to show: dirty / notification dot, pin glyph, or Cmd-N shortcut-hint pill.

Trailing mode always reserves the slot so the close × can fade in/out without layout shift.

## Changes

- `BonsplitConfiguration.swift` — new public `CloseButtonPosition` enum (`String`, `Sendable`, `Codable`, `CaseIterable`); `Appearance.closeButtonPosition` field + init parameter (default `.trailing`).
- `TabItemView.swift` — two added lines on the favicon Group (`.opacity(showsLeadingCloseOverlay ? 0 : 1)` + `.overlay(alignment: .center) { if showsLeadingCloseOverlay { leadingCloseOverlayButton } }`) plus the `showsLeadingCloseOverlay` / `leadingCloseOverlayButton` / `rendersTrailingAccessorySlot` helpers. Both modifiers are no-ops when trailing mode is active, preserving the upstream body layout for the default configuration. One-line gate in `closeOrDirtyIndicator` skips the trailing close button when leading mode owns it.
- `BonsplitTests.swift` — new tests for default `.trailing`, round-trip through `Appearance.init`, and `Codable` round-trip.

Hot-path safe: no new `ObservableObject` / `@Binding` / `@EnvironmentObject` on the typing-sensitive `TabItemView.body`; just a scalar read of `appearance.closeButtonPosition` + booleans.

## Note on PR diff

The diff against `main` currently includes 4 commits from a not-yet-merged shared-backdrop branch (`61dad7f`, `282c5296`, `7adf710`, `d403ae6`) that are pulled in transitively because `manaflow-ai/cmux@main` already bumped `vendor/bonsplit` to that branch's tip. Reviewers should focus on the final commit (`feat: add configurable tab close button position`) — the four upstream commits will disappear from the diff once the shared-backdrop work lands on bonsplit `main`.

## Consumed by

[manaflow-ai/cmux#3066](https://github.com/manaflow-ai/cmux/pull/3066) — adds a cmux Settings toggle (`Left` / `Right`) with live update.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter CloseButtonPosition` — 3/3 passing
- [x] Downstream cmux build + live toggle verified manually in Debug app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New configuration to place tab close buttons on the leading or trailing edge (defaults to trailing). Leading placement shows a centered close overlay and fades the favicon/icon; trailing placement keeps the close control at the trailing edge and retains trailing indicators.

* **Tests**
  * Added tests verifying close-button placement, default behavior, and serialization round-trip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
