### PR TITLE
Gate tab shortcut hints by host focus

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -36,6 +36,11 @@ final class SplitViewController {
     /// updateNSView is called to toggle isHidden on the AppKit containers.
     var isInteractive: Bool = true
 
+    /// When false, pane tab shortcut hints stay hidden even if this pane is
+    /// selected. The host app owns this because keyboard focus can move outside
+    /// Bonsplit while the selected pane remains unchanged.
+    var tabShortcutHintsEnabled: Bool = true
+
     /// Handler for file/URL drops from external apps (e.g. Finder).
     /// Receives the dropped URLs and the pane ID where the drop occurred.
     @ObservationIgnored var onFileDrop: ((_ urls: [URL], _ paneId: PaneID) -> Bool)?

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1108,6 +1108,9 @@ private struct SplitActionButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+            .opacity(configuration.isPressed ? 0.72 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
+            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -184,9 +184,7 @@ enum TabBarStyling {
     }
 
     static func imageDataShouldRenderAsTemplate(_ data: Data) -> Bool {
-        guard let text = String(data: data.prefix(4096), encoding: .utf8) else {
-            return false
-        }
+        let text = String(decoding: data.prefix(4096), as: UTF8.self)
         let lowercased = text.lowercased()
         return lowercased.contains("<svg") && lowercased.contains("currentcolor")
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1068,33 +1068,36 @@ struct TabBarView: View {
 private final class SplitActionButtonImageCache {
     static let shared = SplitActionButtonImageCache()
 
-    private var images: [Data: NSImage] = [:]
-    private var invalidImageData: Set<Data> = []
-    private let lock = NSLock()
+    private let images = NSCache<NSData, NSImage>()
+    private let invalidImageData = NSCache<NSData, NSNumber>()
+
+    private init() {
+        images.countLimit = 128
+        images.totalCostLimit = 8 * 1024 * 1024
+        invalidImageData.countLimit = 256
+        invalidImageData.totalCostLimit = 512 * 1024
+    }
 
     func image(for data: Data) -> NSImage? {
-        lock.lock()
-        if let image = images[data] {
-            lock.unlock()
+        let key = data as NSData
+        if let image = images.object(forKey: key) {
             return image
         }
-        if invalidImageData.contains(data) {
-            lock.unlock()
+        if invalidImageData.object(forKey: key) != nil {
             return nil
         }
-        lock.unlock()
 
         guard let image = NSImage(data: data) else {
-            lock.lock()
-            invalidImageData.insert(data)
-            lock.unlock()
+            invalidImageData.setObject(
+                NSNumber(value: true),
+                forKey: key,
+                cost: max(1, min(data.count, 1024))
+            )
             return nil
         }
         image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
 
-        lock.lock()
-        images[data] = image
-        lock.unlock()
+        images.setObject(image, forKey: key, cost: max(1, data.count))
         return image
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -351,7 +351,7 @@ struct TabBarView: View {
     }
 
     private var showsControlShortcutHints: Bool {
-        isFocused && controlKeyMonitor.isShortcutHintVisible
+        isFocused && splitViewController.tabShortcutHintsEnabled && controlKeyMonitor.isShortcutHintVisible
     }
 
     private var isMinimalMode: Bool {
@@ -605,6 +605,7 @@ struct TabBarView: View {
             appearance: appearance,
             saturation: tabBarSaturation,
             controlShortcutDigit: tabControlShortcutDigit(for: index, tabCount: pane.tabs.count),
+            allowsShortcutHints: isFocused && splitViewController.tabShortcutHintsEnabled,
             showsControlShortcutHint: showsControlShortcutHints,
             shortcutModifierSymbol: controlKeyMonitor.shortcutModifierSymbol,
             contextMenuState: contextMenuState,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1134,6 +1134,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         nsView.isMinimalMode = isMinimalMode
         nsView.onDoubleClick = onDoubleClick
         nsView.onHoverChanged = onHoverChanged
+        nsView.syncHoverStateToCurrentMouseLocation()
     }
 
     final class TabBarBackgroundNSView: NSView {
@@ -1141,18 +1142,26 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         var onDoubleClick: (() -> Bool)?
         var onHoverChanged: ((Bool) -> Void)?
         private var hoverTrackingArea: NSTrackingArea?
+        private var windowDidBecomeKeyObserver: NSObjectProtocol?
+        private var windowDidResignKeyObserver: NSObjectProtocol?
 
         override var mouseDownCanMoveWindow: Bool { false }
 
         deinit {
+            removeWindowObservers()
             BonsplitTabBarHitRegionRegistry.unregister(self)
         }
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             BonsplitTabBarHitRegionRegistry.unregister(self)
+            removeWindowObservers()
             if window != nil {
                 BonsplitTabBarHitRegionRegistry.register(self)
+                installWindowObservers()
+                syncHoverStateToCurrentMouseLocation()
+            } else {
+                onHoverChanged?(false)
             }
         }
 
@@ -1175,6 +1184,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             )
             addTrackingArea(area)
             hoverTrackingArea = area
+            syncHoverStateToCurrentMouseLocation()
         }
 
         override func mouseEntered(with event: NSEvent) {
@@ -1214,6 +1224,44 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             window.isMovable = true
             window.performDrag(with: event)
             window.isMovable = wasMovable
+        }
+
+        func syncHoverStateToCurrentMouseLocation() {
+            guard let window else {
+                onHoverChanged?(false)
+                return
+            }
+            let point = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            onHoverChanged?(bounds.contains(point))
+        }
+
+        private func installWindowObservers() {
+            guard let window else { return }
+            windowDidBecomeKeyObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.syncHoverStateToCurrentMouseLocation()
+            }
+            windowDidResignKeyObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.syncHoverStateToCurrentMouseLocation()
+            }
+        }
+
+        private func removeWindowObservers() {
+            if let windowDidBecomeKeyObserver {
+                NotificationCenter.default.removeObserver(windowDidBecomeKeyObserver)
+                self.windowDidBecomeKeyObserver = nil
+            }
+            if let windowDidResignKeyObserver {
+                NotificationCenter.default.removeObserver(windowDidResignKeyObserver)
+                self.windowDidResignKeyObserver = nil
+            }
         }
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -852,9 +852,9 @@ struct TabBarView: View {
         case .systemImage(let name):
             Image(systemName: name)
                 .font(.system(size: 12))
-        case .emoji(let value):
+        case .emoji(let value, let scale):
             Text(value)
-                .font(.system(size: 13))
+                .font(.system(size: emojiIconFontSize(scale: scale)))
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
         case .imageData(let data):
@@ -870,6 +870,16 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
         }
+    }
+
+    private func emojiIconFontSize(scale: Double) -> CGFloat {
+        let safeScale: CGFloat
+        if scale.isFinite, scale > 0 {
+            safeScale = CGFloat(scale)
+        } else {
+            safeScale = 1
+        }
+        return 13 * safeScale
     }
 
     private func splitActionButtonImage(from data: Data) -> NSImage? {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -183,6 +183,14 @@ enum TabBarStyling {
             + (CGFloat(max(0, buttonCount - 1)) * splitButtonsSpacing)
     }
 
+    static func imageDataShouldRenderAsTemplate(_ data: Data) -> Bool {
+        guard let text = String(data: data.prefix(4096), encoding: .utf8) else {
+            return false
+        }
+        let lowercased = text.lowercased()
+        return lowercased.contains("<svg") && lowercased.contains("currentcolor")
+    }
+
     enum ScrollTarget: Equatable {
         case leading
         case selectedTab(UUID)
@@ -852,8 +860,9 @@ struct TabBarView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
         case .imageData(let data):
-            if let image = NSImage(data: data) {
+            if let image = splitActionButtonImage(from: data) {
                 Image(nsImage: image)
+                    .renderingMode(image.isTemplate ? .template : .original)
                     .resizable()
                     .interpolation(.high)
                     .scaledToFit()
@@ -863,6 +872,12 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
         }
+    }
+
+    private func splitActionButtonImage(from data: Data) -> NSImage? {
+        guard let image = NSImage(data: data) else { return nil }
+        image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
+        return image
     }
 
     private func splitActionButtonTooltip(

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -189,6 +189,10 @@ enum TabBarStyling {
         return lowercased.contains("<svg") && lowercased.contains("currentcolor")
     }
 
+    static func splitActionButtonImage(from data: Data) -> NSImage? {
+        SplitActionButtonImageCache.shared.image(for: data)
+    }
+
     enum ScrollTarget: Equatable {
         case leading
         case selectedTab(UUID)
@@ -878,9 +882,7 @@ struct TabBarView: View {
     }
 
     private func splitActionButtonImage(from data: Data) -> NSImage? {
-        guard let image = NSImage(data: data) else { return nil }
-        image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
-        return image
+        TabBarStyling.splitActionButtonImage(from: data)
     }
 
     private func splitActionButtonTooltip(
@@ -1060,6 +1062,40 @@ struct TabBarView: View {
                 }
                 .frame(height: 1)
             }
+    }
+}
+
+private final class SplitActionButtonImageCache {
+    static let shared = SplitActionButtonImageCache()
+
+    private var images: [Data: NSImage] = [:]
+    private var invalidImageData: Set<Data> = []
+    private let lock = NSLock()
+
+    func image(for data: Data) -> NSImage? {
+        lock.lock()
+        if let image = images[data] {
+            lock.unlock()
+            return image
+        }
+        if invalidImageData.contains(data) {
+            lock.unlock()
+            return nil
+        }
+        lock.unlock()
+
+        guard let image = NSImage(data: data) else {
+            lock.lock()
+            invalidImageData.insert(data)
+            lock.unlock()
+            return nil
+        }
+        image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
+
+        lock.lock()
+        images[data] = image
+        lock.unlock()
+        return image
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -166,7 +166,22 @@ private final class TabBarScrollViewBridge: ObservableObject {
 }
 
 enum TabBarStyling {
-    static let splitButtonsBackdropWidth: CGFloat = 114
+    static let splitActionButtonReservedWidth: CGFloat = 22
+    static let splitButtonsSpacing: CGFloat = 4
+    static let splitButtonsLeadingPadding: CGFloat = 6
+    static let splitButtonsTrailingPadding: CGFloat = 8
+
+    static var splitButtonsBackdropWidth: CGFloat {
+        splitButtonsBackdropWidth(buttonCount: BonsplitConfiguration.SplitActionButton.defaults.count)
+    }
+
+    static func splitButtonsBackdropWidth(buttonCount: Int) -> CGFloat {
+        guard buttonCount > 0 else { return 0 }
+        return splitButtonsLeadingPadding
+            + splitButtonsTrailingPadding
+            + (CGFloat(buttonCount) * splitActionButtonReservedWidth)
+            + (CGFloat(max(0, buttonCount - 1)) * splitButtonsSpacing)
+    }
 
     enum ScrollTarget: Equatable {
         case leading
@@ -193,14 +208,15 @@ enum TabBarStyling {
 
     static func trailingTabContentInset(
         showSplitButtons: Bool,
-        isMinimalMode: Bool
+        isMinimalMode: Bool,
+        buttonCount: Int = BonsplitConfiguration.SplitActionButton.defaults.count
     ) -> CGFloat {
-        guard showSplitButtons else { return 0 }
+        guard showSplitButtons, buttonCount > 0 else { return 0 }
 
         // In minimal mode the split buttons fade in on hover as an overlay. Reserving that
         // width in the scroll content leaves a dead NSClipView strip when the buttons are
         // hidden, so clicks there never reach the tab-bar chrome.
-        return isMinimalMode ? 0 : splitButtonsBackdropWidth
+        return isMinimalMode ? 0 : splitButtonsBackdropWidth(buttonCount: buttonCount)
     }
 
     static func preferredScrollTarget(
@@ -311,6 +327,19 @@ struct TabBarView: View {
         controller.configuration.appearance
     }
 
+    private var visibleSplitButtons: [BonsplitConfiguration.SplitActionButton] {
+        guard showSplitButtons else { return [] }
+        return appearance.splitButtons
+    }
+
+    private var shouldRenderSplitButtons: Bool {
+        !visibleSplitButtons.isEmpty
+    }
+
+    private var splitButtonsBackdropWidth: CGFloat {
+        TabBarStyling.splitButtonsBackdropWidth(buttonCount: visibleSplitButtons.count)
+    }
+
     private var showsControlShortcutHints: Bool {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
@@ -322,7 +351,8 @@ struct TabBarView: View {
     private var trailingTabContentInset: CGFloat {
         TabBarStyling.trailingTabContentInset(
             showSplitButtons: showSplitButtons,
-            isMinimalMode: isMinimalMode
+            isMinimalMode: isMinimalMode,
+            buttonCount: visibleSplitButtons.count
         )
     }
 
@@ -476,7 +506,7 @@ struct TabBarView: View {
                 // tab clicks fall through to `TabBarDragAndHoverView` (which performs a
                 // window drag in minimal mode).
                 .overlay(alignment: .trailing) {
-                    if showSplitButtons {
+                    if shouldRenderSplitButtons {
                         let shouldShow = !isMinimalMode || isHoveringTabBar
                         let backdropColor = Color(nsColor: Self.buttonBackdropColor(
                             for: appearance,
@@ -493,7 +523,7 @@ struct TabBarView: View {
                                 .frame(width: 24)
                                 Rectangle().fill(backdropColor)
                             }
-                            .frame(width: TabBarStyling.splitButtonsBackdropWidth)
+                            .frame(width: splitButtonsBackdropWidth)
 
                             splitButtons
                                 .saturation(tabBarSaturation)
@@ -506,11 +536,17 @@ struct TabBarView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: TabBarMetrics.barHeight)
         .coordinateSpace(name: "tabBar")
         .background(tabBarBackground)
         .background(TabBarDragAndHoverView(
             isMinimalMode: isMinimalMode,
+            onDoubleClick: {
+                guard splitViewController.isInteractive else { return false }
+                controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                return true
+            },
             onHoverChanged: { isHoveringTabBar = $0 }
         ))
         .background(
@@ -783,47 +819,84 @@ struct TabBarView: View {
     @ViewBuilder
     private var splitButtons: some View {
         let tooltips = controller.configuration.appearance.splitButtonTooltips
-        HStack(spacing: 4) {
-            Button {
-                controller.requestNewTab(kind: "terminal", inPane: pane.id)
-            } label: {
-                Image(systemName: "terminal")
-                    .font(.system(size: 12))
+        HStack(spacing: TabBarStyling.splitButtonsSpacing) {
+            ForEach(visibleSplitButtons, id: \.id) { button in
+                Button {
+                    performSplitActionButton(button)
+                } label: {
+                    splitActionButtonIcon(button.icon)
+                }
+                .buttonStyle(SplitActionButtonStyle(appearance: appearance))
+                .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
             }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.newTerminal)
-
-            Button {
-                controller.requestNewTab(kind: "browser", inPane: pane.id)
-            } label: {
-                Image(systemName: "globe")
-                    .font(.system(size: 12))
-            }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.newBrowser)
-
-            Button {
-                // 120fps animation handled by SplitAnimator
-                controller.splitPane(pane.id, orientation: .horizontal)
-            } label: {
-                Image(systemName: "square.split.2x1")
-                    .font(.system(size: 12))
-            }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.splitRight)
-
-            Button {
-                // 120fps animation handled by SplitAnimator
-                controller.splitPane(pane.id, orientation: .vertical)
-            } label: {
-                Image(systemName: "square.split.1x2")
-                    .font(.system(size: 12))
-            }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.splitDown)
         }
-        .padding(.leading, 6)
-        .padding(.trailing, 8)
+        .padding(.leading, TabBarStyling.splitButtonsLeadingPadding)
+        .padding(.trailing, TabBarStyling.splitButtonsTrailingPadding)
+    }
+
+    @ViewBuilder
+    private func splitActionButtonIcon(_ icon: BonsplitConfiguration.SplitActionButton.Icon) -> some View {
+        switch icon {
+        case .systemImage(let name):
+            Image(systemName: name)
+                .font(.system(size: 12))
+        case .emoji(let value):
+            Text(value)
+                .font(.system(size: 13))
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+        case .imageData(let data):
+            if let image = NSImage(data: data) {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 14, height: 14)
+            } else {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: 12))
+            }
+        }
+    }
+
+    private func splitActionButtonTooltip(
+        _ button: BonsplitConfiguration.SplitActionButton,
+        tooltips: BonsplitConfiguration.SplitButtonTooltips
+    ) -> String {
+        if let tooltip = button.tooltip?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !tooltip.isEmpty {
+            return tooltip
+        }
+
+        switch button.action {
+        case .newTerminal:
+            return tooltips.newTerminal
+        case .newBrowser:
+            return tooltips.newBrowser
+        case .splitRight:
+            return tooltips.splitRight
+        case .splitDown:
+            return tooltips.splitDown
+        case .custom(let identifier):
+            return identifier
+        }
+    }
+
+    private func performSplitActionButton(_ button: BonsplitConfiguration.SplitActionButton) {
+        switch button.action {
+        case .newTerminal:
+            controller.requestNewTab(kind: "terminal", inPane: pane.id)
+        case .newBrowser:
+            controller.requestNewTab(kind: "browser", inPane: pane.id)
+        case .splitRight:
+            // 120fps animation handled by SplitAnimator
+            controller.splitPane(pane.id, orientation: .horizontal)
+        case .splitDown:
+            // 120fps animation handled by SplitAnimator
+            controller.splitPane(pane.id, orientation: .vertical)
+        case .custom(let identifier):
+            controller.requestCustomAction(identifier, inPane: pane.id)
+        }
     }
 
 
@@ -979,22 +1052,26 @@ private struct SplitActionButtonStyle: ButtonStyle {
 /// this view only receives hits in truly empty space.
 private struct TabBarDragAndHoverView: NSViewRepresentable {
     let isMinimalMode: Bool
+    let onDoubleClick: () -> Bool
     let onHoverChanged: (Bool) -> Void
 
     func makeNSView(context: Context) -> TabBarBackgroundNSView {
         let view = TabBarBackgroundNSView()
         view.isMinimalMode = isMinimalMode
+        view.onDoubleClick = onDoubleClick
         view.onHoverChanged = onHoverChanged
         return view
     }
 
     func updateNSView(_ nsView: TabBarBackgroundNSView, context: Context) {
         nsView.isMinimalMode = isMinimalMode
+        nsView.onDoubleClick = onDoubleClick
         nsView.onHoverChanged = onHoverChanged
     }
 
     final class TabBarBackgroundNSView: NSView {
         var isMinimalMode = false
+        var onDoubleClick: (() -> Bool)?
         var onHoverChanged: ((Bool) -> Void)?
         private var hoverTrackingArea: NSTrackingArea?
 
@@ -1045,16 +1122,25 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 #if DEBUG
             dlog("tab.bar.bg.mouseDown isMinimal=\(isMinimalMode ? 1 : 0) clickCount=\(event.clickCount)")
 #endif
-            guard isMinimalMode, let window else {
+            guard let window else {
                 super.mouseDown(with: event)
                 return
             }
             if event.clickCount >= 2 {
-                let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
-                switch action {
-                case "Minimize": window.miniaturize(nil)
-                default: window.zoom(nil)
+                if isMinimalMode {
+                    let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
+                    switch action {
+                    case "Minimize": window.miniaturize(nil)
+                    default: window.zoom(nil)
+                    }
+                    return
                 }
+                if onDoubleClick?() == true {
+                    return
+                }
+            }
+            guard isMinimalMode else {
+                super.mouseDown(with: event)
                 return
             }
             let wasMovable = window.isMovable

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -558,7 +558,10 @@ struct TabBarView: View {
             isMinimalMode: isMinimalMode,
             onDoubleClick: {
                 guard splitViewController.isInteractive else { return false }
-                controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                guard let button = visibleSplitButtons.first(where: { $0.action == .newTerminal }) else {
+                    return false
+                }
+                performSplitActionButton(button)
                 return true
             },
             onHoverChanged: { isHoveringTabBar = $0 }
@@ -833,8 +836,10 @@ struct TabBarView: View {
     @ViewBuilder
     private var splitButtons: some View {
         let tooltips = controller.configuration.appearance.splitButtonTooltips
+        let buttons = visibleSplitButtons
         HStack(spacing: TabBarStyling.splitButtonsSpacing) {
-            ForEach(visibleSplitButtons, id: \.id) { button in
+            ForEach(buttons.indices, id: \.self) { index in
+                let button = buttons[index]
                 Button {
                     performSplitActionButton(button)
                 } label: {
@@ -904,6 +909,8 @@ struct TabBarView: View {
     }
 
     private func performSplitActionButton(_ button: BonsplitConfiguration.SplitActionButton) {
+        guard splitViewController.isInteractive else { return }
+
         switch button.action {
         case .newTerminal:
             controller.requestNewTab(kind: "terminal", inPane: pane.id)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1109,7 +1109,6 @@ private struct SplitActionButtonStyle: ButtonStyle {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
             .opacity(configuration.isPressed ? 0.72 : 1.0)
-            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
             .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1802,7 +1802,7 @@ private final class TabControlShortcutKeyMonitor: ObservableObject {
             ) else { return }
             guard let currentModifier = TabControlShortcutHintPolicy.hintModifier(for: NSEvent.modifierFlags) else { return }
             self.shortcutModifierSymbol = currentModifier.symbol
-            withAnimation(.easeInOut(duration: 0.14)) {
+            withAnimation(TabControlShortcutHintAnimation.visibility) {
                 self.isShortcutHintVisible = true
             }
         }
@@ -1817,7 +1817,7 @@ private final class TabControlShortcutKeyMonitor: ObservableObject {
         pendingShowWorkItem = nil
         pendingModifier = nil
         if resetVisible {
-            withAnimation(.easeInOut(duration: 0.14)) {
+            withAnimation(TabControlShortcutHintAnimation.visibility) {
                 isShortcutHintVisible = false
             }
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -481,9 +481,7 @@ struct TabBarView: View {
                                 isFocusedPane: isFocused,
                                 onSingleClick: focusPaneFromTabBarChrome
                             ) {
-                                guard splitViewController.isInteractive else { return false }
-                                controller.requestNewTab(kind: "terminal", inPane: pane.id)
-                                return true
+                                performNewTerminalSplitButtonAction()
                             }
                             .frame(width: trailing + 30, height: TabBarMetrics.tabHeight)
                             .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
@@ -559,12 +557,7 @@ struct TabBarView: View {
         .background(TabBarDragAndHoverView(
             isMinimalMode: isMinimalMode,
             onDoubleClick: {
-                guard splitViewController.isInteractive else { return false }
-                guard let button = visibleSplitButtons.first(where: { $0.action == .newTerminal }) else {
-                    return false
-                }
-                performSplitActionButton(button)
-                return true
+                performNewTerminalSplitButtonAction()
             },
             onHoverChanged: { isHoveringTabBar = $0 }
         ))
@@ -802,9 +795,7 @@ struct TabBarView: View {
             isFocusedPane: isFocused,
             onSingleClick: focusPaneFromTabBarChrome
         ) {
-            guard splitViewController.isInteractive else { return false }
-            controller.requestNewTab(kind: "terminal", inPane: pane.id)
-            return true
+            performNewTerminalSplitButtonAction()
         }
         .frame(width: 30, height: TabBarMetrics.tabHeight)
         .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
@@ -925,6 +916,15 @@ struct TabBarView: View {
         case .custom(let identifier):
             controller.requestCustomAction(identifier, inPane: pane.id)
         }
+    }
+
+    private func performNewTerminalSplitButtonAction() -> Bool {
+        guard splitViewController.isInteractive else { return false }
+        guard let button = visibleSplitButtons.first(where: { $0.action == .newTerminal }) else {
+            return false
+        }
+        performSplitActionButton(button)
+        return true
     }
 
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -43,6 +43,7 @@ struct TabItemView: View {
     let appearance: BonsplitConfiguration.Appearance
     let saturation: Double
     let controlShortcutDigit: Int?
+    let allowsShortcutHints: Bool
     let showsControlShortcutHint: Bool
     let shortcutModifierSymbol: String
     let contextMenuState: TabContextMenuState
@@ -212,7 +213,7 @@ struct TabItemView: View {
     }
 
     private var showsShortcutHint: Bool {
-        (showsControlShortcutHint || alwaysShowShortcutHints) && shortcutHintLabel != nil
+        allowsShortcutHints && (showsControlShortcutHint || alwaysShowShortcutHints) && shortcutHintLabel != nil
     }
 
     private var shortcutHintSlotWidth: CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 import AppKit
 
+enum TabControlShortcutHintAnimation {
+    static let visibility: Animation = .easeOut(duration: 0.12)
+}
+
+extension View {
+    func tabControlShortcutHintVisibilityAnimation<Value: Equatable>(value: Value) -> some View {
+        animation(TabControlShortcutHintAnimation.visibility, value: value)
+    }
+}
+
 private enum TabControlShortcutHintDebugSettings {
     static let xKey = "shortcutHintPaneTabXOffset"
     static let yKey = "shortcutHintPaneTabYOffset"
@@ -174,7 +184,7 @@ struct TabItemView: View {
         )
         .padding(.bottom, isSelected ? 1 : 0)
         .background(tabBackground.saturation(saturation))
-        .animation(.easeInOut(duration: 0.14), value: showsShortcutHint)
+        .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
         .contentShape(Rectangle())
         // Middle click to close (macOS convention).
         // Uses an AppKit event monitor so it doesn't interfere with left click selection or drag/reorder.
@@ -277,7 +287,7 @@ struct TabItemView: View {
                 .allowsHitTesting(!showsShortcutHint)
         }
         .frame(width: shortcutHintSlotWidth, height: accessorySlotSize, alignment: .center)
-        .animation(.easeInOut(duration: 0.14), value: showsShortcutHint)
+        .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
     }
 
     private func updateGlobeFallback() {

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -285,6 +285,7 @@ extension BonsplitConfiguration {
             action: .splitDown
         )
 
+        /// Built-in split actions shown by default. Hosts can replace this list with custom buttons.
         public static let defaults: [SplitActionButton] = [
             .newTerminal,
             .newBrowser,
@@ -363,8 +364,13 @@ extension BonsplitConfiguration {
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
 
-        /// Ordered action buttons shown in the tab bar when split buttons are enabled
-        public var splitButtons: [SplitActionButton]
+        /// Ordered action buttons shown in the tab bar when split buttons are enabled.
+        /// Duplicate button ids are ignored, preserving the first matching button.
+        public var splitButtons: [SplitActionButton] {
+            didSet {
+                splitButtons = Self.uniqueSplitButtons(splitButtons)
+            }
+        }
 
         /// When true, split buttons are only visible on hover
         public var splitButtonsOnHover: Bool
@@ -434,13 +440,18 @@ extension BonsplitConfiguration {
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.showSplitButtons = showSplitButtons
-            self.splitButtons = splitButtons
+            self.splitButtons = Self.uniqueSplitButtons(splitButtons)
             self.splitButtonsOnHover = splitButtonsOnHover
             self.tabBarLeadingInset = tabBarLeadingInset
             self.splitButtonTooltips = splitButtonTooltips
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations
             self.chromeColors = chromeColors
+        }
+
+        private static func uniqueSplitButtons(_ buttons: [SplitActionButton]) -> [SplitActionButton] {
+            var seenIds = Set<String>()
+            return buttons.filter { seenIds.insert($0.id).inserted }
         }
     }
 }

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -105,7 +105,7 @@ extension BonsplitConfiguration {
     public struct SplitActionButton: Sendable, Codable, Hashable, Identifiable {
         public enum Icon: Sendable, Codable, Hashable {
             case systemImage(String)
-            case emoji(String)
+            case emoji(String, scale: Double = 1)
             case imageData(Data)
 
             private enum CodingKeys: String, CodingKey {
@@ -113,6 +113,7 @@ extension BonsplitConfiguration {
                 case name
                 case value
                 case data
+                case scale
             }
 
             public init(from decoder: Decoder) throws {
@@ -127,7 +128,10 @@ extension BonsplitConfiguration {
                 case "systemImage", "symbol", "sfSymbol":
                     self = .systemImage(try container.decode(String.self, forKey: .name))
                 case "emoji":
-                    self = .emoji(try container.decode(String.self, forKey: .value))
+                    self = .emoji(
+                        try container.decode(String.self, forKey: .value),
+                        scale: try Self.emojiScale(in: container)
+                    )
                 case "imageData":
                     self = .imageData(try container.decode(Data.self, forKey: .data))
                 default:
@@ -145,13 +149,28 @@ extension BonsplitConfiguration {
                 case .systemImage(let name):
                     try container.encode("systemImage", forKey: .type)
                     try container.encode(name, forKey: .name)
-                case .emoji(let value):
+                case .emoji(let value, let scale):
                     try container.encode("emoji", forKey: .type)
                     try container.encode(value, forKey: .value)
+                    if scale != 1 {
+                        try container.encode(scale, forKey: .scale)
+                    }
                 case .imageData(let data):
                     try container.encode("imageData", forKey: .type)
                     try container.encode(data, forKey: .data)
                 }
+            }
+
+            private static func emojiScale(in container: KeyedDecodingContainer<CodingKeys>) throws -> Double {
+                let scale = try container.decodeIfPresent(Double.self, forKey: .scale) ?? 1
+                guard scale.isFinite, scale > 0 else {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .scale,
+                        in: container,
+                        debugDescription: "Emoji icon scale must be a positive number"
+                    )
+                }
+                return scale
             }
         }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -162,6 +162,11 @@ extension BonsplitConfiguration {
             case splitDown
             case custom(String)
 
+            private enum CodingKeys: String, CodingKey {
+                case type
+                case identifier
+            }
+
             public var rawValue: String {
                 switch self {
                 case .newTerminal:
@@ -178,25 +183,46 @@ extension BonsplitConfiguration {
             }
 
             public init(from decoder: Decoder) throws {
-                let container = try decoder.singleValueContainer()
-                let value = try container.decode(String.self)
-                switch value {
-                case "newTerminal":
-                    self = .newTerminal
-                case "newBrowser":
-                    self = .newBrowser
-                case "splitRight":
-                    self = .splitRight
-                case "splitDown":
-                    self = .splitDown
-                default:
-                    self = .custom(value)
+                if let container = try? decoder.singleValueContainer(),
+                   let value = try? container.decode(String.self) {
+                    self = Self.action(for: value)
+                    return
+                }
+
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let type = try container.decode(String.self, forKey: .type)
+                if type == "custom" {
+                    self = .custom(try container.decode(String.self, forKey: .identifier))
+                } else {
+                    self = Self.action(for: type)
                 }
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
-                try container.encode(rawValue)
+                switch self {
+                case .custom(let identifier):
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    try container.encode("custom", forKey: .type)
+                    try container.encode(identifier, forKey: .identifier)
+                default:
+                    var container = encoder.singleValueContainer()
+                    try container.encode(rawValue)
+                }
+            }
+
+            private static func action(for value: String) -> Action {
+                switch value {
+                case "newTerminal":
+                    return .newTerminal
+                case "newBrowser":
+                    return .newBrowser
+                case "splitRight":
+                    return .splitRight
+                case "splitDown":
+                    return .splitDown
+                default:
+                    return .custom(value)
+                }
             }
         }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -102,6 +102,171 @@ public struct BonsplitConfiguration: Sendable {
 // MARK: - Appearance Configuration
 
 extension BonsplitConfiguration {
+    public struct SplitActionButton: Sendable, Codable, Hashable, Identifiable {
+        public enum Icon: Sendable, Codable, Hashable {
+            case systemImage(String)
+            case emoji(String)
+            case imageData(Data)
+
+            private enum CodingKeys: String, CodingKey {
+                case type
+                case name
+                case value
+                case data
+            }
+
+            public init(from decoder: Decoder) throws {
+                if let value = try? decoder.singleValueContainer().decode(String.self) {
+                    self = .systemImage(value)
+                    return
+                }
+
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let type = try container.decode(String.self, forKey: .type)
+                switch type {
+                case "systemImage", "symbol", "sfSymbol":
+                    self = .systemImage(try container.decode(String.self, forKey: .name))
+                case "emoji":
+                    self = .emoji(try container.decode(String.self, forKey: .value))
+                case "imageData":
+                    self = .imageData(try container.decode(Data.self, forKey: .data))
+                default:
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .type,
+                        in: container,
+                        debugDescription: "Unknown split action button icon type '\(type)'"
+                    )
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                switch self {
+                case .systemImage(let name):
+                    try container.encode("systemImage", forKey: .type)
+                    try container.encode(name, forKey: .name)
+                case .emoji(let value):
+                    try container.encode("emoji", forKey: .type)
+                    try container.encode(value, forKey: .value)
+                case .imageData(let data):
+                    try container.encode("imageData", forKey: .type)
+                    try container.encode(data, forKey: .data)
+                }
+            }
+        }
+
+        public enum Action: Sendable, Codable, Hashable {
+            case newTerminal
+            case newBrowser
+            case splitRight
+            case splitDown
+            case custom(String)
+
+            public var rawValue: String {
+                switch self {
+                case .newTerminal:
+                    return "newTerminal"
+                case .newBrowser:
+                    return "newBrowser"
+                case .splitRight:
+                    return "splitRight"
+                case .splitDown:
+                    return "splitDown"
+                case .custom(let identifier):
+                    return identifier
+                }
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let value = try container.decode(String.self)
+                switch value {
+                case "newTerminal":
+                    self = .newTerminal
+                case "newBrowser":
+                    self = .newBrowser
+                case "splitRight":
+                    self = .splitRight
+                case "splitDown":
+                    self = .splitDown
+                default:
+                    self = .custom(value)
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(rawValue)
+            }
+        }
+
+        public var id: String
+        public var icon: Icon
+        public var tooltip: String?
+        public var action: Action
+
+        public var systemImage: String {
+            if case .systemImage(let name) = icon {
+                return name
+            }
+            return "questionmark.circle"
+        }
+
+        public init(
+            id: String,
+            systemImage: String,
+            tooltip: String? = nil,
+            action: Action
+        ) {
+            self.init(
+                id: id,
+                icon: .systemImage(systemImage),
+                tooltip: tooltip,
+                action: action
+            )
+        }
+
+        public init(
+            id: String,
+            icon: Icon,
+            tooltip: String? = nil,
+            action: Action
+        ) {
+            self.id = id
+            self.icon = icon
+            self.tooltip = tooltip
+            self.action = action
+        }
+
+        public static let newTerminal = SplitActionButton(
+            id: "newTerminal",
+            systemImage: "terminal",
+            action: .newTerminal
+        )
+        public static let newBrowser = SplitActionButton(
+            id: "newBrowser",
+            systemImage: "globe",
+            action: .newBrowser
+        )
+        public static let splitRight = SplitActionButton(
+            id: "splitRight",
+            systemImage: "square.split.2x1",
+            action: .splitRight
+        )
+        public static let splitDown = SplitActionButton(
+            id: "splitDown",
+            systemImage: "square.split.1x2",
+            action: .splitDown
+        )
+
+        public static let defaults: [SplitActionButton] = [
+            .newTerminal,
+            .newBrowser,
+            .splitRight,
+            .splitDown
+        ]
+    }
+
     public struct SplitButtonTooltips: Sendable, Equatable {
         public var newTerminal: String
         public var newBrowser: String
@@ -172,6 +337,9 @@ extension BonsplitConfiguration {
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
 
+        /// Ordered action buttons shown in the tab bar when split buttons are enabled
+        public var splitButtons: [SplitActionButton]
+
         /// When true, split buttons are only visible on hover
         public var splitButtonsOnHover: Bool
 
@@ -224,6 +392,7 @@ extension BonsplitConfiguration {
             minimumPaneWidth: CGFloat = 100,
             minimumPaneHeight: CGFloat = 100,
             showSplitButtons: Bool = true,
+            splitButtons: [SplitActionButton] = SplitActionButton.defaults,
             splitButtonsOnHover: Bool = false,
             tabBarLeadingInset: CGFloat = 0,
             splitButtonTooltips: SplitButtonTooltips = .default,
@@ -239,6 +408,7 @@ extension BonsplitConfiguration {
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.showSplitButtons = showSplitButtons
+            self.splitButtons = splitButtons
             self.splitButtonsOnHover = splitButtonsOnHover
             self.tabBarLeadingInset = tabBarLeadingInset
             self.splitButtonTooltips = splitButtonTooltips

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -159,6 +159,11 @@ public final class BonsplitController {
         delegate?.splitTabBar(self, didRequestNewTab: kind, inPane: pane)
     }
 
+    /// Request the delegate to handle a host-defined tab bar action.
+    public func requestCustomAction(_ identifier: String, inPane pane: PaneID) {
+        delegate?.splitTabBar(self, didRequestCustomAction: identifier, inPane: pane)
+    }
+
     /// Request the delegate to handle a tab context-menu action.
     public func requestTabContextAction(_ action: TabContextAction, for tabId: TabID, inPane pane: PaneID) {
         guard let tab = tab(tabId) else { return }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -40,6 +40,15 @@ public final class BonsplitController {
         didSet { internalController.isInteractive = isInteractive }
     }
 
+    /// Whether pane tab shortcut hints are currently actionable.
+    ///
+    /// Pane focus is internal to Bonsplit, but host apps can move keyboard focus
+    /// to external controls while keeping the focused pane selected. Set this
+    /// to false when pane-number shortcuts should not currently be advertised.
+    public var tabShortcutHintsEnabled: Bool = true {
+        didSet { internalController.tabShortcutHintsEnabled = tabShortcutHintsEnabled }
+    }
+
     /// Handler for file/URL drops from external apps (e.g., Finder).
     /// Called when files are dropped onto a pane's content area.
     /// Return `true` if the drop was handled.

--- a/Sources/Bonsplit/Public/BonsplitDelegate.swift
+++ b/Sources/Bonsplit/Public/BonsplitDelegate.swift
@@ -55,6 +55,9 @@ public protocol BonsplitDelegate: AnyObject {
     /// The `kind` string identifies the type of tab (e.g. "terminal", "browser").
     func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID)
 
+    /// Called when the user clicks a host-defined action in the tab bar.
+    func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID)
+
     /// Called when the user triggers an action from a tab's context menu.
     func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID)
 
@@ -82,6 +85,7 @@ public extension BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, didClosePane paneId: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didFocusPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID) {}
+    func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {}
     func splitTabBar(_ controller: BonsplitController, shouldNotifyDuringDrag: Bool) -> Bool { false }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1159,6 +1159,19 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testControllerMirrorsTabShortcutHintEligibilityToInternalController() {
+        let controller = BonsplitController()
+
+        XCTAssertTrue(controller.tabShortcutHintsEnabled)
+        XCTAssertTrue(controller.internalController.tabShortcutHintsEnabled)
+
+        controller.tabShortcutHintsEnabled = false
+
+        XCTAssertFalse(controller.tabShortcutHintsEnabled)
+        XCTAssertFalse(controller.internalController.tabShortcutHintsEnabled)
+    }
+
     func testSelectedTabNeverShowsHoverBackground() {
         XCTAssertFalse(
             TabItemStyling.shouldShowHoverBackground(isHovered: true, isSelected: true)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -529,6 +529,30 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(controller.configuration.appearance.splitButtons, buttons)
     }
 
+    func testAppearanceKeepsFirstSplitActionButtonForDuplicateIds() {
+        let firstRunTests = BonsplitConfiguration.SplitActionButton(
+            id: "run-tests",
+            systemImage: "checkmark.circle",
+            tooltip: "Run tests",
+            action: .custom("run-tests")
+        )
+        let duplicateRunTests = BonsplitConfiguration.SplitActionButton(
+            id: "run-tests",
+            systemImage: "xmark.circle",
+            tooltip: "Duplicate",
+            action: .custom("duplicate")
+        )
+        var appearance = BonsplitConfiguration.Appearance(
+            splitButtons: [.newTerminal, .newTerminal, firstRunTests, duplicateRunTests]
+        )
+
+        XCTAssertEqual(appearance.splitButtons, [.newTerminal, firstRunTests])
+
+        appearance.splitButtons = [duplicateRunTests, firstRunTests, .splitRight]
+
+        XCTAssertEqual(appearance.splitButtons, [duplicateRunTests, .splitRight])
+    }
+
     @MainActor
     func testControllerRequestsCustomAction() {
         let controller = BonsplitController()

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -315,6 +315,19 @@ final class BonsplitTests: XCTestCase {
         XCTAssertFalse(TabBarStyling.imageDataShouldRenderAsTemplate(colorSVG))
     }
 
+    func testCurrentColorSVGImageDataRendersAsTemplateWithInvalidUTF8Suffix() throws {
+        var svg = Data(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path fill="currentColor" d="M4 4h16v16H4z"/>
+            </svg>
+            """.utf8
+        )
+        svg.append(0xE2)
+
+        XCTAssertTrue(TabBarStyling.imageDataShouldRenderAsTemplate(svg))
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -266,6 +266,26 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(decoded, button)
     }
 
+    func testCurrentColorSVGImageDataRendersAsTemplate() throws {
+        let templateSVG = Data(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path fill="currentColor" d="M4 4h16v16H4z"/>
+            </svg>
+            """.utf8
+        )
+        let colorSVG = Data(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path fill="#D97757" d="M4 4h16v16H4z"/>
+            </svg>
+            """.utf8
+        )
+
+        XCTAssertTrue(TabBarStyling.imageDataShouldRenderAsTemplate(templateSVG))
+        XCTAssertFalse(TabBarStyling.imageDataShouldRenderAsTemplate(colorSVG))
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -269,7 +269,7 @@ final class BonsplitTests: XCTestCase {
     func testCustomSplitActionButtonSupportsEmojiIcon() throws {
         let button = BonsplitConfiguration.SplitActionButton(
             id: "agent",
-            icon: .emoji("🤖"),
+            icon: .emoji("🤖", scale: 0.85),
             tooltip: "Start agent",
             action: .custom("agent")
         )

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -98,6 +98,16 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    private final class CustomActionDelegateSpy: BonsplitDelegate {
+        var requestedIdentifier: String?
+        var requestedPaneId: PaneID?
+
+        func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID) {
+            requestedIdentifier = identifier
+            requestedPaneId = pane
+        }
+    }
+
     @MainActor
     func testControllerCreation() {
         let controller = BonsplitController()
@@ -206,6 +216,56 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(defaults.splitDown, "Split Down")
     }
 
+    func testDefaultSplitActionButtons() {
+        XCTAssertEqual(
+            BonsplitConfiguration.SplitActionButton.defaults,
+            [.newTerminal, .newBrowser, .splitRight, .splitDown]
+        )
+    }
+
+    func testCustomSplitActionButtonRoundTrips() throws {
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "run-tests",
+            systemImage: "checkmark.circle",
+            tooltip: "Run tests",
+            action: .custom("run-tests")
+        )
+
+        let data = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded, button)
+    }
+
+    func testCustomSplitActionButtonSupportsEmojiIcon() throws {
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "agent",
+            icon: .emoji("🤖"),
+            tooltip: "Start agent",
+            action: .custom("agent")
+        )
+
+        let data = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded, button)
+    }
+
+    func testCustomSplitActionButtonSupportsImageDataIcon() throws {
+        let data = Data([0x89, 0x50, 0x4E, 0x47])
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "image-agent",
+            icon: .imageData(data),
+            tooltip: "Start image agent",
+            action: .custom("image-agent")
+        )
+
+        let encoded = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: encoded)
+
+        XCTAssertEqual(decoded, button)
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),
@@ -214,8 +274,18 @@ final class BonsplitTests: XCTestCase {
         )
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: false),
-            TabBarStyling.splitButtonsBackdropWidth,
+            TabBarStyling.splitButtonsBackdropWidth(buttonCount: 4),
             "Standard mode should keep reserving space for the always-visible split buttons"
+        )
+        XCTAssertEqual(
+            TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: false, buttonCount: 2),
+            TabBarStyling.splitButtonsBackdropWidth(buttonCount: 2),
+            "Standard mode should reserve space for the configured split buttons only"
+        )
+        XCTAssertEqual(
+            TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: false, buttonCount: 0),
+            0,
+            "No strip should be reserved when the configured split button list is empty"
         )
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: false, isMinimalMode: false),
@@ -365,6 +435,40 @@ final class BonsplitTests: XCTestCase {
         let controller = BonsplitController(configuration: config)
 
         XCTAssertEqual(controller.configuration.appearance.splitButtonTooltips, customTooltips)
+    }
+
+    @MainActor
+    func testConfigurationAcceptsCustomSplitActionButtons() {
+        let buttons: [BonsplitConfiguration.SplitActionButton] = [
+            .newTerminal,
+            .init(
+                id: "run-tests",
+                systemImage: "checkmark.circle",
+                tooltip: "Run tests",
+                action: .custom("run-tests")
+            ),
+        ]
+        let config = BonsplitConfiguration(
+            appearance: .init(
+                splitButtons: buttons
+            )
+        )
+        let controller = BonsplitController(configuration: config)
+
+        XCTAssertEqual(controller.configuration.appearance.splitButtons, buttons)
+    }
+
+    @MainActor
+    func testControllerRequestsCustomAction() {
+        let controller = BonsplitController()
+        let delegate = CustomActionDelegateSpy()
+        controller.delegate = delegate
+        let paneId = controller.focusedPaneId!
+
+        controller.requestCustomAction("run-tests", inPane: paneId)
+
+        XCTAssertEqual(delegate.requestedIdentifier, "run-tests")
+        XCTAssertEqual(delegate.requestedPaneId, paneId)
     }
 
     func testChromeBackgroundHexOverrideParsesForPaneBackground() {
@@ -708,11 +812,17 @@ final class BonsplitTests: XCTestCase {
         contentView.layoutSubtreeIfNeeded()
 
         let clickPoint = NSPoint(x: hostingView.bounds.maxX - 12, y: hostingView.bounds.midY)
-        guard let event = try? makeLeftMouseDownEvent(in: hostingView, at: clickPoint, clickCount: 2) else {
-            XCTFail("Expected mouse event")
+        let pointInWindow = hostingView.convert(clickPoint, to: nil)
+        guard let hitView = waitForDescendant(
+            ofType: TabBarDragZoneView.DragNSView.self,
+            in: contentView,
+            containingWindowPoint: pointInWindow,
+            where: { $0.onDoubleClick != nil }
+        ) else {
+            XCTFail("Expected trailing tab bar drag zone")
             return
         }
-        NSApp.sendEvent(event)
+        XCTAssertEqual(hitView.onDoubleClick?(), true)
 
         XCTAssertEqual(spy.requestedKind, "terminal")
         XCTAssertEqual(spy.requestedPaneId, pane.id)
@@ -1239,6 +1349,61 @@ final class BonsplitTests: XCTestCase {
         }
         for subview in root.subviews {
             if let match = firstDescendant(ofType: type, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private func waitForDescendant<T: NSView>(
+        ofType type: T.Type,
+        in root: NSView,
+        containingWindowPoint point: NSPoint,
+        timeout: TimeInterval = 1.0,
+        where predicate: (T) -> Bool = { _ in true }
+    ) -> T? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            root.layoutSubtreeIfNeeded()
+            if let match = firstDescendant(
+                ofType: type,
+                in: root,
+                containingWindowPoint: point,
+                where: predicate
+            ) {
+                return match
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        } while Date() < deadline
+        return firstDescendant(
+            ofType: type,
+            in: root,
+            containingWindowPoint: point,
+            where: predicate
+        )
+    }
+
+    @MainActor
+    private func firstDescendant<T: NSView>(
+        ofType type: T.Type,
+        in root: NSView,
+        containingWindowPoint point: NSPoint,
+        where predicate: (T) -> Bool = { _ in true }
+    ) -> T? {
+        if let match = root as? T {
+            let frameInWindow = root.convert(root.bounds, to: nil)
+            if frameInWindow.contains(point), predicate(match) {
+                return match
+            }
+        }
+        for subview in root.subviews {
+            if let match = firstDescendant(
+                ofType: type,
+                in: subview,
+                containingWindowPoint: point,
+                where: predicate
+            ) {
                 return match
             }
         }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -849,7 +849,7 @@ final class BonsplitTests: XCTestCase {
 
     @MainActor
     func testDoubleClickingEmptyTrailingTabBarSpaceRequestsNewTerminalTab() {
-        let appearance = BonsplitConfiguration.Appearance(showSplitButtons: false)
+        let appearance = BonsplitConfiguration.Appearance()
         let configuration = BonsplitConfiguration(appearance: appearance)
         let controller = BonsplitController(configuration: configuration)
         let pane = controller.internalController.rootNode.allPanes.first!
@@ -857,7 +857,7 @@ final class BonsplitTests: XCTestCase {
         controller.delegate = spy
 
         let hostingView = NSHostingView(
-            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: false)
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: true)
                 .environment(controller)
                 .environment(controller.internalController)
         )
@@ -897,6 +897,58 @@ final class BonsplitTests: XCTestCase {
 
         XCTAssertEqual(spy.requestedKind, "terminal")
         XCTAssertEqual(spy.requestedPaneId, pane.id)
+    }
+
+    @MainActor
+    func testEmptyTrailingTabBarSpaceDoesNotRequestNewTerminalWhenButtonHidden() {
+        let appearance = BonsplitConfiguration.Appearance(splitButtons: [])
+        let configuration = BonsplitConfiguration(appearance: appearance)
+        let controller = BonsplitController(configuration: configuration)
+        let pane = controller.internalController.rootNode.allPanes.first!
+        let spy = NewTabRequestDelegateSpy()
+        controller.delegate = spy
+
+        let hostingView = NSHostingView(
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: true)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 60),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        let clickPoint = NSPoint(x: hostingView.bounds.maxX - 12, y: hostingView.bounds.midY)
+        let pointInWindow = hostingView.convert(clickPoint, to: nil)
+        guard let hitView = waitForDescendant(
+            ofType: TabBarDragZoneView.DragNSView.self,
+            in: contentView,
+            containingWindowPoint: pointInWindow,
+            where: { $0.onDoubleClick != nil }
+        ) else {
+            XCTFail("Expected trailing tab bar drag zone")
+            return
+        }
+        XCTAssertEqual(hitView.onDoubleClick?(), false)
+
+        XCTAssertNil(spy.requestedKind)
+        XCTAssertNil(spy.requestedPaneId)
     }
 
     func testIconSaturationKeepsRasterFaviconInColorWhenInactive() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -328,6 +328,15 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(TabBarStyling.imageDataShouldRenderAsTemplate(svg))
     }
 
+    @MainActor
+    func testSplitActionButtonImageDataIsCached() throws {
+        let png = try XCTUnwrap(Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="))
+        let first = try XCTUnwrap(TabBarStyling.splitActionButtonImage(from: png))
+        let second = try XCTUnwrap(TabBarStyling.splitActionButtonImage(from: png))
+
+        XCTAssertTrue(first === second)
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -237,6 +237,35 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(decoded, button)
     }
 
+    func testCustomSplitActionButtonPreservesReservedActionName() throws {
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "custom-terminal",
+            systemImage: "terminal",
+            tooltip: "Custom terminal action",
+            action: .custom("newTerminal")
+        )
+
+        let data = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded.action, .custom("newTerminal"))
+        XCTAssertEqual(decoded, button)
+    }
+
+    func testSplitActionButtonDecodesLegacyBuiltInActionString() throws {
+        let data = #"""
+        {
+          "id": "terminal",
+          "icon": { "type": "systemImage", "name": "terminal" },
+          "action": "newTerminal"
+        }
+        """#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded.action, .newTerminal)
+    }
+
     func testCustomSplitActionButtonSupportsEmojiIcon() throws {
         let button = BonsplitConfiguration.SplitActionButton(
             id: "agent",


### PR DESCRIPTION
Adds host-controlled eligibility for Bonsplit tab shortcut hints so embedding apps can hide pane tab hints when keyboard focus belongs to another surface.

Tests:
- swift test --package-path vendor/bonsplit --filter BonsplitTests.testControllerMirrorsTabShortcutHintEligibilityToInternalController

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host-controlled switch for pane tab shortcut hints and makes split action buttons in the tab bar fully configurable. This lets embedders hide hints when focus is elsewhere and tailor tab bar actions and icons.

- **New Features**
  - Added `BonsplitController.tabShortcutHintsEnabled` (mirrored to internal controller). Tab number hints now show only when the pane is focused and this flag is true.
  - Configurable split action buttons via `BonsplitConfiguration.Appearance.splitButtons` using `SplitActionButton` (unique by `id`) with built-in actions (`.newTerminal`, `.newBrowser`, `.splitRight`, `.splitDown`) and `.custom(String)`.
  - Flexible icons for actions: `.systemImage`, `.emoji(scale:)`, and `.imageData` with caching and template rendering for currentColor SVGs.
  - New delegate hook `splitTabBar(_:didRequestCustomAction:inPane:)` and `BonsplitController.requestCustomAction(_:inPane:)`.
  - Double-clicking empty trailing tab bar space now triggers the first configured “New Terminal” button only if that button exists.

- **Bug Fixes**
  - Trailing tab content inset now reflects the actual number of visible split buttons (no reserved strip when empty; minimal mode still reserves none).
  - Hover state for split buttons stays in sync when the window gains/loses focus.
  - Shortcut hint rendering in `TabItemView` now respects an explicit `allowsShortcutHints` gate.
  - Standardized the show/hide animation for shortcut hints for consistent timing across the tab UI.

<sup>Written for commit 427e48a9166ed65a42f0f618b3c84ac47fba1b04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable split-action buttons on the tab bar with custom icons (emoji, system, or image data) and actions.
  * Public control to enable/disable pane tab keyboard shortcut hints.
  * New API to request/handle custom tab-bar actions from the host.
  * Double-click behavior for creating new splits unified for consistency.

* **Style**
  * Improved pressed visuals and hint animations for split buttons.

* **Tests**
  * Expanded tests for split-button configuration, icons, custom actions, and hint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->