### PR TITLE
Fix standard tab-bar new-tab click handling

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1095,7 +1095,8 @@ struct TabBarDragZoneView: NSViewRepresentable {
         var onSingleClick: (() -> Bool)?
         var onDoubleClick: (() -> Bool)?
         var performWindowDrag: ((NSEvent) -> Bool)?
-        var nextWindowDragEvent: ((NSWindow) -> NSEvent?)?
+        private var pendingWindowDragEvent: NSEvent?
+        private var pendingWindowDragStart: NSPoint?
 
         private static let windowDragStartDistanceSquared: CGFloat = 16
 
@@ -1123,6 +1124,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if event.clickCount >= 2 {
+                clearPendingWindowDrag()
                 if onDoubleClick?() == true {
 #if DEBUG
                     dlog("tab.bar.dragZone.doubleClick action=newTab")
@@ -1140,6 +1142,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if isMinimalMode, !isFocusedPane, onSingleClick?() == true {
+                clearPendingWindowDrag()
 #if DEBUG
                 dlog("tab.bar.dragZone.focusPane")
 #endif
@@ -1147,68 +1150,63 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if isMinimalMode {
-                trackWindowDragIfNeeded(from: event, in: window)
+                pendingWindowDragEvent = event
+                pendingWindowDragStart = event.locationInWindow
             } else {
+                clearPendingWindowDrag()
                 super.mouseDown(with: event)
             }
         }
 
-        private func trackWindowDragIfNeeded(from event: NSEvent, in window: NSWindow) {
-            let start = event.locationInWindow
-            while true {
-                guard let nextEvent = nextTrackedEvent(in: window) else {
-#if DEBUG
-                    dlog("tab.bar.dragZone.dragTrack.end reason=noEvent")
-#endif
-                    return
-                }
-
-                switch nextEvent.type {
-                case .leftMouseDragged:
-                    let dx = nextEvent.locationInWindow.x - start.x
-                    let dy = nextEvent.locationInWindow.y - start.y
-                    guard dx * dx + dy * dy >= Self.windowDragStartDistanceSquared else {
-                        continue
-                    }
-#if DEBUG
-                    dlog(
-                        "tab.bar.dragZone.dragStart " +
-                        "dx=\(dx.rounded()) dy=\(dy.rounded())"
-                    )
-#endif
-                    startWindowDrag(with: event, in: window)
-                    return
-                case .leftMouseUp:
-#if DEBUG
-                    dlog("tab.bar.dragZone.dragTrack.end reason=mouseUp")
-#endif
-                    return
-                default:
-                    continue
-                }
+        override func mouseDragged(with event: NSEvent) {
+            guard isMinimalMode,
+                  let window,
+                  let pendingEvent = pendingWindowDragEvent,
+                  let start = pendingWindowDragStart else {
+                super.mouseDragged(with: event)
+                return
             }
+
+            let dx = event.locationInWindow.x - start.x
+            let dy = event.locationInWindow.y - start.y
+            guard dx * dx + dy * dy >= Self.windowDragStartDistanceSquared else {
+                return
+            }
+
+#if DEBUG
+            dlog(
+                "tab.bar.dragZone.dragStart " +
+                "dx=\(dx.rounded()) dy=\(dy.rounded())"
+            )
+#endif
+            clearPendingWindowDrag()
+            startWindowDrag(with: pendingEvent, in: window)
         }
 
-        private func nextTrackedEvent(in window: NSWindow) -> NSEvent? {
-            if let nextWindowDragEvent {
-                return nextWindowDragEvent(window)
-            }
-            return window.nextEvent(
-                matching: [.leftMouseDragged, .leftMouseUp],
-                until: .distantFuture,
-                inMode: .eventTracking,
-                dequeue: true
-            )
+        override func mouseUp(with event: NSEvent) {
+            clearPendingWindowDrag()
+            super.mouseUp(with: event)
+        }
+
+        private func clearPendingWindowDrag() {
+            pendingWindowDragEvent = nil
+            pendingWindowDragStart = nil
         }
 
         private func startWindowDrag(with event: NSEvent, in window: NSWindow) {
             if let performWindowDrag, performWindowDrag(event) {
+#if DEBUG
+                dlog("tab.bar.dragZone.dragStart action=testHook")
+#endif
                 return
             }
             let wasMovable = window.isMovable
             window.isMovable = true
             defer { window.isMovable = wasMovable }
             window.performDrag(with: event)
+#if DEBUG
+            dlog("tab.bar.dragZone.dragStart action=windowPerformDrag")
+#endif
         }
 
         private func performTitlebarDoubleClickAction(in window: NSWindow) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1100,9 +1100,14 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
         private static let windowDragStartDistanceSquared: CGFloat = 16
 
-        override var mouseDownCanMoveWindow: Bool {
-            isMinimalMode && isFocusedPane
-        }
+        // Must stay false so AppKit does not intercept mouseUp as part of its
+        // own window-drag tracking. When AppKit steals mouseUp from the first
+        // click, the second click of a double-click is registered as a fresh
+        // clickCount=1 instead of 2, making new-tab double-clicks flaky. We
+        // still support window dragging via the custom mouseDragged →
+        // window.performDrag flow below. See `NonDraggableHostingView` in
+        // SplitNodeView.swift for the same class of bug on pane tab clicks.
+        override var mouseDownCanMoveWindow: Bool { false }
 
         override func hitTest(_ point: NSPoint) -> NSView? {
             return bounds.contains(point) ? self : nil

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -425,8 +425,14 @@ struct TabBarView: View {
                         }
                         .frame(width: 0, height: 0)
                     )
-                    // When the tab strip is shorter than the visible area, allow dropping in the
-                    // empty trailing space without forcing tabs to stretch.
+                    // When the tab strip is shorter than the visible area, place a single
+                    // drag zone over both the empty trailing space AND the 30pt inline
+                    // dropZoneAfterTabs (extended leftward by 30pt). The inline zone's
+                    // DragNSView is then visually covered, so all clicks in this region land
+                    // on this overlay's single DragNSView. AppKit tracks `clickCount` per
+                    // view, so without this an unlucky shift in the inline/overlay boundary
+                    // between two clicks would split a double-click into two clickCount=1
+                    // events and the new-tab action would never fire.
                     .overlay(alignment: .trailing) {
                         let trailing = max(0, containerGeo.size.width - contentWidth)
                         if trailing >= 1 {
@@ -439,7 +445,7 @@ struct TabBarView: View {
                                 controller.requestNewTab(kind: "terminal", inPane: pane.id)
                                 return true
                             }
-                            .frame(width: trailing, height: TabBarMetrics.tabHeight)
+                            .frame(width: trailing + 30, height: TabBarMetrics.tabHeight)
                             .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
                                 targetIndex: pane.tabs.count,
                                 pane: pane,
@@ -1128,6 +1134,29 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 return
             }
 
+            // Standard (non-minimal) mode: a click in the empty trailing area
+            // should create a new tab on the very first click, not require a
+            // double-click. We dedupe subsequent clicks of the same gesture so
+            // a real double-click doesn't create two tabs back-to-back.
+            if !isMinimalMode {
+                clearPendingWindowDrag()
+                if event.clickCount == 1 {
+                    if onDoubleClick?() == true {
+#if DEBUG
+                        dlog("tab.bar.dragZone.singleClick action=newTab")
+#endif
+                        return
+                    }
+                    super.mouseDown(with: event)
+                    return
+                }
+                // clickCount >= 2: same gesture as a click we already acted on.
+#if DEBUG
+                dlog("tab.bar.dragZone.click skipped reason=dedupeStandardMode clickCount=\(event.clickCount)")
+#endif
+                return
+            }
+
             if event.clickCount >= 2 {
                 clearPendingWindowDrag()
                 if onDoubleClick?() == true {
@@ -1137,16 +1166,14 @@ struct TabBarDragZoneView: NSViewRepresentable {
                     return
                 }
 
-                if isMinimalMode {
 #if DEBUG
-                    dlog("tab.bar.dragZone.doubleClick action=titlebar")
+                dlog("tab.bar.dragZone.doubleClick action=titlebar")
 #endif
-                    performTitlebarDoubleClickAction(in: window)
-                    return
-                }
+                performTitlebarDoubleClickAction(in: window)
+                return
             }
 
-            if isMinimalMode, !isFocusedPane, onSingleClick?() == true {
+            if !isFocusedPane, onSingleClick?() == true {
                 clearPendingWindowDrag()
 #if DEBUG
                 dlog("tab.bar.dragZone.focusPane")
@@ -1154,13 +1181,8 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 return
             }
 
-            if isMinimalMode {
-                pendingWindowDragEvent = event
-                pendingWindowDragStart = event.locationInWindow
-            } else {
-                clearPendingWindowDrag()
-                super.mouseDown(with: event)
-            }
+            pendingWindowDragEvent = event
+            pendingWindowDragStart = event.locationInWindow
         }
 
         override func mouseDragged(with event: NSEvent) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1095,6 +1095,9 @@ struct TabBarDragZoneView: NSViewRepresentable {
         var onSingleClick: (() -> Bool)?
         var onDoubleClick: (() -> Bool)?
         var performWindowDrag: ((NSEvent) -> Bool)?
+        var nextWindowDragEvent: ((NSWindow) -> NSEvent?)?
+
+        private static let windowDragStartDistanceSquared: CGFloat = 16
 
         override var mouseDownCanMoveWindow: Bool {
             isMinimalMode && isFocusedPane
@@ -1106,9 +1109,12 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
         override func mouseDown(with event: NSEvent) {
 #if DEBUG
+            let point = convert(event.locationInWindow, from: nil)
             dlog(
                 "tab.bar.dragZone.mouseDown isMinimal=\(isMinimalMode ? 1 : 0) " +
-                "focused=\(isFocusedPane ? 1 : 0) clickCount=\(event.clickCount)"
+                "focused=\(isFocusedPane ? 1 : 0) clickCount=\(event.clickCount) " +
+                "point=\(point.x.rounded()),\(point.y.rounded()) " +
+                "bounds=\(bounds.width.rounded())x\(bounds.height.rounded())"
             )
 #endif
             guard let window = self.window else {
@@ -1117,17 +1123,19 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if event.clickCount >= 2 {
-                if isMinimalMode {
-                    let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
-                    switch action {
-                    case "Minimize": window.miniaturize(nil)
-                    default: window.zoom(nil)
-                    }
+                if onDoubleClick?() == true {
+#if DEBUG
+                    dlog("tab.bar.dragZone.doubleClick action=newTab")
+#endif
                     return
-                } else {
-                    if onDoubleClick?() == true {
-                        return
-                    }
+                }
+
+                if isMinimalMode {
+#if DEBUG
+                    dlog("tab.bar.dragZone.doubleClick action=titlebar")
+#endif
+                    performTitlebarDoubleClickAction(in: window)
+                    return
                 }
             }
 
@@ -1139,15 +1147,75 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if isMinimalMode {
-                if let performWindowDrag, performWindowDrag(event) {
-                    return
-                }
-                let wasMovable = window.isMovable
-                window.isMovable = true
-                window.performDrag(with: event)
-                window.isMovable = wasMovable
+                trackWindowDragIfNeeded(from: event, in: window)
             } else {
                 super.mouseDown(with: event)
+            }
+        }
+
+        private func trackWindowDragIfNeeded(from event: NSEvent, in window: NSWindow) {
+            let start = event.locationInWindow
+            while true {
+                guard let nextEvent = nextTrackedEvent(in: window) else {
+#if DEBUG
+                    dlog("tab.bar.dragZone.dragTrack.end reason=noEvent")
+#endif
+                    return
+                }
+
+                switch nextEvent.type {
+                case .leftMouseDragged:
+                    let dx = nextEvent.locationInWindow.x - start.x
+                    let dy = nextEvent.locationInWindow.y - start.y
+                    guard dx * dx + dy * dy >= Self.windowDragStartDistanceSquared else {
+                        continue
+                    }
+#if DEBUG
+                    dlog(
+                        "tab.bar.dragZone.dragStart " +
+                        "dx=\(dx.rounded()) dy=\(dy.rounded())"
+                    )
+#endif
+                    startWindowDrag(with: event, in: window)
+                    return
+                case .leftMouseUp:
+#if DEBUG
+                    dlog("tab.bar.dragZone.dragTrack.end reason=mouseUp")
+#endif
+                    return
+                default:
+                    continue
+                }
+            }
+        }
+
+        private func nextTrackedEvent(in window: NSWindow) -> NSEvent? {
+            if let nextWindowDragEvent {
+                return nextWindowDragEvent(window)
+            }
+            return window.nextEvent(
+                matching: [.leftMouseDragged, .leftMouseUp],
+                until: .distantFuture,
+                inMode: .eventTracking,
+                dequeue: true
+            )
+        }
+
+        private func startWindowDrag(with event: NSEvent, in window: NSWindow) {
+            if let performWindowDrag, performWindowDrag(event) {
+                return
+            }
+            let wasMovable = window.isMovable
+            window.isMovable = true
+            defer { window.isMovable = wasMovable }
+            window.performDrag(with: event)
+        }
+
+        private func performTitlebarDoubleClickAction(in window: NSWindow) {
+            let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
+            switch action {
+            case "Minimize": window.miniaturize(nil)
+            default: window.zoom(nil)
             }
         }
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1252,6 +1252,86 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarDragZoneSingleClickRequestsNewTabInStandardMode() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+        view.isMinimalMode = false
+        view.isFocusedPane = true
+
+        var newTabCount = 0
+        var dragged = false
+        view.onDoubleClick = {
+            newTabCount += 1
+            return true
+        }
+        view.performWindowDrag = { _ in
+            dragged = true
+            return true
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
+        view.mouseDown(with: event)
+
+        XCTAssertEqual(newTabCount, 1, "Standard-mode drag zone single click should immediately request a new tab")
+        XCTAssertFalse(dragged, "Standard-mode drag zone single click should not begin a window drag")
+    }
+
+    @MainActor
+    func testTabBarDragZoneStandardModeDoubleClickCreatesOnlyOneTab() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+        view.isMinimalMode = false
+        view.isFocusedPane = true
+
+        var newTabCount = 0
+        view.onDoubleClick = {
+            newTabCount += 1
+            return true
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        let firstDown = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
+        let firstUp = try makeMouseEvent(
+            type: .leftMouseUp,
+            in: view,
+            at: NSPoint(x: 20, y: 15),
+            clickCount: 1
+        )
+        let secondDown = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 2)
+
+        view.mouseDown(with: firstDown)
+        view.mouseUp(with: firstUp)
+        view.mouseDown(with: secondDown)
+
+        XCTAssertEqual(newTabCount, 1, "A standard-mode double-click must only create one tab; the clickCount=2 follow-up should be deduped")
+    }
+
+    @MainActor
     func testTabBarDragZoneKeepsFocusedPaneWindowDragInMinimalMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.isMinimalMode = true

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1166,6 +1166,54 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarDragZoneSingleClickDoesNotBlockLaterDoubleClickInMinimalMode() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+        view.isMinimalMode = true
+        view.isFocusedPane = true
+
+        var requestedNewTab = false
+        var dragged = false
+        view.onDoubleClick = {
+            requestedNewTab = true
+            return true
+        }
+        view.performWindowDrag = { _ in
+            dragged = true
+            return true
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        let firstDown = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
+        let firstUp = try makeMouseEvent(
+            type: .leftMouseUp,
+            in: view,
+            at: NSPoint(x: 20, y: 15),
+            clickCount: 1
+        )
+        let doubleClick = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 2)
+
+        view.mouseDown(with: firstDown)
+        view.mouseUp(with: firstUp)
+        view.mouseDown(with: doubleClick)
+
+        XCTAssertTrue(requestedNewTab, "A prior single click must not leave the drag zone unable to handle double-clicks")
+        XCTAssertFalse(dragged, "A plain click followed by a double-click should not start a window drag")
+    }
+
+    @MainActor
     func testTabBarDragZoneDoubleClickRequestsNewTabInMinimalMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.isMinimalMode = true
@@ -1241,13 +1289,8 @@ final class BonsplitTests: XCTestCase {
             at: NSPoint(x: 30, y: 15),
             clickCount: 1
         )
-        var returnedDragEvent = false
-        view.nextWindowDragEvent = { _ in
-            guard !returnedDragEvent else { return nil }
-            returnedDragEvent = true
-            return dragEvent
-        }
         view.mouseDown(with: event)
+        view.mouseDragged(with: dragEvent)
 
         XCTAssertFalse(focused, "Focused-pane drag zone should not bounce through first-click focus")
         XCTAssertTrue(dragged, "Focused-pane drag zone should continue to start window drags in minimal mode")

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1294,7 +1294,7 @@ final class BonsplitTests: XCTestCase {
 
         XCTAssertFalse(focused, "Focused-pane drag zone should not bounce through first-click focus")
         XCTAssertTrue(dragged, "Focused-pane drag zone should continue to start window drags in minimal mode")
-        XCTAssertTrue(view.mouseDownCanMoveWindow, "Focused-pane drag zone should continue advertising window dragging to AppKit")
+        XCTAssertFalse(view.mouseDownCanMoveWindow, "Focused-pane drag zone must not advertise window dragging to AppKit or AppKit steals mouseUp and breaks new-tab double-clicks")
     }
 
     private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1235,6 +1235,18 @@ final class BonsplitTests: XCTestCase {
         contentView.addSubview(view)
         window.makeKeyAndOrderFront(nil)
         let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
+        let dragEvent = try makeMouseEvent(
+            type: .leftMouseDragged,
+            in: view,
+            at: NSPoint(x: 30, y: 15),
+            clickCount: 1
+        )
+        var returnedDragEvent = false
+        view.nextWindowDragEvent = { _ in
+            guard !returnedDragEvent else { return nil }
+            returnedDragEvent = true
+            return dragEvent
+        }
         view.mouseDown(with: event)
 
         XCTAssertFalse(focused, "Focused-pane drag zone should not bounce through first-click focus")
@@ -1343,12 +1355,22 @@ final class BonsplitTests: XCTestCase {
         at point: NSPoint,
         clickCount: Int
     ) throws -> NSEvent {
+        try makeMouseEvent(type: .leftMouseDown, in: view, at: point, clickCount: clickCount)
+    }
+
+    @MainActor
+    private func makeMouseEvent(
+        type: NSEvent.EventType,
+        in view: NSView,
+        at point: NSPoint,
+        clickCount: Int
+    ) throws -> NSEvent {
         guard let window = view.window else {
             throw NSError(domain: "BonsplitTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing window"])
         }
         let pointInWindow = view.convert(point, to: nil)
         guard let event = NSEvent.mouseEvent(
-            with: .leftMouseDown,
+            with: type,
             location: pointInWindow,
             modifierFlags: [],
             timestamp: ProcessInfo.processInfo.systemUptime,

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1166,6 +1166,44 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarDragZoneDoubleClickRequestsNewTabInMinimalMode() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+        view.isMinimalMode = true
+        view.isFocusedPane = true
+
+        var requestedNewTab = false
+        var dragged = false
+        view.onDoubleClick = {
+            requestedNewTab = true
+            return true
+        }
+        view.performWindowDrag = { _ in
+            dragged = true
+            return true
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 2)
+        view.mouseDown(with: event)
+
+        XCTAssertTrue(requestedNewTab, "Minimal-mode drag zone double-click should request the new-tab action")
+        XCTAssertFalse(dragged, "Minimal-mode double-click should not start a window drag")
+    }
+
+    @MainActor
     func testTabBarDragZoneKeepsFocusedPaneWindowDragInMinimalMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.isMinimalMode = true


### PR DESCRIPTION
Publishes the bonsplit side of manaflow-ai/cmux issue 3049.\n\n- adds standard-mode tab-bar new-tab regression coverage\n- makes a click in the empty trailing tab-bar region request a new tab immediately\n- keeps follow-up double-click events from creating duplicate tabs\n\nThis PR is needed before the cmux parent repo can point at a clean bonsplit SHA on origin/main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the tab bar drag zone hit-testing area
  * Improved single-click and double-click handling in the tab bar interface
  * Fixed window drag initiation behavior during click operations
  * Enhanced click response detection across minimal and standard modes

* **Tests**
  * Added comprehensive test cases covering tab bar mouse interactions and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab-bar new-tab click handling to remove flakiness and accidental duplicates. Single clicks in the trailing empty space now create a tab, and double-clicks behave correctly in both standard and minimal modes while preserving window drag.

- **Bug Fixes**
  - Standard mode: single click in trailing space opens a new tab; follow-up double-click is deduped.
  - Add a trailing overlay and widen it by 30pt to cover the inline `dropZoneAfterTabs`, keeping `clickCount` consistent across boundary shifts.
  - Stop advertising `mouseDownCanMoveWindow`; use custom `mouseDragged` → `window.performDrag` with a small movement threshold to prevent AppKit from stealing mouseUp.
  - Minimal mode: double-click reliably triggers new tab; window dragging still works when focused.
  - Add regression tests for standard/minimal modes, double-click dedupe, and drag behavior.

<sup>Written for commit 68659a284c85e0175be1d173082972fcb6fa98c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

