### PR TITLE
Add copy identifiers tab action

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -36,6 +36,11 @@ final class SplitViewController {
     /// updateNSView is called to toggle isHidden on the AppKit containers.
     var isInteractive: Bool = true
 
+    /// When false, pane tab shortcut hints stay hidden even if this pane is
+    /// selected. The host app owns this because keyboard focus can move outside
+    /// Bonsplit while the selected pane remains unchanged.
+    var tabShortcutHintsEnabled: Bool = true
+
     /// Handler for file/URL drops from external apps (e.g. Finder).
     /// Receives the dropped URLs and the pane ID where the drop occurred.
     @ObservationIgnored var onFileDrop: ((_ urls: [URL], _ paneId: PaneID) -> Bool)?

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -40,6 +40,24 @@ enum TabBarColors {
         chromeBackgroundColor(for: appearance) ?? fallbackColor
     }
 
+    private static func precompositedPaneBackground(
+        for appearance: BonsplitConfiguration.Appearance,
+        focused: Bool
+    ) -> NSColor {
+        let chrome = nsColorPaneBackground(for: appearance)
+        let windowBackground = NSColor.windowBackgroundColor
+        guard let foreground = chrome.usingColorSpace(.sRGB),
+              let background = windowBackground.usingColorSpace(.sRGB) else {
+            return chrome.withAlphaComponent(1.0)
+        }
+        let alpha = focused ? foreground.alphaComponent : foreground.alphaComponent * 0.95
+        let oneMinusAlpha = 1.0 - alpha
+        let red = foreground.redComponent * alpha + background.redComponent * oneMinusAlpha
+        let green = foreground.greenComponent * alpha + background.greenComponent * oneMinusAlpha
+        let blue = foreground.blueComponent * alpha + background.blueComponent * oneMinusAlpha
+        return NSColor(red: red, green: green, blue: blue, alpha: 1.0)
+    }
+
     private static func effectiveTextColor(
         for appearance: BonsplitConfiguration.Appearance,
         secondary: Bool
@@ -75,8 +93,11 @@ enum TabBarColors {
         Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor))
     }
 
-    static func nsColorSplitButtonBackdrop(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
-        effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor)
+    static func nsColorSplitButtonBackdrop(
+        for appearance: BonsplitConfiguration.Appearance,
+        focused: Bool = true
+    ) -> NSColor {
+        precompositedPaneBackground(for: appearance, focused: focused)
     }
 
     static func shouldPaintSplitButtonBackdrop(for appearance: BonsplitConfiguration.Appearance) -> Bool {

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -80,7 +80,7 @@ enum TabBarColors {
     }
 
     static func shouldPaintSplitButtonBackdrop(for appearance: BonsplitConfiguration.Appearance) -> Bool {
-        nsColorSplitButtonBackdrop(for: appearance).alphaComponent >= 0.999
+        chromeBackgroundColor(for: appearance) != nil
     }
 
     static var barMaterial: Material {

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -17,6 +17,15 @@ enum TabBarColors {
         return NSColor(bonsplitHex: value)
     }
 
+    private static func paneBackgroundColor(
+        for appearance: BonsplitConfiguration.Appearance
+    ) -> NSColor? {
+        guard let value = appearance.chromeColors.paneBackgroundHex else {
+            return chromeBackgroundColor(for: appearance)
+        }
+        return NSColor(bonsplitHex: value)
+    }
+
     private static func chromeBorderColor(
         for appearance: BonsplitConfiguration.Appearance
     ) -> NSColor? {
@@ -49,11 +58,11 @@ enum TabBarColors {
     }
 
     static func paneBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor))
+        Color(nsColor: paneBackgroundColor(for: appearance) ?? .textBackgroundColor)
     }
 
     static func nsColorPaneBackground(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
-        effectiveBackgroundColor(for: appearance, fallback: .textBackgroundColor)
+        paneBackgroundColor(for: appearance) ?? .textBackgroundColor
     }
 
     // MARK: - Tab Bar Background

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -75,6 +75,10 @@ enum TabBarColors {
         Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor))
     }
 
+    static func nsColorSplitButtonBackdrop(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor)
+    }
+
     static var barMaterial: Material {
         .bar
     }

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -79,6 +79,10 @@ enum TabBarColors {
         effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor)
     }
 
+    static func shouldPaintSplitButtonBackdrop(for appearance: BonsplitConfiguration.Appearance) -> Bool {
+        nsColorSplitButtonBackdrop(for: appearance).alphaComponent >= 0.999
+    }
+
     static var barMaterial: Material {
         .bar
     }

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -93,6 +93,10 @@ enum TabBarColors {
         Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor))
     }
 
+    static func nsColorChromeBackground(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor)
+    }
+
     static func nsColorSplitButtonBackdrop(
         for appearance: BonsplitConfiguration.Appearance,
         focused: Bool = true

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -26,6 +26,24 @@ enum TabBarColors {
         return NSColor(bonsplitHex: value)
     }
 
+    private static func tabBarBackgroundColor(
+        for appearance: BonsplitConfiguration.Appearance
+    ) -> NSColor? {
+        guard let value = appearance.chromeColors.tabBarBackgroundHex else {
+            return chromeBackgroundColor(for: appearance)
+        }
+        return NSColor(bonsplitHex: value)
+    }
+
+    private static func splitButtonBackdropColor(
+        for appearance: BonsplitConfiguration.Appearance
+    ) -> NSColor? {
+        guard let value = appearance.chromeColors.splitButtonBackdropHex else {
+            return tabBarBackgroundColor(for: appearance)
+        }
+        return NSColor(bonsplitHex: value)
+    }
+
     private static func chromeBorderColor(
         for appearance: BonsplitConfiguration.Appearance
     ) -> NSColor? {
@@ -62,7 +80,7 @@ enum TabBarColors {
         for appearance: BonsplitConfiguration.Appearance,
         secondary: Bool
     ) -> NSColor {
-        guard let custom = chromeBackgroundColor(for: appearance) else {
+        guard let custom = tabBarBackgroundColor(for: appearance) else {
             return secondary ? .secondaryLabelColor : .labelColor
         }
 
@@ -90,11 +108,20 @@ enum TabBarColors {
     }
 
     static func barBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        Color(nsColor: effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor))
+        Color(nsColor: nsColorBarBackground(for: appearance))
+    }
+
+    static func nsColorBarBackground(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        tabBarBackgroundColor(for: appearance)
+            ?? effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor)
     }
 
     static func nsColorChromeBackground(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
         effectiveBackgroundColor(for: appearance, fallback: .windowBackgroundColor)
+    }
+
+    static func nsColorSplitButtonBackdropSurface(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        splitButtonBackdropColor(for: appearance) ?? nsColorBarBackground(for: appearance)
     }
 
     static func nsColorSplitButtonBackdrop(
@@ -105,7 +132,9 @@ enum TabBarColors {
     }
 
     static func shouldPaintSplitButtonBackdrop(for appearance: BonsplitConfiguration.Appearance) -> Bool {
-        chromeBackgroundColor(for: appearance) != nil
+        splitButtonBackdropColor(for: appearance) != nil
+            || tabBarBackgroundColor(for: appearance) != nil
+            || chromeBackgroundColor(for: appearance) != nil
     }
 
     static var barMaterial: Material {
@@ -119,7 +148,7 @@ enum TabBarColors {
     }
 
     static func activeTabBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        guard let custom = chromeBackgroundColor(for: appearance) else {
+        guard let custom = tabBarBackgroundColor(for: appearance) else {
             return activeTabBackground
         }
         let adjusted = custom.isBonsplitLightColor
@@ -133,7 +162,7 @@ enum TabBarColors {
     }
 
     static func hoveredTabBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        guard let custom = chromeBackgroundColor(for: appearance) else {
+        guard let custom = tabBarBackgroundColor(for: appearance) else {
             return hoveredTabBackground
         }
         let adjusted = custom.isBonsplitLightColor
@@ -198,7 +227,7 @@ enum TabBarColors {
             return explicit
         }
 
-        guard let custom = chromeBackgroundColor(for: appearance) else {
+        guard let custom = tabBarBackgroundColor(for: appearance) else {
             return .separatorColor
         }
         let alpha: CGFloat = custom.isBonsplitLightColor ? 0.26 : 0.36

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -360,11 +360,11 @@ struct TabBarView: View {
         if let debugStyle = BonsplitConfiguration.Appearance.SplitButtonBackdropStyle(rawValue: fadeColorStyle) {
             return .init(
                 style: debugStyle,
-                fadeWidth: 112,
-                solidWidth: 6,
-                fadeRampStartFraction: 0.72,
+                fadeWidth: 136,
+                solidWidth: 2,
+                fadeRampStartFraction: 0.80,
                 leadingOpacity: 0,
-                trailingOpacity: 1,
+                trailingOpacity: 0.80,
                 masksTabContent: false
             )
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1108,6 +1108,9 @@ private struct SplitActionButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
+            .opacity(configuration.isPressed ? 0.72 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
+            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -184,9 +184,7 @@ enum TabBarStyling {
     }
 
     static func imageDataShouldRenderAsTemplate(_ data: Data) -> Bool {
-        guard let text = String(data: data.prefix(4096), encoding: .utf8) else {
-            return false
-        }
+        let text = String(decoding: data.prefix(4096), as: UTF8.self)
         let lowercased = text.lowercased()
         return lowercased.contains("<svg") && lowercased.contains("currentcolor")
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1068,33 +1068,36 @@ struct TabBarView: View {
 private final class SplitActionButtonImageCache {
     static let shared = SplitActionButtonImageCache()
 
-    private var images: [Data: NSImage] = [:]
-    private var invalidImageData: Set<Data> = []
-    private let lock = NSLock()
+    private let images = NSCache<NSData, NSImage>()
+    private let invalidImageData = NSCache<NSData, NSNumber>()
+
+    private init() {
+        images.countLimit = 128
+        images.totalCostLimit = 8 * 1024 * 1024
+        invalidImageData.countLimit = 256
+        invalidImageData.totalCostLimit = 512 * 1024
+    }
 
     func image(for data: Data) -> NSImage? {
-        lock.lock()
-        if let image = images[data] {
-            lock.unlock()
+        let key = data as NSData
+        if let image = images.object(forKey: key) {
             return image
         }
-        if invalidImageData.contains(data) {
-            lock.unlock()
+        if invalidImageData.object(forKey: key) != nil {
             return nil
         }
-        lock.unlock()
 
         guard let image = NSImage(data: data) else {
-            lock.lock()
-            invalidImageData.insert(data)
-            lock.unlock()
+            invalidImageData.setObject(
+                NSNumber(value: true),
+                forKey: key,
+                cost: max(1, min(data.count, 1024))
+            )
             return nil
         }
         image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
 
-        lock.lock()
-        images[data] = image
-        lock.unlock()
+        images.setObject(image, forKey: key, cost: max(1, data.count))
         return image
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -351,7 +351,7 @@ struct TabBarView: View {
     }
 
     private var showsControlShortcutHints: Bool {
-        isFocused && controlKeyMonitor.isShortcutHintVisible
+        isFocused && splitViewController.tabShortcutHintsEnabled && controlKeyMonitor.isShortcutHintVisible
     }
 
     private var isMinimalMode: Bool {
@@ -605,6 +605,7 @@ struct TabBarView: View {
             appearance: appearance,
             saturation: tabBarSaturation,
             controlShortcutDigit: tabControlShortcutDigit(for: index, tabCount: pane.tabs.count),
+            allowsShortcutHints: isFocused && splitViewController.tabShortcutHintsEnabled,
             showsControlShortcutHint: showsControlShortcutHints,
             shortcutModifierSymbol: controlKeyMonitor.shortcutModifierSymbol,
             contextMenuState: contextMenuState,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -975,10 +975,8 @@ struct TabBarView: View {
             let g = fg.greenComponent * a + bk.greenComponent * oneMinusA
             let b = fg.blueComponent * a + bk.blueComponent * oneMinusA
             return NSColor(red: r, green: g, blue: b, alpha: 1.0)
-        default: // 0: tab bar chrome, preserving translucency
-            let backdrop = TabBarColors.nsColorSplitButtonBackdrop(for: appearance)
-            let alpha = focused ? backdrop.alphaComponent : backdrop.alphaComponent * 0.95
-            return backdrop.withAlphaComponent(alpha)
+        default: // 0: pre-composited pane background over window background
+            return TabBarColors.nsColorSplitButtonBackdrop(for: appearance, focused: focused)
         }
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1134,6 +1134,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         nsView.isMinimalMode = isMinimalMode
         nsView.onDoubleClick = onDoubleClick
         nsView.onHoverChanged = onHoverChanged
+        nsView.syncHoverStateToCurrentMouseLocation()
     }
 
     final class TabBarBackgroundNSView: NSView {
@@ -1141,18 +1142,26 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         var onDoubleClick: (() -> Bool)?
         var onHoverChanged: ((Bool) -> Void)?
         private var hoverTrackingArea: NSTrackingArea?
+        private var windowDidBecomeKeyObserver: NSObjectProtocol?
+        private var windowDidResignKeyObserver: NSObjectProtocol?
 
         override var mouseDownCanMoveWindow: Bool { false }
 
         deinit {
+            removeWindowObservers()
             BonsplitTabBarHitRegionRegistry.unregister(self)
         }
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             BonsplitTabBarHitRegionRegistry.unregister(self)
+            removeWindowObservers()
             if window != nil {
                 BonsplitTabBarHitRegionRegistry.register(self)
+                installWindowObservers()
+                syncHoverStateToCurrentMouseLocation()
+            } else {
+                onHoverChanged?(false)
             }
         }
 
@@ -1175,6 +1184,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             )
             addTrackingArea(area)
             hoverTrackingArea = area
+            syncHoverStateToCurrentMouseLocation()
         }
 
         override func mouseEntered(with event: NSEvent) {
@@ -1214,6 +1224,44 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             window.isMovable = true
             window.performDrag(with: event)
             window.isMovable = wasMovable
+        }
+
+        func syncHoverStateToCurrentMouseLocation() {
+            guard let window else {
+                onHoverChanged?(false)
+                return
+            }
+            let point = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+            onHoverChanged?(bounds.contains(point))
+        }
+
+        private func installWindowObservers() {
+            guard let window else { return }
+            windowDidBecomeKeyObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.syncHoverStateToCurrentMouseLocation()
+            }
+            windowDidResignKeyObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.syncHoverStateToCurrentMouseLocation()
+            }
+        }
+
+        private func removeWindowObservers() {
+            if let windowDidBecomeKeyObserver {
+                NotificationCenter.default.removeObserver(windowDidBecomeKeyObserver)
+                self.windowDidBecomeKeyObserver = nil
+            }
+            if let windowDidResignKeyObserver {
+                NotificationCenter.default.removeObserver(windowDidResignKeyObserver)
+                self.windowDidResignKeyObserver = nil
+            }
         }
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -852,9 +852,9 @@ struct TabBarView: View {
         case .systemImage(let name):
             Image(systemName: name)
                 .font(.system(size: 12))
-        case .emoji(let value):
+        case .emoji(let value, let scale):
             Text(value)
-                .font(.system(size: 13))
+                .font(.system(size: emojiIconFontSize(scale: scale)))
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
         case .imageData(let data):
@@ -870,6 +870,16 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
         }
+    }
+
+    private func emojiIconFontSize(scale: Double) -> CGFloat {
+        let safeScale: CGFloat
+        if scale.isFinite, scale > 0 {
+            safeScale = CGFloat(scale)
+        } else {
+            safeScale = 1
+        }
+        return 13 * safeScale
     }
 
     private func splitActionButtonImage(from data: Data) -> NSImage? {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -183,6 +183,14 @@ enum TabBarStyling {
             + (CGFloat(max(0, buttonCount - 1)) * splitButtonsSpacing)
     }
 
+    static func imageDataShouldRenderAsTemplate(_ data: Data) -> Bool {
+        guard let text = String(data: data.prefix(4096), encoding: .utf8) else {
+            return false
+        }
+        let lowercased = text.lowercased()
+        return lowercased.contains("<svg") && lowercased.contains("currentcolor")
+    }
+
     enum ScrollTarget: Equatable {
         case leading
         case selectedTab(UUID)
@@ -852,8 +860,9 @@ struct TabBarView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
         case .imageData(let data):
-            if let image = NSImage(data: data) {
+            if let image = splitActionButtonImage(from: data) {
                 Image(nsImage: image)
+                    .renderingMode(image.isTemplate ? .template : .original)
                     .resizable()
                     .interpolation(.high)
                     .scaledToFit()
@@ -863,6 +872,12 @@ struct TabBarView: View {
                     .font(.system(size: 12))
             }
         }
+    }
+
+    private func splitActionButtonImage(from data: Data) -> NSImage? {
+        guard let image = NSImage(data: data) else { return nil }
+        image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
+        return image
     }
 
     private func splitActionButtonTooltip(

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -189,6 +189,10 @@ enum TabBarStyling {
         return lowercased.contains("<svg") && lowercased.contains("currentcolor")
     }
 
+    static func splitActionButtonImage(from data: Data) -> NSImage? {
+        SplitActionButtonImageCache.shared.image(for: data)
+    }
+
     enum ScrollTarget: Equatable {
         case leading
         case selectedTab(UUID)
@@ -878,9 +882,7 @@ struct TabBarView: View {
     }
 
     private func splitActionButtonImage(from data: Data) -> NSImage? {
-        guard let image = NSImage(data: data) else { return nil }
-        image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
-        return image
+        TabBarStyling.splitActionButtonImage(from: data)
     }
 
     private func splitActionButtonTooltip(
@@ -1060,6 +1062,40 @@ struct TabBarView: View {
                 }
                 .frame(height: 1)
             }
+    }
+}
+
+private final class SplitActionButtonImageCache {
+    static let shared = SplitActionButtonImageCache()
+
+    private var images: [Data: NSImage] = [:]
+    private var invalidImageData: Set<Data> = []
+    private let lock = NSLock()
+
+    func image(for data: Data) -> NSImage? {
+        lock.lock()
+        if let image = images[data] {
+            lock.unlock()
+            return image
+        }
+        if invalidImageData.contains(data) {
+            lock.unlock()
+            return nil
+        }
+        lock.unlock()
+
+        guard let image = NSImage(data: data) else {
+            lock.lock()
+            invalidImageData.insert(data)
+            lock.unlock()
+            return nil
+        }
+        image.isTemplate = TabBarStyling.imageDataShouldRenderAsTemplate(data)
+
+        lock.lock()
+        images[data] = image
+        lock.unlock()
+        return image
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -350,6 +350,10 @@ struct TabBarView: View {
         shouldRenderSplitButtons && (!isMinimalMode || isHoveringTabBar)
     }
 
+    private var shouldPaintSplitButtonBackdrop: Bool {
+        shouldShowSplitButtons && TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance)
+    }
+
     private var splitButtonsBackdropWidth: CGFloat {
         TabBarStyling.splitButtonsBackdropWidth(buttonCount: visibleSplitButtons.count)
     }
@@ -531,16 +535,18 @@ struct TabBarView: View {
                             style: fadeColorStyle
                         ))
                         ZStack(alignment: .trailing) {
-                            HStack(spacing: 0) {
-                                LinearGradient(
-                                    colors: [backdropColor.opacity(0), backdropColor],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                )
-                                .frame(width: 24)
-                                Rectangle().fill(backdropColor)
+                            if shouldPaintSplitButtonBackdrop {
+                                HStack(spacing: 0) {
+                                    LinearGradient(
+                                        colors: [backdropColor.opacity(0), backdropColor],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
+                                    .frame(width: 24)
+                                    Rectangle().fill(backdropColor)
+                                }
+                                .frame(width: splitButtonsBackdropWidth)
                             }
-                            .frame(width: splitButtonsBackdropWidth)
 
                             splitButtons
                                 .saturation(tabBarSaturation)
@@ -1035,7 +1041,7 @@ struct TabBarView: View {
             Rectangle()
                 .fill(barFill)
                 .frame(maxWidth: .infinity)
-            if shouldShowSplitButtons {
+            if shouldPaintSplitButtonBackdrop {
                 Color.clear
                     .frame(width: splitButtonsBackdropWidth)
             }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -401,6 +401,10 @@ struct TabBarView: View {
         max(0, splitButtonBackdropEffect.contentFadeWidth)
     }
 
+    private var splitButtonContentOcclusionWidth: CGFloat {
+        splitButtonsBackdropWidth * min(max(0, splitButtonBackdropEffect.contentOcclusionFraction), 1)
+    }
+
     private var showsControlShortcutHints: Bool {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
@@ -1045,7 +1049,7 @@ struct TabBarView: View {
                 // Content is already fully faded before the backdrop ramp starts. This keeps the
                 // beginning of a transparent backdrop fade from blending over bright tab text.
                 Color.clear
-                    .frame(width: splitButtonsBackdropWidth)
+                    .frame(width: splitButtonContentOcclusionWidth)
             } else {
                 // Right scroll fade only when scroll content actually overflows.
                 LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -166,7 +166,22 @@ private final class TabBarScrollViewBridge: ObservableObject {
 }
 
 enum TabBarStyling {
-    static let splitButtonsBackdropWidth: CGFloat = 114
+    static let splitActionButtonReservedWidth: CGFloat = 22
+    static let splitButtonsSpacing: CGFloat = 4
+    static let splitButtonsLeadingPadding: CGFloat = 6
+    static let splitButtonsTrailingPadding: CGFloat = 8
+
+    static var splitButtonsBackdropWidth: CGFloat {
+        splitButtonsBackdropWidth(buttonCount: BonsplitConfiguration.SplitActionButton.defaults.count)
+    }
+
+    static func splitButtonsBackdropWidth(buttonCount: Int) -> CGFloat {
+        guard buttonCount > 0 else { return 0 }
+        return splitButtonsLeadingPadding
+            + splitButtonsTrailingPadding
+            + (CGFloat(buttonCount) * splitActionButtonReservedWidth)
+            + (CGFloat(max(0, buttonCount - 1)) * splitButtonsSpacing)
+    }
 
     enum ScrollTarget: Equatable {
         case leading
@@ -193,14 +208,15 @@ enum TabBarStyling {
 
     static func trailingTabContentInset(
         showSplitButtons: Bool,
-        isMinimalMode: Bool
+        isMinimalMode: Bool,
+        buttonCount: Int = BonsplitConfiguration.SplitActionButton.defaults.count
     ) -> CGFloat {
-        guard showSplitButtons else { return 0 }
+        guard showSplitButtons, buttonCount > 0 else { return 0 }
 
         // In minimal mode the split buttons fade in on hover as an overlay. Reserving that
         // width in the scroll content leaves a dead NSClipView strip when the buttons are
         // hidden, so clicks there never reach the tab-bar chrome.
-        return isMinimalMode ? 0 : splitButtonsBackdropWidth
+        return isMinimalMode ? 0 : splitButtonsBackdropWidth(buttonCount: buttonCount)
     }
 
     static func preferredScrollTarget(
@@ -311,6 +327,19 @@ struct TabBarView: View {
         controller.configuration.appearance
     }
 
+    private var visibleSplitButtons: [BonsplitConfiguration.SplitActionButton] {
+        guard showSplitButtons else { return [] }
+        return appearance.splitButtons
+    }
+
+    private var shouldRenderSplitButtons: Bool {
+        !visibleSplitButtons.isEmpty
+    }
+
+    private var splitButtonsBackdropWidth: CGFloat {
+        TabBarStyling.splitButtonsBackdropWidth(buttonCount: visibleSplitButtons.count)
+    }
+
     private var showsControlShortcutHints: Bool {
         isFocused && controlKeyMonitor.isShortcutHintVisible
     }
@@ -322,7 +351,8 @@ struct TabBarView: View {
     private var trailingTabContentInset: CGFloat {
         TabBarStyling.trailingTabContentInset(
             showSplitButtons: showSplitButtons,
-            isMinimalMode: isMinimalMode
+            isMinimalMode: isMinimalMode,
+            buttonCount: visibleSplitButtons.count
         )
     }
 
@@ -476,7 +506,7 @@ struct TabBarView: View {
                 // tab clicks fall through to `TabBarDragAndHoverView` (which performs a
                 // window drag in minimal mode).
                 .overlay(alignment: .trailing) {
-                    if showSplitButtons {
+                    if shouldRenderSplitButtons {
                         let shouldShow = !isMinimalMode || isHoveringTabBar
                         let backdropColor = Color(nsColor: Self.buttonBackdropColor(
                             for: appearance,
@@ -493,7 +523,7 @@ struct TabBarView: View {
                                 .frame(width: 24)
                                 Rectangle().fill(backdropColor)
                             }
-                            .frame(width: TabBarStyling.splitButtonsBackdropWidth)
+                            .frame(width: splitButtonsBackdropWidth)
 
                             splitButtons
                                 .saturation(tabBarSaturation)
@@ -506,11 +536,17 @@ struct TabBarView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: TabBarMetrics.barHeight)
         .coordinateSpace(name: "tabBar")
         .background(tabBarBackground)
         .background(TabBarDragAndHoverView(
             isMinimalMode: isMinimalMode,
+            onDoubleClick: {
+                guard splitViewController.isInteractive else { return false }
+                controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                return true
+            },
             onHoverChanged: { isHoveringTabBar = $0 }
         ))
         .background(
@@ -783,47 +819,84 @@ struct TabBarView: View {
     @ViewBuilder
     private var splitButtons: some View {
         let tooltips = controller.configuration.appearance.splitButtonTooltips
-        HStack(spacing: 4) {
-            Button {
-                controller.requestNewTab(kind: "terminal", inPane: pane.id)
-            } label: {
-                Image(systemName: "terminal")
-                    .font(.system(size: 12))
+        HStack(spacing: TabBarStyling.splitButtonsSpacing) {
+            ForEach(visibleSplitButtons, id: \.id) { button in
+                Button {
+                    performSplitActionButton(button)
+                } label: {
+                    splitActionButtonIcon(button.icon)
+                }
+                .buttonStyle(SplitActionButtonStyle(appearance: appearance))
+                .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
             }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.newTerminal)
-
-            Button {
-                controller.requestNewTab(kind: "browser", inPane: pane.id)
-            } label: {
-                Image(systemName: "globe")
-                    .font(.system(size: 12))
-            }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.newBrowser)
-
-            Button {
-                // 120fps animation handled by SplitAnimator
-                controller.splitPane(pane.id, orientation: .horizontal)
-            } label: {
-                Image(systemName: "square.split.2x1")
-                    .font(.system(size: 12))
-            }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.splitRight)
-
-            Button {
-                // 120fps animation handled by SplitAnimator
-                controller.splitPane(pane.id, orientation: .vertical)
-            } label: {
-                Image(systemName: "square.split.1x2")
-                    .font(.system(size: 12))
-            }
-            .buttonStyle(SplitActionButtonStyle(appearance: appearance))
-            .safeHelp(tooltips.splitDown)
         }
-        .padding(.leading, 6)
-        .padding(.trailing, 8)
+        .padding(.leading, TabBarStyling.splitButtonsLeadingPadding)
+        .padding(.trailing, TabBarStyling.splitButtonsTrailingPadding)
+    }
+
+    @ViewBuilder
+    private func splitActionButtonIcon(_ icon: BonsplitConfiguration.SplitActionButton.Icon) -> some View {
+        switch icon {
+        case .systemImage(let name):
+            Image(systemName: name)
+                .font(.system(size: 12))
+        case .emoji(let value):
+            Text(value)
+                .font(.system(size: 13))
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+        case .imageData(let data):
+            if let image = NSImage(data: data) {
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 14, height: 14)
+            } else {
+                Image(systemName: "questionmark.circle")
+                    .font(.system(size: 12))
+            }
+        }
+    }
+
+    private func splitActionButtonTooltip(
+        _ button: BonsplitConfiguration.SplitActionButton,
+        tooltips: BonsplitConfiguration.SplitButtonTooltips
+    ) -> String {
+        if let tooltip = button.tooltip?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !tooltip.isEmpty {
+            return tooltip
+        }
+
+        switch button.action {
+        case .newTerminal:
+            return tooltips.newTerminal
+        case .newBrowser:
+            return tooltips.newBrowser
+        case .splitRight:
+            return tooltips.splitRight
+        case .splitDown:
+            return tooltips.splitDown
+        case .custom(let identifier):
+            return identifier
+        }
+    }
+
+    private func performSplitActionButton(_ button: BonsplitConfiguration.SplitActionButton) {
+        switch button.action {
+        case .newTerminal:
+            controller.requestNewTab(kind: "terminal", inPane: pane.id)
+        case .newBrowser:
+            controller.requestNewTab(kind: "browser", inPane: pane.id)
+        case .splitRight:
+            // 120fps animation handled by SplitAnimator
+            controller.splitPane(pane.id, orientation: .horizontal)
+        case .splitDown:
+            // 120fps animation handled by SplitAnimator
+            controller.splitPane(pane.id, orientation: .vertical)
+        case .custom(let identifier):
+            controller.requestCustomAction(identifier, inPane: pane.id)
+        }
     }
 
 
@@ -979,22 +1052,26 @@ private struct SplitActionButtonStyle: ButtonStyle {
 /// this view only receives hits in truly empty space.
 private struct TabBarDragAndHoverView: NSViewRepresentable {
     let isMinimalMode: Bool
+    let onDoubleClick: () -> Bool
     let onHoverChanged: (Bool) -> Void
 
     func makeNSView(context: Context) -> TabBarBackgroundNSView {
         let view = TabBarBackgroundNSView()
         view.isMinimalMode = isMinimalMode
+        view.onDoubleClick = onDoubleClick
         view.onHoverChanged = onHoverChanged
         return view
     }
 
     func updateNSView(_ nsView: TabBarBackgroundNSView, context: Context) {
         nsView.isMinimalMode = isMinimalMode
+        nsView.onDoubleClick = onDoubleClick
         nsView.onHoverChanged = onHoverChanged
     }
 
     final class TabBarBackgroundNSView: NSView {
         var isMinimalMode = false
+        var onDoubleClick: (() -> Bool)?
         var onHoverChanged: ((Bool) -> Void)?
         private var hoverTrackingArea: NSTrackingArea?
 
@@ -1045,16 +1122,25 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 #if DEBUG
             dlog("tab.bar.bg.mouseDown isMinimal=\(isMinimalMode ? 1 : 0) clickCount=\(event.clickCount)")
 #endif
-            guard isMinimalMode, let window else {
+            guard let window else {
                 super.mouseDown(with: event)
                 return
             }
             if event.clickCount >= 2 {
-                let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
-                switch action {
-                case "Minimize": window.miniaturize(nil)
-                default: window.zoom(nil)
+                if isMinimalMode {
+                    let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
+                    switch action {
+                    case "Minimize": window.miniaturize(nil)
+                    default: window.zoom(nil)
+                    }
+                    return
                 }
+                if onDoubleClick?() == true {
+                    return
+                }
+            }
+            guard isMinimalMode else {
+                super.mouseDown(with: event)
                 return
             }
             let wasMovable = window.isMovable

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -558,7 +558,10 @@ struct TabBarView: View {
             isMinimalMode: isMinimalMode,
             onDoubleClick: {
                 guard splitViewController.isInteractive else { return false }
-                controller.requestNewTab(kind: "terminal", inPane: pane.id)
+                guard let button = visibleSplitButtons.first(where: { $0.action == .newTerminal }) else {
+                    return false
+                }
+                performSplitActionButton(button)
                 return true
             },
             onHoverChanged: { isHoveringTabBar = $0 }
@@ -833,8 +836,10 @@ struct TabBarView: View {
     @ViewBuilder
     private var splitButtons: some View {
         let tooltips = controller.configuration.appearance.splitButtonTooltips
+        let buttons = visibleSplitButtons
         HStack(spacing: TabBarStyling.splitButtonsSpacing) {
-            ForEach(visibleSplitButtons, id: \.id) { button in
+            ForEach(buttons.indices, id: \.self) { index in
+                let button = buttons[index]
                 Button {
                     performSplitActionButton(button)
                 } label: {
@@ -904,6 +909,8 @@ struct TabBarView: View {
     }
 
     private func performSplitActionButton(_ button: BonsplitConfiguration.SplitActionButton) {
+        guard splitViewController.isInteractive else { return }
+
         switch button.action {
         case .newTerminal:
             controller.requestNewTab(kind: "terminal", inPane: pane.id)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -302,7 +302,7 @@ struct TabBarView: View {
     var showSplitButtons: Bool = true
 
     @AppStorage("workspacePresentationMode") private var presentationMode = "standard"
-    @AppStorage("debugFadeColorStyle") private var fadeColorStyle = 0
+    @AppStorage("debugFadeColorStyle") private var fadeColorStyle = -1
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
@@ -350,20 +350,39 @@ struct TabBarView: View {
         shouldRenderSplitButtons && (!isMinimalMode || isHoveringTabBar)
     }
 
-    private var splitButtonBackdropStyle: BonsplitConfiguration.Appearance.SplitButtonBackdropStyle {
-        appearance.splitButtonBackdropStyle
-            ?? BonsplitConfiguration.Appearance.SplitButtonBackdropStyle(rawValue: fadeColorStyle)
-            ?? .precompositedPaneBackground
+    private var splitButtonBackdropEffect: BonsplitConfiguration.Appearance.SplitButtonBackdropEffect {
+        if let effect = appearance.splitButtonBackdropEffect {
+            return effect
+        }
+        if let style = appearance.splitButtonBackdropStyle {
+            return .init(style: style)
+        }
+        if let debugStyle = BonsplitConfiguration.Appearance.SplitButtonBackdropStyle(rawValue: fadeColorStyle) {
+            return .init(style: debugStyle, fadeWidth: 24, leadingOpacity: 0, trailingOpacity: 1, masksTabContent: false)
+        }
+        return .default
     }
 
     private var shouldPaintSplitButtonBackdrop: Bool {
         shouldShowSplitButtons
-            && splitButtonBackdropStyle != .hidden
+            && splitButtonBackdropEffect.style != .hidden
             && TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance)
+    }
+
+    private var shouldMaskTabsUnderSplitButtonBackdrop: Bool {
+        shouldPaintSplitButtonBackdrop && splitButtonBackdropEffect.masksTabContent
     }
 
     private var splitButtonsBackdropWidth: CGFloat {
         TabBarStyling.splitButtonsBackdropWidth(buttonCount: visibleSplitButtons.count)
+    }
+
+    private var splitButtonBackdropFadeWidth: CGFloat {
+        min(max(0, splitButtonBackdropEffect.fadeWidth), splitButtonsBackdropWidth)
+    }
+
+    private var splitButtonContentFadeWidth: CGFloat {
+        max(0, splitButtonBackdropEffect.contentFadeWidth)
     }
 
     private var showsControlShortcutHints: Bool {
@@ -537,21 +556,28 @@ struct TabBarView: View {
                 // window drag in minimal mode).
                 .overlay(alignment: .trailing) {
                     if shouldRenderSplitButtons {
-                        let backdropColor = Color(nsColor: Self.buttonBackdropColor(
+                        let effect = splitButtonBackdropEffect
+                        let backdropColor = Self.buttonBackdropColor(
                             for: appearance,
                             focused: isFocused,
-                            style: splitButtonBackdropStyle
-                        ))
+                            style: effect.style
+                        )
                         ZStack(alignment: .trailing) {
                             if shouldPaintSplitButtonBackdrop {
                                 HStack(spacing: 0) {
-                                    LinearGradient(
-                                        colors: [backdropColor.opacity(0), backdropColor],
-                                        startPoint: .leading,
-                                        endPoint: .trailing
-                                    )
-                                    .frame(width: 24)
-                                    Rectangle().fill(backdropColor)
+                                    if splitButtonBackdropFadeWidth > 0 {
+                                        LinearGradient(
+                                            colors: [
+                                                Color(nsColor: Self.backdropColor(backdropColor, opacityMultiplier: effect.leadingOpacity)),
+                                                Color(nsColor: Self.backdropColor(backdropColor, opacityMultiplier: effect.trailingOpacity))
+                                            ],
+                                            startPoint: .leading,
+                                            endPoint: .trailing
+                                        )
+                                        .frame(width: splitButtonBackdropFadeWidth)
+                                    }
+                                    Rectangle()
+                                        .fill(Color(nsColor: Self.backdropColor(backdropColor, opacityMultiplier: effect.trailingOpacity)))
                                 }
                                 .frame(width: splitButtonsBackdropWidth)
                             }
@@ -994,16 +1020,17 @@ struct TabBarView: View {
         }
     }
 
+    private static func backdropColor(_ color: NSColor, opacityMultiplier: CGFloat) -> NSColor {
+        let clamped = min(max(opacityMultiplier, 0), 1)
+        let converted = color.usingColorSpace(.sRGB) ?? color
+        return converted.withAlphaComponent(converted.alphaComponent * clamped)
+    }
+
     // MARK: - Combined Mask (scroll fades + button area)
     //
-    // IMPORTANT: SwiftUI's `.mask()` with `Color.clear` regions blocks hit testing on the
-    // masked content in those regions. Previously this mask used a 90pt clear region at the
-    // trailing edge to hide tabs under the split buttons; that caused clicks on tabs in that
-    // 90pt area to fall through the masked ScrollView to the `TabBarDragAndHoverView`
-    // background, which (in minimal mode) interpreted the click as a window drag instead
-    // of a tab tap. Keep the entire mask opaque so hit testing works on every tab; the split
-    // buttons' opaque backdrop (rendered in the splitButtons overlay) handles the visual
-    // obscuring of tabs underneath.
+    // The split-button backdrop is responsible for occluding content under the controls.
+    // When enabled, tab content fades out before the backdrop ramp starts. This keeps the
+    // transparent start of the backdrop fade from blending over bright tab text/icons.
 
     @ViewBuilder
     private var combinedMask: some View {
@@ -1016,9 +1043,18 @@ struct TabBarView: View {
             // Visible content area (always opaque so hit testing reaches the tabs)
             Rectangle().fill(Color.black)
 
-            // Right scroll fade only when scroll content actually overflows.
-            LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)
-                .frame(width: canScrollRight ? fadeWidth : 0)
+            if shouldMaskTabsUnderSplitButtonBackdrop {
+                LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)
+                    .frame(width: splitButtonContentFadeWidth)
+                // Content is already fully faded before the backdrop ramp starts. This keeps the
+                // beginning of a transparent backdrop fade from blending over bright tab text.
+                Color.clear
+                    .frame(width: splitButtonsBackdropWidth)
+            } else {
+                // Right scroll fade only when scroll content actually overflows.
+                LinearGradient(colors: [.black, .clear], startPoint: .leading, endPoint: .trailing)
+                    .frame(width: canScrollRight ? fadeWidth : 0)
+            }
         }
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -360,9 +360,9 @@ struct TabBarView: View {
         if let debugStyle = BonsplitConfiguration.Appearance.SplitButtonBackdropStyle(rawValue: fadeColorStyle) {
             return .init(
                 style: debugStyle,
-                fadeWidth: 96,
-                solidWidth: 18,
-                fadeRampStartFraction: 0.82,
+                fadeWidth: 112,
+                solidWidth: 6,
+                fadeRampStartFraction: 0.72,
                 leadingOpacity: 0,
                 trailingOpacity: 1,
                 masksTabContent: false

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1109,7 +1109,6 @@ private struct SplitActionButtonStyle: ButtonStyle {
         configuration.label
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
             .opacity(configuration.isPressed ? 0.72 : 1.0)
-            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
             .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -358,7 +358,15 @@ struct TabBarView: View {
             return .init(style: style)
         }
         if let debugStyle = BonsplitConfiguration.Appearance.SplitButtonBackdropStyle(rawValue: fadeColorStyle) {
-            return .init(style: debugStyle, fadeWidth: 24, leadingOpacity: 0, trailingOpacity: 1, masksTabContent: false)
+            return .init(
+                style: debugStyle,
+                fadeWidth: 96,
+                solidWidth: 18,
+                fadeRampStartFraction: 0.82,
+                leadingOpacity: 0,
+                trailingOpacity: 1,
+                masksTabContent: false
+            )
         }
         return .default
     }
@@ -378,7 +386,15 @@ struct TabBarView: View {
     }
 
     private var splitButtonBackdropFadeWidth: CGFloat {
-        min(max(0, splitButtonBackdropEffect.fadeWidth), splitButtonsBackdropWidth)
+        max(0, splitButtonBackdropEffect.fadeWidth)
+    }
+
+    private var splitButtonBackdropSolidWidth: CGFloat {
+        max(0, splitButtonBackdropEffect.solidWidth)
+    }
+
+    private var splitButtonBackdropFadeRampStartFraction: CGFloat {
+        min(max(0, splitButtonBackdropEffect.fadeRampStartFraction), 0.95)
     }
 
     private var splitButtonContentFadeWidth: CGFloat {
@@ -547,48 +563,18 @@ struct TabBarView: View {
                 }
                 .frame(height: TabBarMetrics.barHeight)
                 .mask(combinedMask)
-                // Split buttons sit on top of the tab strip in their own opaque backdrop.
-                // The backdrop visually obscures any tabs that scroll under the buttons,
-                // and (critically) does not break hit testing on tabs outside the backdrop —
-                // unlike the prior approach of using a `Color.clear` region in `combinedMask`,
-                // which silently blocked SwiftUI hit tests in the masked-out area and let
-                // tab clicks fall through to `TabBarDragAndHoverView` (which performs a
-                // window drag in minimal mode).
+                // Split buttons sit on top of the tab strip. Their backing surface is
+                // painted by `tabBarBackground` so translucent colors are composited once,
+                // while `combinedMask` fades overflowing tab content out below them.
                 .overlay(alignment: .trailing) {
                     if shouldRenderSplitButtons {
-                        let effect = splitButtonBackdropEffect
-                        let backdropColor = Self.buttonBackdropColor(
-                            for: appearance,
-                            focused: isFocused,
-                            style: effect.style
-                        )
-                        ZStack(alignment: .trailing) {
-                            if shouldPaintSplitButtonBackdrop {
-                                HStack(spacing: 0) {
-                                    if splitButtonBackdropFadeWidth > 0 {
-                                        LinearGradient(
-                                            colors: [
-                                                Color(nsColor: Self.backdropColor(backdropColor, opacityMultiplier: effect.leadingOpacity)),
-                                                Color(nsColor: Self.backdropColor(backdropColor, opacityMultiplier: effect.trailingOpacity))
-                                            ],
-                                            startPoint: .leading,
-                                            endPoint: .trailing
-                                        )
-                                        .frame(width: splitButtonBackdropFadeWidth)
-                                    }
-                                    Rectangle()
-                                        .fill(Color(nsColor: Self.backdropColor(backdropColor, opacityMultiplier: effect.trailingOpacity)))
-                                }
-                                .frame(width: splitButtonsBackdropWidth)
-                            }
-
-                            splitButtons
-                                .saturation(tabBarSaturation)
-                                .padding(.bottom, 1)
-                        }
-                        .opacity(shouldShowSplitButtons ? 1 : 0)
-                        .allowsHitTesting(shouldShowSplitButtons)
-                        .animation(.easeInOut(duration: 0.14), value: shouldShowSplitButtons)
+                        splitButtons
+                            .saturation(tabBarSaturation)
+                            .padding(.bottom, 1)
+                            .frame(width: splitButtonsBackdropWidth, alignment: .trailing)
+                            .opacity(shouldShowSplitButtons ? 1 : 0)
+                            .allowsHitTesting(shouldShowSplitButtons)
+                            .animation(.easeInOut(duration: 0.14), value: shouldShowSplitButtons)
                     }
                 }
             }
@@ -990,14 +976,13 @@ struct TabBarView: View {
         case .opaquePaneBackground:
             return TabBarColors.nsColorPaneBackground(for: appearance).withAlphaComponent(1.0)
         case .opaqueBarBackground:
-            let c = NSColor(TabBarColors.barBackground(for: appearance))
-            return (c.usingColorSpace(.sRGB) ?? c).withAlphaComponent(1.0)
+            return TabBarColors.nsColorBarBackground(for: appearance).withAlphaComponent(1.0)
         case .windowBackground:
             return NSColor.windowBackgroundColor.withAlphaComponent(1.0)
         case .controlBackground:
             return NSColor.controlBackgroundColor.withAlphaComponent(1.0)
         case .precompositedBarBackground:
-            let chrome = NSColor(TabBarColors.barBackground(for: appearance))
+            let chrome = TabBarColors.nsColorBarBackground(for: appearance)
             let winBg = NSColor.windowBackgroundColor
             guard let fg = chrome.usingColorSpace(.sRGB),
                   let bk = winBg.usingColorSpace(.sRGB) else {
@@ -1010,7 +995,7 @@ struct TabBarView: View {
             let b = fg.blueComponent * a + bk.blueComponent * oneMinusA
             return NSColor(red: r, green: g, blue: b, alpha: 1.0)
         case .translucentChrome:
-            let backdrop = TabBarColors.nsColorChromeBackground(for: appearance)
+            let backdrop = TabBarColors.nsColorSplitButtonBackdropSurface(for: appearance)
             let alpha = focused ? backdrop.alphaComponent : backdrop.alphaComponent * 0.95
             return backdrop.withAlphaComponent(alpha)
         case .hidden:
@@ -1020,10 +1005,21 @@ struct TabBarView: View {
         }
     }
 
-    private static func backdropColor(_ color: NSColor, opacityMultiplier: CGFloat) -> NSColor {
-        let clamped = min(max(opacityMultiplier, 0), 1)
-        let converted = color.usingColorSpace(.sRGB) ?? color
-        return converted.withAlphaComponent(converted.alphaComponent * clamped)
+    private static func blendedSurfaceColor(
+        from base: NSColor,
+        to target: NSColor,
+        amount: CGFloat
+    ) -> NSColor {
+        let clampedAmount = min(max(amount, 0), 1)
+        let source = base.usingColorSpace(.sRGB) ?? base
+        let destination = target.usingColorSpace(.sRGB) ?? target
+        let inverse = 1 - clampedAmount
+        return NSColor(
+            red: source.redComponent * inverse + destination.redComponent * clampedAmount,
+            green: source.greenComponent * inverse + destination.greenComponent * clampedAmount,
+            blue: source.blueComponent * inverse + destination.blueComponent * clampedAmount,
+            alpha: source.alphaComponent * inverse + destination.alphaComponent * clampedAmount
+        )
     }
 
     // MARK: - Combined Mask (scroll fades + button area)
@@ -1081,17 +1077,49 @@ struct TabBarView: View {
 
     @ViewBuilder
     private var tabBarBackground: some View {
-        let barFill = isFocused
-            ? TabBarColors.barBackground(for: appearance)
-            : TabBarColors.barBackground(for: appearance).opacity(0.95)
+        let baseBarColor = TabBarColors.nsColorBarBackground(for: appearance)
+        let barColor = isFocused
+            ? baseBarColor
+            : baseBarColor.withAlphaComponent(baseBarColor.alphaComponent * 0.95)
+        let barFill = Color(nsColor: barColor)
 
         HStack(spacing: 0) {
             Rectangle()
                 .fill(barFill)
                 .frame(maxWidth: .infinity)
             if shouldPaintSplitButtonBackdrop {
-                Color.clear
-                    .frame(width: splitButtonsBackdropWidth)
+                let effect = splitButtonBackdropEffect
+                let targetColor = Self.buttonBackdropColor(
+                    for: appearance,
+                    focused: isFocused,
+                    style: effect.style
+                )
+                let leadingColor = Self.blendedSurfaceColor(
+                    from: barColor,
+                    to: targetColor,
+                    amount: effect.leadingOpacity
+                )
+                let trailingColor = Self.blendedSurfaceColor(
+                    from: barColor,
+                    to: targetColor,
+                    amount: effect.trailingOpacity
+                )
+                if splitButtonBackdropFadeWidth > 0 {
+                    let rampStart = splitButtonBackdropFadeRampStartFraction
+                    LinearGradient(
+                        stops: [
+                            .init(color: Color(nsColor: leadingColor), location: 0),
+                            .init(color: Color(nsColor: leadingColor), location: rampStart),
+                            .init(color: Color(nsColor: trailingColor), location: 1)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: splitButtonBackdropFadeWidth)
+                }
+                Rectangle()
+                    .fill(Color(nsColor: trailingColor))
+                    .frame(width: splitButtonBackdropSolidWidth)
             }
         }
             .overlay(alignment: .bottom) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -350,8 +350,16 @@ struct TabBarView: View {
         shouldRenderSplitButtons && (!isMinimalMode || isHoveringTabBar)
     }
 
+    private var splitButtonBackdropStyle: BonsplitConfiguration.Appearance.SplitButtonBackdropStyle {
+        appearance.splitButtonBackdropStyle
+            ?? BonsplitConfiguration.Appearance.SplitButtonBackdropStyle(rawValue: fadeColorStyle)
+            ?? .precompositedPaneBackground
+    }
+
     private var shouldPaintSplitButtonBackdrop: Bool {
-        shouldShowSplitButtons && TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance)
+        shouldShowSplitButtons
+            && splitButtonBackdropStyle != .hidden
+            && TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance)
     }
 
     private var splitButtonsBackdropWidth: CGFloat {
@@ -532,7 +540,7 @@ struct TabBarView: View {
                         let backdropColor = Color(nsColor: Self.buttonBackdropColor(
                             for: appearance,
                             focused: isFocused,
-                            style: fadeColorStyle
+                            style: splitButtonBackdropStyle
                         ))
                         ZStack(alignment: .trailing) {
                             if shouldPaintSplitButtonBackdrop {
@@ -950,19 +958,19 @@ struct TabBarView: View {
     private static func buttonBackdropColor(
         for appearance: BonsplitConfiguration.Appearance,
         focused: Bool,
-        style: Int
+        style: BonsplitConfiguration.Appearance.SplitButtonBackdropStyle
     ) -> NSColor {
         switch style {
-        case 1: // raw paneBackground forced opaque
+        case .opaquePaneBackground:
             return TabBarColors.nsColorPaneBackground(for: appearance).withAlphaComponent(1.0)
-        case 2: // barBackground (tab bar chrome)
+        case .opaqueBarBackground:
             let c = NSColor(TabBarColors.barBackground(for: appearance))
             return (c.usingColorSpace(.sRGB) ?? c).withAlphaComponent(1.0)
-        case 3: // windowBackgroundColor
+        case .windowBackground:
             return NSColor.windowBackgroundColor.withAlphaComponent(1.0)
-        case 4: // controlBackgroundColor
+        case .controlBackground:
             return NSColor.controlBackgroundColor.withAlphaComponent(1.0)
-        case 5: // pre-composited barBackground over windowBg
+        case .precompositedBarBackground:
             let chrome = NSColor(TabBarColors.barBackground(for: appearance))
             let winBg = NSColor.windowBackgroundColor
             guard let fg = chrome.usingColorSpace(.sRGB),
@@ -975,7 +983,13 @@ struct TabBarView: View {
             let g = fg.greenComponent * a + bk.greenComponent * oneMinusA
             let b = fg.blueComponent * a + bk.blueComponent * oneMinusA
             return NSColor(red: r, green: g, blue: b, alpha: 1.0)
-        default: // 0: pre-composited pane background over window background
+        case .translucentChrome:
+            let backdrop = TabBarColors.nsColorChromeBackground(for: appearance)
+            let alpha = focused ? backdrop.alphaComponent : backdrop.alphaComponent * 0.95
+            return backdrop.withAlphaComponent(alpha)
+        case .hidden:
+            return .clear
+        case .precompositedPaneBackground:
             return TabBarColors.nsColorSplitButtonBackdrop(for: appearance, focused: focused)
         }
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1802,7 +1802,7 @@ private final class TabControlShortcutKeyMonitor: ObservableObject {
             ) else { return }
             guard let currentModifier = TabControlShortcutHintPolicy.hintModifier(for: NSEvent.modifierFlags) else { return }
             self.shortcutModifierSymbol = currentModifier.symbol
-            withAnimation(.easeInOut(duration: 0.14)) {
+            withAnimation(TabControlShortcutHintAnimation.visibility) {
                 self.isShortcutHintVisible = true
             }
         }
@@ -1817,7 +1817,7 @@ private final class TabControlShortcutKeyMonitor: ObservableObject {
         pendingShowWorkItem = nil
         pendingModifier = nil
         if resetVisible {
-            withAnimation(.easeInOut(duration: 0.14)) {
+            withAnimation(TabControlShortcutHintAnimation.visibility) {
                 isShortcutHintVisible = false
             }
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -346,6 +346,10 @@ struct TabBarView: View {
         !visibleSplitButtons.isEmpty
     }
 
+    private var shouldShowSplitButtons: Bool {
+        shouldRenderSplitButtons && (!isMinimalMode || isHoveringTabBar)
+    }
+
     private var splitButtonsBackdropWidth: CGFloat {
         TabBarStyling.splitButtonsBackdropWidth(buttonCount: visibleSplitButtons.count)
     }
@@ -521,7 +525,6 @@ struct TabBarView: View {
                 // window drag in minimal mode).
                 .overlay(alignment: .trailing) {
                     if shouldRenderSplitButtons {
-                        let shouldShow = !isMinimalMode || isHoveringTabBar
                         let backdropColor = Color(nsColor: Self.buttonBackdropColor(
                             for: appearance,
                             focused: isFocused,
@@ -541,11 +544,11 @@ struct TabBarView: View {
 
                             splitButtons
                                 .saturation(tabBarSaturation)
+                                .padding(.bottom, 1)
                         }
-                        .padding(.bottom, 1)
-                        .opacity(shouldShow ? 1 : 0)
-                        .allowsHitTesting(shouldShow)
-                        .animation(.easeInOut(duration: 0.14), value: shouldShow)
+                        .opacity(shouldShowSplitButtons ? 1 : 0)
+                        .allowsHitTesting(shouldShowSplitButtons)
+                        .animation(.easeInOut(duration: 0.14), value: shouldShowSplitButtons)
                     }
                 }
             }
@@ -966,30 +969,11 @@ struct TabBarView: View {
             let g = fg.greenComponent * a + bk.greenComponent * oneMinusA
             let b = fg.blueComponent * a + bk.blueComponent * oneMinusA
             return NSColor(red: r, green: g, blue: b, alpha: 1.0)
-        default: // 0: pre-composited paneBackground over windowBg
-            return precompositedPaneBackground(for: appearance, focused: focused)
+        default: // 0: tab bar chrome, preserving translucency
+            let backdrop = TabBarColors.nsColorSplitButtonBackdrop(for: appearance)
+            let alpha = focused ? backdrop.alphaComponent : backdrop.alphaComponent * 0.95
+            return backdrop.withAlphaComponent(alpha)
         }
-    }
-
-    /// Pre-composite the pane background over the window background to produce
-    /// a flat opaque color that matches what .background(barFill) looks like
-    /// after compositing. Avoids double-compositing mismatch on overlays.
-    private static func precompositedPaneBackground(
-        for appearance: BonsplitConfiguration.Appearance,
-        focused: Bool
-    ) -> NSColor {
-        let chrome = TabBarColors.nsColorPaneBackground(for: appearance)
-        let winBg = NSColor.windowBackgroundColor
-        guard let fg = chrome.usingColorSpace(.sRGB),
-              let bk = winBg.usingColorSpace(.sRGB) else {
-            return chrome.withAlphaComponent(1.0)
-        }
-        let a: CGFloat = focused ? fg.alphaComponent : fg.alphaComponent * 0.95
-        let oneMinusA = 1.0 - a
-        let r = fg.redComponent * a + bk.redComponent * oneMinusA
-        let g = fg.greenComponent * a + bk.greenComponent * oneMinusA
-        let b = fg.blueComponent * a + bk.blueComponent * oneMinusA
-        return NSColor(red: r, green: g, blue: b, alpha: 1.0)
     }
 
     // MARK: - Combined Mask (scroll fades + button area)
@@ -1047,8 +1031,15 @@ struct TabBarView: View {
             ? TabBarColors.barBackground(for: appearance)
             : TabBarColors.barBackground(for: appearance).opacity(0.95)
 
-        Rectangle()
-            .fill(barFill)
+        HStack(spacing: 0) {
+            Rectangle()
+                .fill(barFill)
+                .frame(maxWidth: .infinity)
+            if shouldShowSplitButtons {
+                Color.clear
+                    .frame(width: splitButtonsBackdropWidth)
+            }
+        }
             .overlay(alignment: .bottom) {
                 GeometryReader { geometry in
                     let separator = TabBarColors.separator(for: appearance)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -481,9 +481,7 @@ struct TabBarView: View {
                                 isFocusedPane: isFocused,
                                 onSingleClick: focusPaneFromTabBarChrome
                             ) {
-                                guard splitViewController.isInteractive else { return false }
-                                controller.requestNewTab(kind: "terminal", inPane: pane.id)
-                                return true
+                                performNewTerminalSplitButtonAction()
                             }
                             .frame(width: trailing + 30, height: TabBarMetrics.tabHeight)
                             .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
@@ -559,12 +557,7 @@ struct TabBarView: View {
         .background(TabBarDragAndHoverView(
             isMinimalMode: isMinimalMode,
             onDoubleClick: {
-                guard splitViewController.isInteractive else { return false }
-                guard let button = visibleSplitButtons.first(where: { $0.action == .newTerminal }) else {
-                    return false
-                }
-                performSplitActionButton(button)
-                return true
+                performNewTerminalSplitButtonAction()
             },
             onHoverChanged: { isHoveringTabBar = $0 }
         ))
@@ -802,9 +795,7 @@ struct TabBarView: View {
             isFocusedPane: isFocused,
             onSingleClick: focusPaneFromTabBarChrome
         ) {
-            guard splitViewController.isInteractive else { return false }
-            controller.requestNewTab(kind: "terminal", inPane: pane.id)
-            return true
+            performNewTerminalSplitButtonAction()
         }
         .frame(width: 30, height: TabBarMetrics.tabHeight)
         .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
@@ -925,6 +916,15 @@ struct TabBarView: View {
         case .custom(let identifier):
             controller.requestCustomAction(identifier, inPane: pane.id)
         }
+    }
+
+    private func performNewTerminalSplitButtonAction() -> Bool {
+        guard splitViewController.isInteractive else { return false }
+        guard let button = visibleSplitButtons.first(where: { $0.action == .newTerminal }) else {
+            return false
+        }
+        performSplitActionButton(button)
+        return true
     }
 
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -349,6 +349,12 @@ struct TabItemView: View {
             contextButton("Remove Custom Tab Name", action: .clearName)
         }
 
+        localizedContextButton(
+            "command.copyWorkspaceAndSurfaceIDs.title",
+            defaultValue: "Copy Workspace and Surface IDs",
+            action: .copyIdentifiers
+        )
+
         Divider()
 
         contextButton("Close Tabs to Left", action: .closeToLeft)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -43,6 +43,7 @@ struct TabItemView: View {
     let appearance: BonsplitConfiguration.Appearance
     let saturation: Double
     let controlShortcutDigit: Int?
+    let allowsShortcutHints: Bool
     let showsControlShortcutHint: Bool
     let shortcutModifierSymbol: String
     let contextMenuState: TabContextMenuState
@@ -212,7 +213,7 @@ struct TabItemView: View {
     }
 
     private var showsShortcutHint: Bool {
-        (showsControlShortcutHint || alwaysShowShortcutHints) && shortcutHintLabel != nil
+        allowsShortcutHints && (showsControlShortcutHint || alwaysShowShortcutHints) && shortcutHintLabel != nil
     }
 
     private var shortcutHintSlotWidth: CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 import AppKit
 
+enum TabControlShortcutHintAnimation {
+    static let visibility: Animation = .easeOut(duration: 0.12)
+}
+
+extension View {
+    func tabControlShortcutHintVisibilityAnimation<Value: Equatable>(value: Value) -> some View {
+        animation(TabControlShortcutHintAnimation.visibility, value: value)
+    }
+}
+
 private enum TabControlShortcutHintDebugSettings {
     static let xKey = "shortcutHintPaneTabXOffset"
     static let yKey = "shortcutHintPaneTabYOffset"
@@ -174,7 +184,7 @@ struct TabItemView: View {
         )
         .padding(.bottom, isSelected ? 1 : 0)
         .background(tabBackground.saturation(saturation))
-        .animation(.easeInOut(duration: 0.14), value: showsShortcutHint)
+        .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
         .contentShape(Rectangle())
         // Middle click to close (macOS convention).
         // Uses an AppKit event monitor so it doesn't interfere with left click selection or drag/reorder.
@@ -277,7 +287,7 @@ struct TabItemView: View {
                 .allowsHitTesting(!showsShortcutHint)
         }
         .frame(width: shortcutHintSlotWidth, height: accessorySlotSize, alignment: .center)
-        .animation(.easeInOut(duration: 0.14), value: showsShortcutHint)
+        .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
     }
 
     private func updateGlobeFallback() {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -349,12 +349,6 @@ struct TabItemView: View {
             contextButton("Remove Custom Tab Name", action: .clearName)
         }
 
-        localizedContextButton(
-            "command.copyWorkspaceAndSurfaceIDs.title",
-            defaultValue: "Copy Workspace and Surface IDs",
-            action: .copyIdentifiers
-        )
-
         Divider()
 
         contextButton("Close Tabs to Left", action: .closeToLeft)
@@ -419,6 +413,14 @@ struct TabItemView: View {
             contextButton("Mark Tab as Unread", action: .markAsUnread)
                 .disabled(!contextMenuState.canMarkAsUnread)
         }
+
+        Divider()
+
+        localizedContextButton(
+            "command.copyWorkspaceAndSurfaceIDs.title",
+            defaultValue: "Copy Workspace and Surface IDs",
+            action: .copyIdentifiers
+        )
     }
 
     @ViewBuilder

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -285,6 +285,7 @@ extension BonsplitConfiguration {
             action: .splitDown
         )
 
+        /// Built-in split actions shown by default. Hosts can replace this list with custom buttons.
         public static let defaults: [SplitActionButton] = [
             .newTerminal,
             .newBrowser,
@@ -363,8 +364,13 @@ extension BonsplitConfiguration {
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
 
-        /// Ordered action buttons shown in the tab bar when split buttons are enabled
-        public var splitButtons: [SplitActionButton]
+        /// Ordered action buttons shown in the tab bar when split buttons are enabled.
+        /// Duplicate button ids are ignored, preserving the first matching button.
+        public var splitButtons: [SplitActionButton] {
+            didSet {
+                splitButtons = Self.uniqueSplitButtons(splitButtons)
+            }
+        }
 
         /// When true, split buttons are only visible on hover
         public var splitButtonsOnHover: Bool
@@ -434,13 +440,18 @@ extension BonsplitConfiguration {
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.showSplitButtons = showSplitButtons
-            self.splitButtons = splitButtons
+            self.splitButtons = Self.uniqueSplitButtons(splitButtons)
             self.splitButtonsOnHover = splitButtonsOnHover
             self.tabBarLeadingInset = tabBarLeadingInset
             self.splitButtonTooltips = splitButtonTooltips
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations
             self.chromeColors = chromeColors
+        }
+
+        private static func uniqueSplitButtons(_ buttons: [SplitActionButton]) -> [SplitActionButton] {
+            var seenIds = Set<String>()
+            return buttons.filter { seenIds.insert($0.id).inserted }
         }
     }
 }

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -105,7 +105,7 @@ extension BonsplitConfiguration {
     public struct SplitActionButton: Sendable, Codable, Hashable, Identifiable {
         public enum Icon: Sendable, Codable, Hashable {
             case systemImage(String)
-            case emoji(String)
+            case emoji(String, scale: Double = 1)
             case imageData(Data)
 
             private enum CodingKeys: String, CodingKey {
@@ -113,6 +113,7 @@ extension BonsplitConfiguration {
                 case name
                 case value
                 case data
+                case scale
             }
 
             public init(from decoder: Decoder) throws {
@@ -127,7 +128,10 @@ extension BonsplitConfiguration {
                 case "systemImage", "symbol", "sfSymbol":
                     self = .systemImage(try container.decode(String.self, forKey: .name))
                 case "emoji":
-                    self = .emoji(try container.decode(String.self, forKey: .value))
+                    self = .emoji(
+                        try container.decode(String.self, forKey: .value),
+                        scale: try Self.emojiScale(in: container)
+                    )
                 case "imageData":
                     self = .imageData(try container.decode(Data.self, forKey: .data))
                 default:
@@ -145,13 +149,28 @@ extension BonsplitConfiguration {
                 case .systemImage(let name):
                     try container.encode("systemImage", forKey: .type)
                     try container.encode(name, forKey: .name)
-                case .emoji(let value):
+                case .emoji(let value, let scale):
                     try container.encode("emoji", forKey: .type)
                     try container.encode(value, forKey: .value)
+                    if scale != 1 {
+                        try container.encode(scale, forKey: .scale)
+                    }
                 case .imageData(let data):
                     try container.encode("imageData", forKey: .type)
                     try container.encode(data, forKey: .data)
                 }
+            }
+
+            private static func emojiScale(in container: KeyedDecodingContainer<CodingKeys>) throws -> Double {
+                let scale = try container.decodeIfPresent(Double.self, forKey: .scale) ?? 1
+                guard scale.isFinite, scale > 0 else {
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .scale,
+                        in: container,
+                        debugDescription: "Emoji icon scale must be a positive number"
+                    )
+                }
+                return scale
             }
         }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -358,12 +358,12 @@ extension BonsplitConfiguration {
 
             public init(
                 style: SplitButtonBackdropStyle = .translucentChrome,
-                fadeWidth: CGFloat = 112,
+                fadeWidth: CGFloat = 136,
                 contentFadeWidth: CGFloat = 42,
-                solidWidth: CGFloat = 6,
-                fadeRampStartFraction: CGFloat = 0.72,
+                solidWidth: CGFloat = 2,
+                fadeRampStartFraction: CGFloat = 0.80,
                 leadingOpacity: CGFloat = 0,
-                trailingOpacity: CGFloat = 1.0,
+                trailingOpacity: CGFloat = 0.80,
                 masksTabContent: Bool = true
             ) {
                 self.style = style

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -358,10 +358,10 @@ extension BonsplitConfiguration {
 
             public init(
                 style: SplitButtonBackdropStyle = .translucentChrome,
-                fadeWidth: CGFloat = 96,
+                fadeWidth: CGFloat = 112,
                 contentFadeWidth: CGFloat = 42,
-                solidWidth: CGFloat = 18,
-                fadeRampStartFraction: CGFloat = 0.82,
+                solidWidth: CGFloat = 6,
+                fadeRampStartFraction: CGFloat = 0.72,
                 leadingOpacity: CGFloat = 0,
                 trailingOpacity: CGFloat = 1.0,
                 masksTabContent: Bool = true

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -354,6 +354,7 @@ extension BonsplitConfiguration {
             public var fadeRampStartFraction: CGFloat
             public var leadingOpacity: CGFloat
             public var trailingOpacity: CGFloat
+            public var contentOcclusionFraction: CGFloat
             public var masksTabContent: Bool
 
             public init(
@@ -364,6 +365,7 @@ extension BonsplitConfiguration {
                 fadeRampStartFraction: CGFloat = 0.80,
                 leadingOpacity: CGFloat = 0,
                 trailingOpacity: CGFloat = 0.80,
+                contentOcclusionFraction: CGFloat = 1.0,
                 masksTabContent: Bool = true
             ) {
                 self.style = style
@@ -373,6 +375,7 @@ extension BonsplitConfiguration {
                 self.fadeRampStartFraction = min(max(0, fadeRampStartFraction), 0.95)
                 self.leadingOpacity = min(max(0, leadingOpacity), 1)
                 self.trailingOpacity = min(max(0, trailingOpacity), 1)
+                self.contentOcclusionFraction = min(max(0, contentOcclusionFraction), 1)
                 self.masksTabContent = masksTabContent
             }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -162,6 +162,11 @@ extension BonsplitConfiguration {
             case splitDown
             case custom(String)
 
+            private enum CodingKeys: String, CodingKey {
+                case type
+                case identifier
+            }
+
             public var rawValue: String {
                 switch self {
                 case .newTerminal:
@@ -178,25 +183,46 @@ extension BonsplitConfiguration {
             }
 
             public init(from decoder: Decoder) throws {
-                let container = try decoder.singleValueContainer()
-                let value = try container.decode(String.self)
-                switch value {
-                case "newTerminal":
-                    self = .newTerminal
-                case "newBrowser":
-                    self = .newBrowser
-                case "splitRight":
-                    self = .splitRight
-                case "splitDown":
-                    self = .splitDown
-                default:
-                    self = .custom(value)
+                if let container = try? decoder.singleValueContainer(),
+                   let value = try? container.decode(String.self) {
+                    self = Self.action(for: value)
+                    return
+                }
+
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let type = try container.decode(String.self, forKey: .type)
+                if type == "custom" {
+                    self = .custom(try container.decode(String.self, forKey: .identifier))
+                } else {
+                    self = Self.action(for: type)
                 }
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
-                try container.encode(rawValue)
+                switch self {
+                case .custom(let identifier):
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    try container.encode("custom", forKey: .type)
+                    try container.encode(identifier, forKey: .identifier)
+                default:
+                    var container = encoder.singleValueContainer()
+                    try container.encode(rawValue)
+                }
+            }
+
+            private static func action(for value: String) -> Action {
+                switch value {
+                case "newTerminal":
+                    return .newTerminal
+                case "newBrowser":
+                    return .newBrowser
+                case "splitRight":
+                    return .splitRight
+                case "splitDown":
+                    return .splitDown
+                default:
+                    return .custom(value)
+                }
             }
         }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -346,6 +346,33 @@ extension BonsplitConfiguration {
             case hidden = 7
         }
 
+        public struct SplitButtonBackdropEffect: Sendable {
+            public var style: SplitButtonBackdropStyle
+            public var fadeWidth: CGFloat
+            public var contentFadeWidth: CGFloat
+            public var leadingOpacity: CGFloat
+            public var trailingOpacity: CGFloat
+            public var masksTabContent: Bool
+
+            public init(
+                style: SplitButtonBackdropStyle = .translucentChrome,
+                fadeWidth: CGFloat = 24,
+                contentFadeWidth: CGFloat = 24,
+                leadingOpacity: CGFloat = 0,
+                trailingOpacity: CGFloat = 1.0,
+                masksTabContent: Bool = true
+            ) {
+                self.style = style
+                self.fadeWidth = max(0, fadeWidth)
+                self.contentFadeWidth = max(0, contentFadeWidth)
+                self.leadingOpacity = min(max(0, leadingOpacity), 1)
+                self.trailingOpacity = min(max(0, trailingOpacity), 1)
+                self.masksTabContent = masksTabContent
+            }
+
+            public static let `default` = SplitButtonBackdropEffect()
+        }
+
         public struct ChromeColors: Sendable {
             /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for tab chrome backgrounds.
             /// When unset, Bonsplit uses native system colors.
@@ -415,6 +442,11 @@ extension BonsplitConfiguration {
         /// When unset, Bonsplit uses the host app's debug override if one is configured.
         public var splitButtonBackdropStyle: SplitButtonBackdropStyle?
 
+        /// Optional explicit backdrop effect for the tab bar's right-side action buttons.
+        /// This controls both the color strategy and how tab content is faded or clipped
+        /// underneath the action-button region.
+        public var splitButtonBackdropEffect: SplitButtonBackdropEffect?
+
         /// Extra leading inset for the tab bar (e.g. for traffic light buttons when sidebar is collapsed)
         public var tabBarLeadingInset: CGFloat
 
@@ -467,6 +499,7 @@ extension BonsplitConfiguration {
             splitButtons: [SplitActionButton] = SplitActionButton.defaults,
             splitButtonsOnHover: Bool = false,
             splitButtonBackdropStyle: SplitButtonBackdropStyle? = nil,
+            splitButtonBackdropEffect: SplitButtonBackdropEffect? = nil,
             tabBarLeadingInset: CGFloat = 0,
             splitButtonTooltips: SplitButtonTooltips = .default,
             animationDuration: Double = 0.15,
@@ -484,6 +517,7 @@ extension BonsplitConfiguration {
             self.splitButtons = Self.uniqueSplitButtons(splitButtons)
             self.splitButtonsOnHover = splitButtonsOnHover
             self.splitButtonBackdropStyle = splitButtonBackdropStyle
+            self.splitButtonBackdropEffect = splitButtonBackdropEffect
             self.tabBarLeadingInset = tabBarLeadingInset
             self.splitButtonTooltips = splitButtonTooltips
             self.animationDuration = animationDuration

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -350,14 +350,18 @@ extension BonsplitConfiguration {
             public var style: SplitButtonBackdropStyle
             public var fadeWidth: CGFloat
             public var contentFadeWidth: CGFloat
+            public var solidWidth: CGFloat
+            public var fadeRampStartFraction: CGFloat
             public var leadingOpacity: CGFloat
             public var trailingOpacity: CGFloat
             public var masksTabContent: Bool
 
             public init(
                 style: SplitButtonBackdropStyle = .translucentChrome,
-                fadeWidth: CGFloat = 24,
-                contentFadeWidth: CGFloat = 24,
+                fadeWidth: CGFloat = 96,
+                contentFadeWidth: CGFloat = 42,
+                solidWidth: CGFloat = 18,
+                fadeRampStartFraction: CGFloat = 0.82,
                 leadingOpacity: CGFloat = 0,
                 trailingOpacity: CGFloat = 1.0,
                 masksTabContent: Bool = true
@@ -365,6 +369,8 @@ extension BonsplitConfiguration {
                 self.style = style
                 self.fadeWidth = max(0, fadeWidth)
                 self.contentFadeWidth = max(0, contentFadeWidth)
+                self.solidWidth = max(0, solidWidth)
+                self.fadeRampStartFraction = min(max(0, fadeRampStartFraction), 0.95)
                 self.leadingOpacity = min(max(0, leadingOpacity), 1)
                 self.trailingOpacity = min(max(0, trailingOpacity), 1)
                 self.masksTabContent = masksTabContent
@@ -374,9 +380,17 @@ extension BonsplitConfiguration {
         }
 
         public struct ChromeColors: Sendable {
-            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for tab chrome backgrounds.
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for general chrome backgrounds.
             /// When unset, Bonsplit uses native system colors.
             public var backgroundHex: String?
+
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for the tab bar's resolved surface.
+            /// When unset, Bonsplit falls back to `backgroundHex`.
+            public var tabBarBackgroundHex: String?
+
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for the split action button backdrop.
+            /// When unset, Bonsplit falls back to `tabBarBackgroundHex`, then `backgroundHex`.
+            public var splitButtonBackdropHex: String?
 
             /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for the split pane background.
             /// When unset, Bonsplit falls back to `backgroundHex`.
@@ -388,10 +402,14 @@ extension BonsplitConfiguration {
 
             public init(
                 backgroundHex: String? = nil,
+                tabBarBackgroundHex: String? = nil,
+                splitButtonBackdropHex: String? = nil,
                 paneBackgroundHex: String? = nil,
                 borderHex: String? = nil
             ) {
                 self.backgroundHex = backgroundHex
+                self.tabBarBackgroundHex = tabBarBackgroundHex
+                self.splitButtonBackdropHex = splitButtonBackdropHex
                 self.paneBackgroundHex = paneBackgroundHex
                 self.borderHex = borderHex
             }

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -335,6 +335,17 @@ extension BonsplitConfiguration {
     }
 
     public struct Appearance: Sendable {
+        public enum SplitButtonBackdropStyle: Int, CaseIterable, Sendable {
+            case precompositedPaneBackground = 0
+            case opaquePaneBackground = 1
+            case opaqueBarBackground = 2
+            case windowBackground = 3
+            case controlBackground = 4
+            case precompositedBarBackground = 5
+            case translucentChrome = 6
+            case hidden = 7
+        }
+
         public struct ChromeColors: Sendable {
             /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for tab chrome backgrounds.
             /// When unset, Bonsplit uses native system colors.
@@ -400,6 +411,10 @@ extension BonsplitConfiguration {
         /// When true, split buttons are only visible on hover
         public var splitButtonsOnHover: Bool
 
+        /// Optional explicit backdrop style for the tab bar's right-side action buttons.
+        /// When unset, Bonsplit uses the host app's debug override if one is configured.
+        public var splitButtonBackdropStyle: SplitButtonBackdropStyle?
+
         /// Extra leading inset for the tab bar (e.g. for traffic light buttons when sidebar is collapsed)
         public var tabBarLeadingInset: CGFloat
 
@@ -451,6 +466,7 @@ extension BonsplitConfiguration {
             showSplitButtons: Bool = true,
             splitButtons: [SplitActionButton] = SplitActionButton.defaults,
             splitButtonsOnHover: Bool = false,
+            splitButtonBackdropStyle: SplitButtonBackdropStyle? = nil,
             tabBarLeadingInset: CGFloat = 0,
             splitButtonTooltips: SplitButtonTooltips = .default,
             animationDuration: Double = 0.15,
@@ -467,6 +483,7 @@ extension BonsplitConfiguration {
             self.showSplitButtons = showSplitButtons
             self.splitButtons = Self.uniqueSplitButtons(splitButtons)
             self.splitButtonsOnHover = splitButtonsOnHover
+            self.splitButtonBackdropStyle = splitButtonBackdropStyle
             self.tabBarLeadingInset = tabBarLeadingInset
             self.splitButtonTooltips = splitButtonTooltips
             self.animationDuration = animationDuration

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -336,9 +336,13 @@ extension BonsplitConfiguration {
 
     public struct Appearance: Sendable {
         public struct ChromeColors: Sendable {
-            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for tab/pane chrome backgrounds.
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for tab chrome backgrounds.
             /// When unset, Bonsplit uses native system colors.
             public var backgroundHex: String?
+
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for the split pane background.
+            /// When unset, Bonsplit falls back to `backgroundHex`.
+            public var paneBackgroundHex: String?
 
             /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for separators/dividers.
             /// When unset, Bonsplit derives separators from the chrome background.
@@ -346,9 +350,11 @@ extension BonsplitConfiguration {
 
             public init(
                 backgroundHex: String? = nil,
+                paneBackgroundHex: String? = nil,
                 borderHex: String? = nil
             ) {
                 self.backgroundHex = backgroundHex
+                self.paneBackgroundHex = paneBackgroundHex
                 self.borderHex = borderHex
             }
         }

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -102,6 +102,171 @@ public struct BonsplitConfiguration: Sendable {
 // MARK: - Appearance Configuration
 
 extension BonsplitConfiguration {
+    public struct SplitActionButton: Sendable, Codable, Hashable, Identifiable {
+        public enum Icon: Sendable, Codable, Hashable {
+            case systemImage(String)
+            case emoji(String)
+            case imageData(Data)
+
+            private enum CodingKeys: String, CodingKey {
+                case type
+                case name
+                case value
+                case data
+            }
+
+            public init(from decoder: Decoder) throws {
+                if let value = try? decoder.singleValueContainer().decode(String.self) {
+                    self = .systemImage(value)
+                    return
+                }
+
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let type = try container.decode(String.self, forKey: .type)
+                switch type {
+                case "systemImage", "symbol", "sfSymbol":
+                    self = .systemImage(try container.decode(String.self, forKey: .name))
+                case "emoji":
+                    self = .emoji(try container.decode(String.self, forKey: .value))
+                case "imageData":
+                    self = .imageData(try container.decode(Data.self, forKey: .data))
+                default:
+                    throw DecodingError.dataCorruptedError(
+                        forKey: .type,
+                        in: container,
+                        debugDescription: "Unknown split action button icon type '\(type)'"
+                    )
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                switch self {
+                case .systemImage(let name):
+                    try container.encode("systemImage", forKey: .type)
+                    try container.encode(name, forKey: .name)
+                case .emoji(let value):
+                    try container.encode("emoji", forKey: .type)
+                    try container.encode(value, forKey: .value)
+                case .imageData(let data):
+                    try container.encode("imageData", forKey: .type)
+                    try container.encode(data, forKey: .data)
+                }
+            }
+        }
+
+        public enum Action: Sendable, Codable, Hashable {
+            case newTerminal
+            case newBrowser
+            case splitRight
+            case splitDown
+            case custom(String)
+
+            public var rawValue: String {
+                switch self {
+                case .newTerminal:
+                    return "newTerminal"
+                case .newBrowser:
+                    return "newBrowser"
+                case .splitRight:
+                    return "splitRight"
+                case .splitDown:
+                    return "splitDown"
+                case .custom(let identifier):
+                    return identifier
+                }
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let value = try container.decode(String.self)
+                switch value {
+                case "newTerminal":
+                    self = .newTerminal
+                case "newBrowser":
+                    self = .newBrowser
+                case "splitRight":
+                    self = .splitRight
+                case "splitDown":
+                    self = .splitDown
+                default:
+                    self = .custom(value)
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(rawValue)
+            }
+        }
+
+        public var id: String
+        public var icon: Icon
+        public var tooltip: String?
+        public var action: Action
+
+        public var systemImage: String {
+            if case .systemImage(let name) = icon {
+                return name
+            }
+            return "questionmark.circle"
+        }
+
+        public init(
+            id: String,
+            systemImage: String,
+            tooltip: String? = nil,
+            action: Action
+        ) {
+            self.init(
+                id: id,
+                icon: .systemImage(systemImage),
+                tooltip: tooltip,
+                action: action
+            )
+        }
+
+        public init(
+            id: String,
+            icon: Icon,
+            tooltip: String? = nil,
+            action: Action
+        ) {
+            self.id = id
+            self.icon = icon
+            self.tooltip = tooltip
+            self.action = action
+        }
+
+        public static let newTerminal = SplitActionButton(
+            id: "newTerminal",
+            systemImage: "terminal",
+            action: .newTerminal
+        )
+        public static let newBrowser = SplitActionButton(
+            id: "newBrowser",
+            systemImage: "globe",
+            action: .newBrowser
+        )
+        public static let splitRight = SplitActionButton(
+            id: "splitRight",
+            systemImage: "square.split.2x1",
+            action: .splitRight
+        )
+        public static let splitDown = SplitActionButton(
+            id: "splitDown",
+            systemImage: "square.split.1x2",
+            action: .splitDown
+        )
+
+        public static let defaults: [SplitActionButton] = [
+            .newTerminal,
+            .newBrowser,
+            .splitRight,
+            .splitDown
+        ]
+    }
+
     public struct SplitButtonTooltips: Sendable, Equatable {
         public var newTerminal: String
         public var newBrowser: String
@@ -172,6 +337,9 @@ extension BonsplitConfiguration {
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
 
+        /// Ordered action buttons shown in the tab bar when split buttons are enabled
+        public var splitButtons: [SplitActionButton]
+
         /// When true, split buttons are only visible on hover
         public var splitButtonsOnHover: Bool
 
@@ -224,6 +392,7 @@ extension BonsplitConfiguration {
             minimumPaneWidth: CGFloat = 100,
             minimumPaneHeight: CGFloat = 100,
             showSplitButtons: Bool = true,
+            splitButtons: [SplitActionButton] = SplitActionButton.defaults,
             splitButtonsOnHover: Bool = false,
             tabBarLeadingInset: CGFloat = 0,
             splitButtonTooltips: SplitButtonTooltips = .default,
@@ -239,6 +408,7 @@ extension BonsplitConfiguration {
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.showSplitButtons = showSplitButtons
+            self.splitButtons = splitButtons
             self.splitButtonsOnHover = splitButtonsOnHover
             self.tabBarLeadingInset = tabBarLeadingInset
             self.splitButtonTooltips = splitButtonTooltips

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -159,6 +159,11 @@ public final class BonsplitController {
         delegate?.splitTabBar(self, didRequestNewTab: kind, inPane: pane)
     }
 
+    /// Request the delegate to handle a host-defined tab bar action.
+    public func requestCustomAction(_ identifier: String, inPane pane: PaneID) {
+        delegate?.splitTabBar(self, didRequestCustomAction: identifier, inPane: pane)
+    }
+
     /// Request the delegate to handle a tab context-menu action.
     public func requestTabContextAction(_ action: TabContextAction, for tabId: TabID, inPane pane: PaneID) {
         guard let tab = tab(tabId) else { return }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -40,6 +40,15 @@ public final class BonsplitController {
         didSet { internalController.isInteractive = isInteractive }
     }
 
+    /// Whether pane tab shortcut hints are currently actionable.
+    ///
+    /// Pane focus is internal to Bonsplit, but host apps can move keyboard focus
+    /// to external controls while keeping the focused pane selected. Set this
+    /// to false when pane-number shortcuts should not currently be advertised.
+    public var tabShortcutHintsEnabled: Bool = true {
+        didSet { internalController.tabShortcutHintsEnabled = tabShortcutHintsEnabled }
+    }
+
     /// Handler for file/URL drops from external apps (e.g., Finder).
     /// Called when files are dropped onto a pane's content area.
     /// Return `true` if the drop was handled.

--- a/Sources/Bonsplit/Public/BonsplitDelegate.swift
+++ b/Sources/Bonsplit/Public/BonsplitDelegate.swift
@@ -55,6 +55,9 @@ public protocol BonsplitDelegate: AnyObject {
     /// The `kind` string identifies the type of tab (e.g. "terminal", "browser").
     func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID)
 
+    /// Called when the user clicks a host-defined action in the tab bar.
+    func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID)
+
     /// Called when the user triggers an action from a tab's context menu.
     func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID)
 
@@ -82,6 +85,7 @@ public extension BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, didClosePane paneId: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didFocusPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID) {}
+    func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {}
     func splitTabBar(_ controller: BonsplitController, shouldNotifyDuringDrag: Bool) -> Bool { false }

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum TabContextAction: String, CaseIterable, Sendable {
     case rename
     case clearName
+    case copyIdentifiers
     case closeToLeft
     case closeToRight
     case closeOthers

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -1,2 +1,3 @@
+"command.copyWorkspaceAndSurfaceIDs.title" = "Copy Workspace and Surface IDs";
 "command.moveTabToLeftPane.title" = "Move to Left Pane";
 "command.moveTabToRightPane.title" = "Move to Right Pane";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -1,2 +1,3 @@
+"command.copyWorkspaceAndSurfaceIDs.title" = "ワークスペースIDとサーフェスIDをコピー";
 "command.moveTabToLeftPane.title" = "左のペインへ移動";
 "command.moveTabToRightPane.title" = "右のペインへ移動";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -616,7 +616,7 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(barAlpha * 255)), 255)
     }
 
-    func testSplitButtonBackdropPreservesTranslucentChromeBackground() {
+    func testSplitButtonBackdropPrecomposesTranslucentPaneBackground() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(
                 backgroundHex: "#11223380",
@@ -624,6 +624,7 @@ final class BonsplitTests: XCTestCase {
             )
         )
         let color = TabBarColors.nsColorSplitButtonBackdrop(for: appearance).usingColorSpace(.sRGB)!
+        let expected = NSColor.windowBackgroundColor.usingColorSpace(.sRGB)!
 
         var red: CGFloat = 0
         var green: CGFloat = 0
@@ -631,10 +632,16 @@ final class BonsplitTests: XCTestCase {
         var alpha: CGFloat = 0
         color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
-        XCTAssertEqual(Int(round(red * 255)), 17)
-        XCTAssertEqual(Int(round(green * 255)), 34)
-        XCTAssertEqual(Int(round(blue * 255)), 51)
-        XCTAssertEqual(Int(round(alpha * 255)), 128)
+        var expectedRed: CGFloat = 0
+        var expectedGreen: CGFloat = 0
+        var expectedBlue: CGFloat = 0
+        var expectedAlpha: CGFloat = 0
+        expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha)
+
+        XCTAssertEqual(Int(round(red * 255)), Int(round(expectedRed * 255)))
+        XCTAssertEqual(Int(round(green * 255)), Int(round(expectedGreen * 255)))
+        XCTAssertEqual(Int(round(blue * 255)), Int(round(expectedBlue * 255)))
+        XCTAssertEqual(Int(round(alpha * 255)), 255)
         XCTAssertTrue(TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance))
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1159,6 +1159,19 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    @MainActor
+    func testControllerMirrorsTabShortcutHintEligibilityToInternalController() {
+        let controller = BonsplitController()
+
+        XCTAssertTrue(controller.tabShortcutHintsEnabled)
+        XCTAssertTrue(controller.internalController.tabShortcutHintsEnabled)
+
+        controller.tabShortcutHintsEnabled = false
+
+        XCTAssertFalse(controller.tabShortcutHintsEnabled)
+        XCTAssertFalse(controller.internalController.tabShortcutHintsEnabled)
+    }
+
     func testSelectedTabNeverShowsHoverBackground() {
         XCTAssertFalse(
             TabItemStyling.shouldShowHoverBackground(isHovered: true, isSelected: true)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -529,6 +529,30 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(controller.configuration.appearance.splitButtons, buttons)
     }
 
+    func testAppearanceKeepsFirstSplitActionButtonForDuplicateIds() {
+        let firstRunTests = BonsplitConfiguration.SplitActionButton(
+            id: "run-tests",
+            systemImage: "checkmark.circle",
+            tooltip: "Run tests",
+            action: .custom("run-tests")
+        )
+        let duplicateRunTests = BonsplitConfiguration.SplitActionButton(
+            id: "run-tests",
+            systemImage: "xmark.circle",
+            tooltip: "Duplicate",
+            action: .custom("duplicate")
+        )
+        var appearance = BonsplitConfiguration.Appearance(
+            splitButtons: [.newTerminal, .newTerminal, firstRunTests, duplicateRunTests]
+        )
+
+        XCTAssertEqual(appearance.splitButtons, [.newTerminal, firstRunTests])
+
+        appearance.splitButtons = [duplicateRunTests, firstRunTests, .splitRight]
+
+        XCTAssertEqual(appearance.splitButtons, [duplicateRunTests, .splitRight])
+    }
+
     @MainActor
     func testControllerRequestsCustomAction() {
         let controller = BonsplitController()

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -315,6 +315,19 @@ final class BonsplitTests: XCTestCase {
         XCTAssertFalse(TabBarStyling.imageDataShouldRenderAsTemplate(colorSVG))
     }
 
+    func testCurrentColorSVGImageDataRendersAsTemplateWithInvalidUTF8Suffix() throws {
+        var svg = Data(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path fill="currentColor" d="M4 4h16v16H4z"/>
+            </svg>
+            """.utf8
+        )
+        svg.append(0xE2)
+
+        XCTAssertTrue(TabBarStyling.imageDataShouldRenderAsTemplate(svg))
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -266,6 +266,26 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(decoded, button)
     }
 
+    func testCurrentColorSVGImageDataRendersAsTemplate() throws {
+        let templateSVG = Data(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path fill="currentColor" d="M4 4h16v16H4z"/>
+            </svg>
+            """.utf8
+        )
+        let colorSVG = Data(
+            """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path fill="#D97757" d="M4 4h16v16H4z"/>
+            </svg>
+            """.utf8
+        )
+
+        XCTAssertTrue(TabBarStyling.imageDataShouldRenderAsTemplate(templateSVG))
+        XCTAssertFalse(TabBarStyling.imageDataShouldRenderAsTemplate(colorSVG))
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -269,7 +269,7 @@ final class BonsplitTests: XCTestCase {
     func testCustomSplitActionButtonSupportsEmojiIcon() throws {
         let button = BonsplitConfiguration.SplitActionButton(
             id: "agent",
-            icon: .emoji("🤖"),
+            icon: .emoji("🤖", scale: 0.85),
             tooltip: "Start agent",
             action: .custom("agent")
         )

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -696,18 +696,22 @@ final class BonsplitTests: XCTestCase {
             fadeWidth: 80,
             contentFadeWidth: 42,
             solidWidth: 32,
-            fadeRampStartFraction: 0.58
+            fadeRampStartFraction: 0.58,
+            contentOcclusionFraction: 0.25
         )
 
         XCTAssertEqual(effect.fadeWidth, 80)
         XCTAssertEqual(effect.contentFadeWidth, 42)
         XCTAssertEqual(effect.solidWidth, 32)
         XCTAssertEqual(effect.fadeRampStartFraction, 0.58)
+        XCTAssertEqual(effect.contentOcclusionFraction, 0.25)
 
         let clamped = BonsplitConfiguration.Appearance.SplitButtonBackdropEffect(
-            fadeRampStartFraction: 1.4
+            fadeRampStartFraction: 1.4,
+            contentOcclusionFraction: 2.2
         )
         XCTAssertEqual(clamped.fadeRampStartFraction, 0.95)
+        XCTAssertEqual(clamped.contentOcclusionFraction, 1.0)
     }
 
     func testChromeBorderHexOverrideParsesForSeparatorColor() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -98,6 +98,16 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    private final class CustomActionDelegateSpy: BonsplitDelegate {
+        var requestedIdentifier: String?
+        var requestedPaneId: PaneID?
+
+        func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID) {
+            requestedIdentifier = identifier
+            requestedPaneId = pane
+        }
+    }
+
     @MainActor
     func testControllerCreation() {
         let controller = BonsplitController()
@@ -206,6 +216,56 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(defaults.splitDown, "Split Down")
     }
 
+    func testDefaultSplitActionButtons() {
+        XCTAssertEqual(
+            BonsplitConfiguration.SplitActionButton.defaults,
+            [.newTerminal, .newBrowser, .splitRight, .splitDown]
+        )
+    }
+
+    func testCustomSplitActionButtonRoundTrips() throws {
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "run-tests",
+            systemImage: "checkmark.circle",
+            tooltip: "Run tests",
+            action: .custom("run-tests")
+        )
+
+        let data = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded, button)
+    }
+
+    func testCustomSplitActionButtonSupportsEmojiIcon() throws {
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "agent",
+            icon: .emoji("🤖"),
+            tooltip: "Start agent",
+            action: .custom("agent")
+        )
+
+        let data = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded, button)
+    }
+
+    func testCustomSplitActionButtonSupportsImageDataIcon() throws {
+        let data = Data([0x89, 0x50, 0x4E, 0x47])
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "image-agent",
+            icon: .imageData(data),
+            tooltip: "Start image agent",
+            action: .custom("image-agent")
+        )
+
+        let encoded = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: encoded)
+
+        XCTAssertEqual(decoded, button)
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),
@@ -214,8 +274,18 @@ final class BonsplitTests: XCTestCase {
         )
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: false),
-            TabBarStyling.splitButtonsBackdropWidth,
+            TabBarStyling.splitButtonsBackdropWidth(buttonCount: 4),
             "Standard mode should keep reserving space for the always-visible split buttons"
+        )
+        XCTAssertEqual(
+            TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: false, buttonCount: 2),
+            TabBarStyling.splitButtonsBackdropWidth(buttonCount: 2),
+            "Standard mode should reserve space for the configured split buttons only"
+        )
+        XCTAssertEqual(
+            TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: false, buttonCount: 0),
+            0,
+            "No strip should be reserved when the configured split button list is empty"
         )
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: false, isMinimalMode: false),
@@ -365,6 +435,40 @@ final class BonsplitTests: XCTestCase {
         let controller = BonsplitController(configuration: config)
 
         XCTAssertEqual(controller.configuration.appearance.splitButtonTooltips, customTooltips)
+    }
+
+    @MainActor
+    func testConfigurationAcceptsCustomSplitActionButtons() {
+        let buttons: [BonsplitConfiguration.SplitActionButton] = [
+            .newTerminal,
+            .init(
+                id: "run-tests",
+                systemImage: "checkmark.circle",
+                tooltip: "Run tests",
+                action: .custom("run-tests")
+            ),
+        ]
+        let config = BonsplitConfiguration(
+            appearance: .init(
+                splitButtons: buttons
+            )
+        )
+        let controller = BonsplitController(configuration: config)
+
+        XCTAssertEqual(controller.configuration.appearance.splitButtons, buttons)
+    }
+
+    @MainActor
+    func testControllerRequestsCustomAction() {
+        let controller = BonsplitController()
+        let delegate = CustomActionDelegateSpy()
+        controller.delegate = delegate
+        let paneId = controller.focusedPaneId!
+
+        controller.requestCustomAction("run-tests", inPane: paneId)
+
+        XCTAssertEqual(delegate.requestedIdentifier, "run-tests")
+        XCTAssertEqual(delegate.requestedPaneId, paneId)
     }
 
     func testChromeBackgroundHexOverrideParsesForPaneBackground() {
@@ -708,11 +812,17 @@ final class BonsplitTests: XCTestCase {
         contentView.layoutSubtreeIfNeeded()
 
         let clickPoint = NSPoint(x: hostingView.bounds.maxX - 12, y: hostingView.bounds.midY)
-        guard let event = try? makeLeftMouseDownEvent(in: hostingView, at: clickPoint, clickCount: 2) else {
-            XCTFail("Expected mouse event")
+        let pointInWindow = hostingView.convert(clickPoint, to: nil)
+        guard let hitView = waitForDescendant(
+            ofType: TabBarDragZoneView.DragNSView.self,
+            in: contentView,
+            containingWindowPoint: pointInWindow,
+            where: { $0.onDoubleClick != nil }
+        ) else {
+            XCTFail("Expected trailing tab bar drag zone")
             return
         }
-        NSApp.sendEvent(event)
+        XCTAssertEqual(hitView.onDoubleClick?(), true)
 
         XCTAssertEqual(spy.requestedKind, "terminal")
         XCTAssertEqual(spy.requestedPaneId, pane.id)
@@ -1239,6 +1349,61 @@ final class BonsplitTests: XCTestCase {
         }
         for subview in root.subviews {
             if let match = firstDescendant(ofType: type, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private func waitForDescendant<T: NSView>(
+        ofType type: T.Type,
+        in root: NSView,
+        containingWindowPoint point: NSPoint,
+        timeout: TimeInterval = 1.0,
+        where predicate: (T) -> Bool = { _ in true }
+    ) -> T? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            root.layoutSubtreeIfNeeded()
+            if let match = firstDescendant(
+                ofType: type,
+                in: root,
+                containingWindowPoint: point,
+                where: predicate
+            ) {
+                return match
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        } while Date() < deadline
+        return firstDescendant(
+            ofType: type,
+            in: root,
+            containingWindowPoint: point,
+            where: predicate
+        )
+    }
+
+    @MainActor
+    private func firstDescendant<T: NSView>(
+        ofType type: T.Type,
+        in root: NSView,
+        containingWindowPoint point: NSPoint,
+        where predicate: (T) -> Bool = { _ in true }
+    ) -> T? {
+        if let match = root as? T {
+            let frameInWindow = root.convert(root.bounds, to: nil)
+            if frameInWindow.contains(point), predicate(match) {
+                return match
+            }
+        }
+        for subview in root.subviews {
+            if let match = firstDescendant(
+                ofType: type,
+                in: subview,
+                containingWindowPoint: point,
+                where: predicate
+            ) {
                 return match
             }
         }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -849,7 +849,7 @@ final class BonsplitTests: XCTestCase {
 
     @MainActor
     func testDoubleClickingEmptyTrailingTabBarSpaceRequestsNewTerminalTab() {
-        let appearance = BonsplitConfiguration.Appearance(showSplitButtons: false)
+        let appearance = BonsplitConfiguration.Appearance()
         let configuration = BonsplitConfiguration(appearance: appearance)
         let controller = BonsplitController(configuration: configuration)
         let pane = controller.internalController.rootNode.allPanes.first!
@@ -857,7 +857,7 @@ final class BonsplitTests: XCTestCase {
         controller.delegate = spy
 
         let hostingView = NSHostingView(
-            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: false)
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: true)
                 .environment(controller)
                 .environment(controller.internalController)
         )
@@ -897,6 +897,58 @@ final class BonsplitTests: XCTestCase {
 
         XCTAssertEqual(spy.requestedKind, "terminal")
         XCTAssertEqual(spy.requestedPaneId, pane.id)
+    }
+
+    @MainActor
+    func testEmptyTrailingTabBarSpaceDoesNotRequestNewTerminalWhenButtonHidden() {
+        let appearance = BonsplitConfiguration.Appearance(splitButtons: [])
+        let configuration = BonsplitConfiguration(appearance: appearance)
+        let controller = BonsplitController(configuration: configuration)
+        let pane = controller.internalController.rootNode.allPanes.first!
+        let spy = NewTabRequestDelegateSpy()
+        controller.delegate = spy
+
+        let hostingView = NSHostingView(
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: true)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 60),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        let clickPoint = NSPoint(x: hostingView.bounds.maxX - 12, y: hostingView.bounds.midY)
+        let pointInWindow = hostingView.convert(clickPoint, to: nil)
+        guard let hitView = waitForDescendant(
+            ofType: TabBarDragZoneView.DragNSView.self,
+            in: contentView,
+            containingWindowPoint: pointInWindow,
+            where: { $0.onDoubleClick != nil }
+        ) else {
+            XCTFail("Expected trailing tab bar drag zone")
+            return
+        }
+        XCTAssertEqual(hitView.onDoubleClick?(), false)
+
+        XCTAssertNil(spy.requestedKind)
+        XCTAssertNil(spy.requestedPaneId)
     }
 
     func testIconSaturationKeepsRasterFaviconInColorWhenInactive() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -328,6 +328,15 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(TabBarStyling.imageDataShouldRenderAsTemplate(svg))
     }
 
+    @MainActor
+    func testSplitActionButtonImageDataIsCached() throws {
+        let png = try XCTUnwrap(Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="))
+        let first = try XCTUnwrap(TabBarStyling.splitActionButtonImage(from: png))
+        let second = try XCTUnwrap(TabBarStyling.splitActionButtonImage(from: png))
+
+        XCTAssertTrue(first === second)
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -616,6 +616,44 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(barAlpha * 255)), 255)
     }
 
+    func testTabBarAndSplitButtonBackdropSurfacesCanBeExplicit() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(
+                backgroundHex: "#010203",
+                tabBarBackgroundHex: "#11223380",
+                splitButtonBackdropHex: "#44556699"
+            )
+        )
+        let barColor = TabBarColors.nsColorBarBackground(for: appearance).usingColorSpace(.sRGB)!
+        let backdropColor = TabBarColors.nsColorSplitButtonBackdropSurface(for: appearance).usingColorSpace(.sRGB)!
+
+        var barRed: CGFloat = 0
+        var barGreen: CGFloat = 0
+        var barBlue: CGFloat = 0
+        var barAlpha: CGFloat = 0
+        barColor.getRed(&barRed, green: &barGreen, blue: &barBlue, alpha: &barAlpha)
+
+        var backdropRed: CGFloat = 0
+        var backdropGreen: CGFloat = 0
+        var backdropBlue: CGFloat = 0
+        var backdropAlpha: CGFloat = 0
+        backdropColor.getRed(
+            &backdropRed,
+            green: &backdropGreen,
+            blue: &backdropBlue,
+            alpha: &backdropAlpha
+        )
+
+        XCTAssertEqual(Int(round(barRed * 255)), 17)
+        XCTAssertEqual(Int(round(barGreen * 255)), 34)
+        XCTAssertEqual(Int(round(barBlue * 255)), 51)
+        XCTAssertEqual(Int(round(barAlpha * 255)), 128)
+        XCTAssertEqual(Int(round(backdropRed * 255)), 68)
+        XCTAssertEqual(Int(round(backdropGreen * 255)), 85)
+        XCTAssertEqual(Int(round(backdropBlue * 255)), 102)
+        XCTAssertEqual(Int(round(backdropAlpha * 255)), 153)
+    }
+
     func testSplitButtonBackdropPrecomposesTranslucentPaneBackground() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(
@@ -651,6 +689,25 @@ final class BonsplitTests: XCTestCase {
         )
 
         XCTAssertTrue(TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance))
+    }
+
+    func testSplitButtonBackdropEffectTracksSolidWidthSeparately() {
+        let effect = BonsplitConfiguration.Appearance.SplitButtonBackdropEffect(
+            fadeWidth: 80,
+            contentFadeWidth: 42,
+            solidWidth: 32,
+            fadeRampStartFraction: 0.58
+        )
+
+        XCTAssertEqual(effect.fadeWidth, 80)
+        XCTAssertEqual(effect.contentFadeWidth, 42)
+        XCTAssertEqual(effect.solidWidth, 32)
+        XCTAssertEqual(effect.fadeRampStartFraction, 0.58)
+
+        let clamped = BonsplitConfiguration.Appearance.SplitButtonBackdropEffect(
+            fadeRampStartFraction: 1.4
+        )
+        XCTAssertEqual(clamped.fadeRampStartFraction, 0.95)
     }
 
     func testChromeBorderHexOverrideParsesForSeparatorColor() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -635,7 +635,7 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(green * 255)), 34)
         XCTAssertEqual(Int(round(blue * 255)), 51)
         XCTAssertEqual(Int(round(alpha * 255)), 128)
-        XCTAssertFalse(TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance))
+        XCTAssertTrue(TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance))
     }
 
     func testSplitButtonBackdropPaintsForOpaqueChromeBackground() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -635,6 +635,15 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(green * 255)), 34)
         XCTAssertEqual(Int(round(blue * 255)), 51)
         XCTAssertEqual(Int(round(alpha * 255)), 128)
+        XCTAssertFalse(TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance))
+    }
+
+    func testSplitButtonBackdropPaintsForOpaqueChromeBackground() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#112233")
+        )
+
+        XCTAssertTrue(TabBarColors.shouldPaintSplitButtonBackdrop(for: appearance))
     }
 
     func testChromeBorderHexOverrideParsesForSeparatorColor() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -237,6 +237,35 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(decoded, button)
     }
 
+    func testCustomSplitActionButtonPreservesReservedActionName() throws {
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "custom-terminal",
+            systemImage: "terminal",
+            tooltip: "Custom terminal action",
+            action: .custom("newTerminal")
+        )
+
+        let data = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded.action, .custom("newTerminal"))
+        XCTAssertEqual(decoded, button)
+    }
+
+    func testSplitActionButtonDecodesLegacyBuiltInActionString() throws {
+        let data = #"""
+        {
+          "id": "terminal",
+          "icon": { "type": "systemImage", "name": "terminal" },
+          "action": "newTerminal"
+        }
+        """#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded.action, .newTerminal)
+    }
+
     func testCustomSplitActionButtonSupportsEmojiIcon() throws {
         let button = BonsplitConfiguration.SplitActionButton(
             id: "agent",

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -584,6 +584,38 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(alpha * 255)), 255)
     }
 
+    func testPaneBackgroundHexOverrideCanDifferFromChromeBackground() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(
+                backgroundHex: "#FDF6E3",
+                paneBackgroundHex: "#11223380"
+            )
+        )
+        let paneColor = TabBarColors.nsColorPaneBackground(for: appearance).usingColorSpace(.sRGB)!
+        let barColor = NSColor(TabBarColors.barBackground(for: appearance)).usingColorSpace(.sRGB)!
+
+        var paneRed: CGFloat = 0
+        var paneGreen: CGFloat = 0
+        var paneBlue: CGFloat = 0
+        var paneAlpha: CGFloat = 0
+        paneColor.getRed(&paneRed, green: &paneGreen, blue: &paneBlue, alpha: &paneAlpha)
+
+        var barRed: CGFloat = 0
+        var barGreen: CGFloat = 0
+        var barBlue: CGFloat = 0
+        var barAlpha: CGFloat = 0
+        barColor.getRed(&barRed, green: &barGreen, blue: &barBlue, alpha: &barAlpha)
+
+        XCTAssertEqual(Int(round(paneRed * 255)), 17)
+        XCTAssertEqual(Int(round(paneGreen * 255)), 34)
+        XCTAssertEqual(Int(round(paneBlue * 255)), 51)
+        XCTAssertEqual(Int(round(paneAlpha * 255)), 128)
+        XCTAssertEqual(Int(round(barRed * 255)), 253)
+        XCTAssertEqual(Int(round(barGreen * 255)), 246)
+        XCTAssertEqual(Int(round(barBlue * 255)), 227)
+        XCTAssertEqual(Int(round(barAlpha * 255)), 255)
+    }
+
     func testChromeBorderHexOverrideParsesForSeparatorColor() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(backgroundHex: "#272822", borderHex: "#112233")

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -616,6 +616,27 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(barAlpha * 255)), 255)
     }
 
+    func testSplitButtonBackdropPreservesTranslucentChromeBackground() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(
+                backgroundHex: "#11223380",
+                paneBackgroundHex: "#00000000"
+            )
+        )
+        let color = TabBarColors.nsColorSplitButtonBackdrop(for: appearance).usingColorSpace(.sRGB)!
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(Int(round(red * 255)), 17)
+        XCTAssertEqual(Int(round(green * 255)), 34)
+        XCTAssertEqual(Int(round(blue * 255)), 51)
+        XCTAssertEqual(Int(round(alpha * 255)), 128)
+    }
+
     func testChromeBorderHexOverrideParsesForSeparatorColor() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(backgroundHex: "#272822", borderHex: "#112233")


### PR DESCRIPTION
## Summary
- Add a tab context-menu action for copying host-provided identifiers.
- Add localized menu text for English and Japanese.

## Testing
- `plutil -lint Sources/Bonsplit/Resources/en.lproj/Localizable.strings Sources/Bonsplit/Resources/ja.lproj/Localizable.strings`
- Covered by cmux tagged build: `./scripts/reload.sh --tag surfid`

## Issues
- Related task: right-click a cmux surface tab and copy workspace/surface IDs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tab context‑menu action to copy host identifiers (workspace and surface IDs), positioned at the bottom of the menu. Also adds configurable split action buttons with customizable icons and backdrop effects, plus an API to control when tab shortcut hints are shown.

- New Features
  - Tab context menu: “Copy Workspace and Surface IDs” (en/ja); exposed as `TabContextAction.copyIdentifiers` and placed at the menu bottom.
  - Configurable split action buttons in the tab bar (`Appearance.splitButtons`), with defaults for terminal/browser/split actions and support for system icons, emoji (scalable), or image data (cached; template SVG supported).
  - Custom actions routed to hosts via `splitTabBar(_:didRequestCustomAction:inPane:)`.
  - Split‑button backdrop styling and effects (`splitButtonBackdropStyle`/`splitButtonBackdropEffect`) for fade/opacity and content masking.
  - Separate pane vs. tab‑bar background colors (`ChromeColors.paneBackgroundHex`, `tabBarBackgroundHex`, `splitButtonBackdropHex`).
  - Gate tab shortcut hints with `BonsplitController.tabShortcutHintsEnabled`.
  - Double‑click on trailing tab bar space triggers the first `.newTerminal` split button if present (no action if not).

- Migration
  - If you switch exhaustively on `TabContextAction`, add a case for `.copyIdentifiers`.
  - If you define custom split buttons with `.custom(...)`, implement `splitTabBar(_:didRequestCustomAction:inPane:)`.
  - Optionally set `BonsplitController.tabShortcutHintsEnabled = false` when keyboard focus leaves Bonsplit to suppress shortcut hints.

<sup>Written for commit cd1eed7770f81b7f55b4a1d201f3dcc89082ff4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Customizable split action buttons with configurable icons, tooltips, and actions
  * Control over keyboard shortcut hint visibility for tabs
  * Copy workspace and surface IDs directly from tab context menu
  * Support for custom tab bar actions via delegate callbacks
  * Enhanced tab bar appearance configuration with improved color control and styling options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->