### PR TITLE
Shorten copy identifiers menu title

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -418,7 +418,7 @@ struct TabItemView: View {
 
         localizedContextButton(
             "command.copyWorkspaceAndSurfaceIDs.title",
-            defaultValue: "Copy Workspace and Surface IDs",
+            defaultValue: "Copy IDs",
             action: .copyIdentifiers
         )
     }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -417,7 +417,7 @@ struct TabItemView: View {
         Divider()
 
         localizedContextButton(
-            "command.copyWorkspaceAndSurfaceIDs.title",
+            "command.copyIdentifiers.title",
             defaultValue: "Copy IDs",
             action: .copyIdentifiers
         )

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"command.copyWorkspaceAndSurfaceIDs.title" = "Copy IDs";
+"command.copyIdentifiers.title" = "Copy IDs";
 "command.moveTabToLeftPane.title" = "Move to Left Pane";
 "command.moveTabToRightPane.title" = "Move to Right Pane";

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"command.copyWorkspaceAndSurfaceIDs.title" = "Copy Workspace and Surface IDs";
+"command.copyWorkspaceAndSurfaceIDs.title" = "Copy IDs";
 "command.moveTabToLeftPane.title" = "Move to Left Pane";
 "command.moveTabToRightPane.title" = "Move to Right Pane";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"command.copyWorkspaceAndSurfaceIDs.title" = "IDをコピー";
+"command.copyIdentifiers.title" = "IDをコピー";
 "command.moveTabToLeftPane.title" = "左のペインへ移動";
 "command.moveTabToRightPane.title" = "右のペインへ移動";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"command.copyWorkspaceAndSurfaceIDs.title" = "ワークスペースIDとサーフェスIDをコピー";
+"command.copyWorkspaceAndSurfaceIDs.title" = "IDをコピー";
 "command.moveTabToLeftPane.title" = "左のペインへ移動";
 "command.moveTabToRightPane.title" = "右のペインへ移動";


### PR DESCRIPTION
Updates the tab context menu label from "Copy Workspace and Surface IDs" to "Copy IDs" so the title stays accurate as the copied payload includes workspace, pane, and surface identifiers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened the tab context menu label to "Copy IDs" to match the payload (workspace, pane, and surface IDs). Renamed the localization key to `command.copyIdentifiers.title` and updated English and Japanese strings.

<sup>Written for commit 5fdfc6b916422975cd4fb957fc3985f25cc95118. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/108?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Streamlined the copy identifiers menu label for a more concise interface across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->