### PR TITLE
Fix TabItem equality to include all display fields

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -50,12 +50,24 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.isPinned = isPinned
     }
 
+    // Hash is intentionally id-only: equality includes display fields
+    // for SwiftUI diffing, but hash stability is preserved for
+    // identity-based collection semantics and cross-platform FFI.
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
 
     static func == (lhs: TabItem, rhs: TabItem) -> Bool {
         lhs.id == rhs.id
+            && lhs.title == rhs.title
+            && lhs.hasCustomTitle == rhs.hasCustomTitle
+            && lhs.icon == rhs.icon
+            && lhs.iconImageData == rhs.iconImageData
+            && lhs.kind == rhs.kind
+            && lhs.isDirty == rhs.isDirty
+            && lhs.showsNotificationBadge == rhs.showsNotificationBadge
+            && lhs.isLoading == rhs.isLoading
+            && lhs.isPinned == rhs.isPinned
     }
 
     private enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
Hey there y'all! 

Very minor TabItem equality fix; glad to chat about my reasoning here.


Summary:

- Include all mutable display fields in `TabItem.==` (previously only compared `id`)
- Fixes stale tab titles in unfocused workspace tabs when properties change via `updateTab()`
- No performance regression: during typing, no TabItem fields change so `==` still returns `true`

## Problem

`TabItem` conforms to `Equatable` with an `==` that only compares `id`:

```swift
static func == (lhs: TabItem, rhs: TabItem) -> Bool {
    lhs.id == rhs.id
}
```

When the host app calls `updateTab()` to change a tab's title, badge, icon, or other display properties, the `TabItem` still compares as equal. SwiftUI skips re-rendering the tab because it sees no change, so the UI shows stale values — most visibly, terminal titles not updating in unfocused workspace tabs.

## Fix

Add all 10 mutable display fields to the equality check:

```swift
static func == (lhs: TabItem, rhs: TabItem) -> Bool {
    lhs.id == rhs.id
        && lhs.title == rhs.title
        && lhs.hasCustomTitle == rhs.hasCustomTitle
        && lhs.icon == rhs.icon
        && lhs.iconImageData == rhs.iconImageData
        && lhs.kind == rhs.kind
        && lhs.isDirty == rhs.isDirty
        && lhs.showsNotificationBadge == rhs.showsNotificationBadge
        && lhs.isLoading == rhs.isLoading
        && lhs.isPinned == rhs.isPinned
}
```

`hash(into:)` remains id-only, which is valid — Swift permits hash collisions and the hash contract only requires that equal values produce equal hashes.

## Notes

- One file changed, 9 lines added
- All 10 fields match the parameters accepted by `updateTab()` in `BonsplitController`
- No new fields have been added to `TabItem` since this fix was written; the equality check is complete


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale tab titles and badges by comparing all mutable display fields in `TabItem.==`, ensuring tabs re-render when `updateTab()` changes title, icon, or badge. No performance change during typing.

- **Bug Fixes**
  - `TabItem.==` now includes all display fields (title, customTitle, icon/image, kind, dirty, badge, loading, pinned).
  - `hash(into:)` remains id-only; added inline rationale for stability/FFI; equality contract preserved.
  - SwiftUI re-renders on display changes; `.equatable()` still skips during typing.

<sup>Written for commit ff61382aefe64a4575078c100e43f41f5fa567b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



