### PR TITLE
Align pane tab indicator to top

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -273,6 +273,11 @@ enum TabBarColors {
         return dropIndicator
     }
 
+    static func activeIndicator(saturation: Double) -> Color {
+        guard saturation < 1 else { return Color.accentColor }
+        return Color(nsColor: NSColor.controlAccentColor.bonsplitSaturating(by: saturation))
+    }
+
     static var focusRing: Color {
         Color.accentColor.opacity(0.5)
     }
@@ -340,6 +345,23 @@ private extension NSColor {
         color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
         let luminance = (0.299 * red) + (0.587 * green) + (0.114 * blue)
         return luminance > 0.5
+    }
+
+    func bonsplitSaturating(by amount: Double) -> NSColor {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        let color = usingColorSpace(.sRGB) ?? self
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        let clamped = CGFloat(min(max(amount, 0), 1))
+        let luminance = (0.299 * red) + (0.587 * green) + (0.114 * blue)
+        return NSColor(
+            red: luminance + ((red - luminance) * clamped),
+            green: luminance + ((green - luminance) * clamped),
+            blue: luminance + ((blue - luminance) * clamped),
+            alpha: alpha
+        )
     }
 
     func bonsplitLighten(by amount: CGFloat) -> NSColor {

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -274,7 +274,6 @@ enum TabBarColors {
     }
 
     static func activeIndicator(saturation: Double) -> Color {
-        guard saturation < 1 else { return Color.accentColor }
         return Color(nsColor: NSColor.controlAccentColor.bonsplitSaturating(by: saturation))
     }
 

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -15,7 +15,8 @@ enum TabBarMetrics {
     static let tabCornerRadius: CGFloat = 0
     static let tabHorizontalPadding: CGFloat = 6
     static let tabSpacing: CGFloat = 0
-    static let activeIndicatorHeight: CGFloat = 1.5
+    static let activeIndicatorHeight: CGFloat = 2
+    static let activeIndicatorTrailingInset: CGFloat = 1
 
     // MARK: - Tab Content
 

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -15,7 +15,7 @@ enum TabBarMetrics {
     static let tabCornerRadius: CGFloat = 0
     static let tabHorizontalPadding: CGFloat = 6
     static let tabSpacing: CGFloat = 0
-    static let activeIndicatorHeight: CGFloat = 1
+    static let activeIndicatorHeight: CGFloat = 1.5
 
     // MARK: - Tab Content
 

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -15,7 +15,7 @@ enum TabBarMetrics {
     static let tabCornerRadius: CGFloat = 0
     static let tabHorizontalPadding: CGFloat = 6
     static let tabSpacing: CGFloat = 0
-    static let activeIndicatorHeight: CGFloat = 2
+    static let activeIndicatorHeight: CGFloat = 1.5
     static let activeIndicatorTrailingInset: CGFloat = 1
 
     // MARK: - Tab Content

--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -15,7 +15,7 @@ enum TabBarMetrics {
     static let tabCornerRadius: CGFloat = 0
     static let tabHorizontalPadding: CGFloat = 6
     static let tabSpacing: CGFloat = 0
-    static let activeIndicatorHeight: CGFloat = 2
+    static let activeIndicatorHeight: CGFloat = 1
 
     // MARK: - Tab Content
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -511,6 +511,7 @@ struct TabBarView: View {
                         }
                         .padding(.horizontal, TabBarMetrics.barPadding)
                         .padding(.trailing, trailingTabContentInset)
+                        .frame(height: tabBarHeight, alignment: .top)
                         .animation(nil, value: pane.tabs.map(\.id))
                         .background(
                             GeometryReader { contentGeo in

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1263,7 +1263,7 @@ struct TabBarView: View {
         guard let selectedTabFrameInBar, totalWidth > 0 else { return nil }
         let minX = min(max(selectedTabFrameInBar.minX, 0), totalWidth)
         let maxX = min(max(selectedTabFrameInBar.maxX, 0), totalWidth)
-        let width = max(0, maxX - minX)
+        let width = max(0, maxX - minX - TabBarMetrics.activeIndicatorTrailingInset)
         guard width > 0 else { return nil }
         return CGRect(
             x: minX,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1229,7 +1229,7 @@ struct TabBarView: View {
     private func selectedTabIndicator(totalWidth: CGFloat) -> some View {
         if let frame = selectedIndicatorFrame(totalWidth: totalWidth) {
             Rectangle()
-                .fill(Color.accentColor)
+                .fill(TabBarColors.activeIndicator(saturation: tabBarSaturation))
                 .frame(width: frame.width, height: TabBarMetrics.activeIndicatorHeight)
                 .offset(x: frame.minX)
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1212,29 +1212,65 @@ struct TabBarView: View {
                     .frame(width: splitButtonBackdropSolidWidth)
             }
         }
-            .overlay(alignment: .bottom) {
-                GeometryReader { geometry in
-                    let separator = TabBarColors.separator(for: appearance)
-                    let gapRange: ClosedRange<CGFloat>? = selectedTabFrameInBar.map { frame in
-                        frame.minX...frame.maxX
-                    }
-                    let segments = TabBarStyling.separatorSegments(
-                        totalWidth: geometry.size.width,
-                        gap: gapRange
-                    )
-
-                    HStack(spacing: 0) {
-                        Rectangle()
-                            .fill(separator)
-                            .frame(width: segments.left, height: 1)
-                        Spacer(minLength: 0)
-                        Rectangle()
-                            .fill(separator)
-                            .frame(width: segments.right, height: 1)
-                    }
+        .overlay {
+            GeometryReader { geometry in
+                // Bar-edge chrome stays in tab-bar coordinates so item content
+                // offsets and padding cannot move it.
+                ZStack(alignment: .topLeading) {
+                    selectedTabIndicator(totalWidth: geometry.size.width)
+                    tabBarBottomSeparator(totalWidth: geometry.size.width)
                 }
-                .frame(height: 1)
             }
+            .allowsHitTesting(false)
+        }
+    }
+
+    @ViewBuilder
+    private func selectedTabIndicator(totalWidth: CGFloat) -> some View {
+        if let frame = selectedIndicatorFrame(totalWidth: totalWidth) {
+            Rectangle()
+                .fill(Color.accentColor)
+                .frame(width: frame.width, height: TabBarMetrics.activeIndicatorHeight)
+                .offset(x: frame.minX)
+        }
+    }
+
+    @ViewBuilder
+    private func tabBarBottomSeparator(totalWidth: CGFloat) -> some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            HStack(spacing: 0) {
+                let separator = TabBarColors.separator(for: appearance)
+                let gapRange: ClosedRange<CGFloat>? = selectedTabFrameInBar.map { frame in
+                    frame.minX...frame.maxX
+                }
+                let segments = TabBarStyling.separatorSegments(
+                    totalWidth: totalWidth,
+                    gap: gapRange
+                )
+                Rectangle()
+                    .fill(separator)
+                    .frame(width: segments.left, height: 1)
+                Spacer(minLength: 0)
+                Rectangle()
+                    .fill(separator)
+                    .frame(width: segments.right, height: 1)
+            }
+        }
+    }
+
+    private func selectedIndicatorFrame(totalWidth: CGFloat) -> CGRect? {
+        guard let selectedTabFrameInBar, totalWidth > 0 else { return nil }
+        let minX = min(max(selectedTabFrameInBar.minX, 0), totalWidth)
+        let maxX = min(max(selectedTabFrameInBar.maxX, 0), totalWidth)
+        let width = max(0, maxX - minX)
+        guard width > 0 else { return nil }
+        return CGRect(
+            x: minX,
+            y: 0,
+            width: width,
+            height: TabBarMetrics.activeIndicatorHeight
+        )
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -182,7 +182,6 @@ struct TabItemView: View {
             minHeight: tabHeight,
             maxHeight: tabHeight
         )
-        .padding(.bottom, isSelected ? 1 : 0)
         .background(tabBackground.saturation(saturation))
         .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
         .contentShape(Rectangle())

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -175,7 +175,6 @@ struct TabItemView: View {
             trailingAccessory
         }
         .padding(.horizontal, TabBarMetrics.tabHorizontalPadding)
-        .offset(y: isSelected ? 0.5 : 0)
         .frame(
             minWidth: TabBarMetrics.tabMinWidth,
             maxWidth: TabBarMetrics.tabMaxWidth,
@@ -464,13 +463,6 @@ struct TabItemView: View {
                     .fill(TabBarColors.hoveredTabBackground(for: appearance))
             } else {
                 Color.clear
-            }
-
-            // Top accent indicator for selected tab
-            if isSelected {
-                Rectangle()
-                    .fill(Color.accentColor)
-                    .frame(height: TabBarMetrics.activeIndicatorHeight)
             }
 
             // Right border separator

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1350,8 +1350,8 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
-    func testActiveTabIndicatorHeightIsTwoPixels() {
-        XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 2)
+    func testActiveTabIndicatorHeightIsOneAndHalfPixels() {
+        XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 1.5)
     }
 
     @MainActor

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1350,8 +1350,20 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
-    func testActiveTabIndicatorHeightIsSinglePixel() {
-        XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 1)
+    func testActiveTabIndicatorHeightIsOneAndHalfPixels() {
+        XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 1.5)
+    }
+
+    @MainActor
+    func testInactiveSelectedTabIndicatorUsesDesaturatedAccent() {
+        guard let focusedSaturation = renderedTabBarIndicatorSaturation(isFocused: true),
+              let unfocusedSaturation = renderedTabBarIndicatorSaturation(isFocused: false) else {
+            XCTFail("Expected rendered tab bar colors")
+            return
+        }
+
+        XCTAssertGreaterThan(focusedSaturation, 0.4)
+        XCTAssertLessThan(unfocusedSaturation, 0.1)
     }
 
     func testTabBarSeparatorSegmentsClampGapIntoBounds() {
@@ -1949,6 +1961,80 @@ final class BonsplitTests: XCTestCase {
         contentView.layoutSubtreeIfNeeded()
 
         return renderedColor(in: hostingView, at: samplePoint)?.alphaComponent
+    }
+
+    @MainActor
+    private func renderedTabBarIndicatorSaturation(isFocused: Bool) -> CGFloat? {
+        let controller = BonsplitController()
+        guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
+        let tab = TabItem(title: "", icon: nil)
+        pane.tabs = [tab]
+        pane.selectedTabId = tab.id
+
+        let size = NSSize(width: 160, height: TabBarMetrics.barHeight)
+        let hostingView = NSHostingView(
+            rootView: TabBarView(pane: pane, isFocused: isFocused, showSplitButtons: false)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else { return nil }
+
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        let sampleRect = NSRect(x: 4, y: 0, width: 44, height: 4)
+        return maximumSaturation(in: hostingView, sampleRect: sampleRect)
+    }
+
+    @MainActor
+    private func maximumSaturation(in view: NSView, sampleRect: NSRect? = nil) -> CGFloat? {
+        let integralBounds = view.bounds.integral
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: integralBounds) else { return nil }
+        bitmap.size = integralBounds.size
+        view.cacheDisplay(in: integralBounds, to: bitmap)
+
+        let rect = sampleRect ?? integralBounds
+        let scaleX = CGFloat(bitmap.pixelsWide) / max(1, integralBounds.width)
+        let scaleY = CGFloat(bitmap.pixelsHigh) / max(1, integralBounds.height)
+        let minX = max(0, Int(floor(rect.minX * scaleX)))
+        let maxX = min(bitmap.pixelsWide, Int(ceil(rect.maxX * scaleX)))
+        let minY = max(0, Int(floor(rect.minY * scaleY)))
+        let maxY = min(bitmap.pixelsHigh, Int(ceil(rect.maxY * scaleY)))
+
+        var maximum: CGFloat = 0
+        for y in minY..<maxY {
+            for x in minX..<maxX {
+                guard let color = bitmap.colorAt(x: x, y: y),
+                      let rgb = color.usingColorSpace(.sRGB),
+                      rgb.alphaComponent > 0.05 else { continue }
+                let red = rgb.redComponent
+                let green = rgb.greenComponent
+                let blue = rgb.blueComponent
+                let high = max(red, green, blue)
+                guard high > 0.01 else { continue }
+                let low = min(red, green, blue)
+                let saturation = (high - low) / high
+                maximum = max(maximum, saturation)
+            }
+        }
+        return maximum
     }
 
     @MainActor

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1350,8 +1350,18 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
-    func testActiveTabIndicatorHeightIsOneAndHalfPixels() {
-        XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 1.5)
+    func testActiveTabIndicatorHeightIsTwoPixels() {
+        XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 2)
+    }
+
+    @MainActor
+    func testActiveTabIndicatorLeavesTrailingPixelGap() {
+        guard let width = renderedTabBarIndicatorWidth(isFocused: true) else {
+            XCTFail("Expected rendered tab bar indicator width")
+            return
+        }
+
+        XCTAssertEqual(width, TabBarMetrics.tabMinWidth - 1, accuracy: 0.5)
     }
 
     @MainActor
@@ -1965,6 +1975,22 @@ final class BonsplitTests: XCTestCase {
 
     @MainActor
     private func renderedTabBarIndicatorSaturation(isFocused: Bool) -> CGFloat? {
+        renderedTabBarValue(isFocused: isFocused) { hostingView in
+            let sampleRect = NSRect(x: 4, y: 0, width: 44, height: 4)
+            return maximumSaturation(in: hostingView, sampleRect: sampleRect)
+        }
+    }
+
+    @MainActor
+    private func renderedTabBarIndicatorWidth(isFocused: Bool) -> CGFloat? {
+        renderedTabBarValue(isFocused: isFocused) { hostingView in
+            let sampleRect = NSRect(x: 0, y: 0, width: 80, height: 4)
+            return highSaturationWidth(in: hostingView, sampleRect: sampleRect)
+        }
+    }
+
+    @MainActor
+    private func renderedTabBarValue<T>(isFocused: Bool, extract: (NSView) -> T?) -> T? {
         let controller = BonsplitController()
         guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
         let tab = TabItem(title: "", icon: nil)
@@ -1999,8 +2025,7 @@ final class BonsplitTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         contentView.layoutSubtreeIfNeeded()
 
-        let sampleRect = NSRect(x: 4, y: 0, width: 44, height: 4)
-        return maximumSaturation(in: hostingView, sampleRect: sampleRect)
+        return extract(hostingView)
     }
 
     @MainActor
@@ -2035,6 +2060,42 @@ final class BonsplitTests: XCTestCase {
             }
         }
         return maximum
+    }
+
+    @MainActor
+    private func highSaturationWidth(in view: NSView, sampleRect: NSRect) -> CGFloat? {
+        let integralBounds = view.bounds.integral
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: integralBounds) else { return nil }
+        bitmap.size = integralBounds.size
+        view.cacheDisplay(in: integralBounds, to: bitmap)
+
+        let scaleX = CGFloat(bitmap.pixelsWide) / max(1, integralBounds.width)
+        let scaleY = CGFloat(bitmap.pixelsHigh) / max(1, integralBounds.height)
+        let minX = max(0, Int(floor(sampleRect.minX * scaleX)))
+        let maxX = min(bitmap.pixelsWide, Int(ceil(sampleRect.maxX * scaleX)))
+        let minY = max(0, Int(floor(sampleRect.minY * scaleY)))
+        let maxY = min(bitmap.pixelsHigh, Int(ceil(sampleRect.maxY * scaleY)))
+
+        var activeColumnCount = 0
+        for x in minX..<maxX {
+            var hasIndicatorPixel = false
+            for y in minY..<maxY {
+                guard let color = bitmap.colorAt(x: x, y: y),
+                      let rgb = color.usingColorSpace(.sRGB),
+                      rgb.alphaComponent > 0.05 else { continue }
+                let high = max(rgb.redComponent, rgb.greenComponent, rgb.blueComponent)
+                guard high > 0.01 else { continue }
+                let low = min(rgb.redComponent, rgb.greenComponent, rgb.blueComponent)
+                if (high - low) / high > 0.4 {
+                    hasIndicatorPixel = true
+                    break
+                }
+            }
+            if hasIndicatorPixel {
+                activeColumnCount += 1
+            }
+        }
+        return CGFloat(activeColumnCount) / scaleX
     }
 
     @MainActor

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1350,6 +1350,10 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
+    func testActiveTabIndicatorHeightIsSinglePixel() {
+        XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 1)
+    }
+
     func testTabBarSeparatorSegmentsClampGapIntoBounds() {
         var segments = TabBarStyling.separatorSegments(totalWidth: 100, gap: -20...40)
         XCTAssertEqual(segments.left, 0, accuracy: 0.0001)


### PR DESCRIPTION
## Summary
- Move selected tab indicator ownership from `TabItemView` to `TabBarView`.
- Draw the indicator once in tab-bar coordinates from the selected tab frame.
- Set the active tab indicator height to 1.5pt and render it 1pt narrower than the selected tab.
- Match main's inactive-pane behavior by desaturating the selected indicator to grey when the pane is unfocused.
- Keep tab items responsible for content, hover fill, hit testing, and separators only.

## Testing
- `git diff --check`
- Red check: `swift test --filter BonsplitTests/testActiveTabIndicatorHeightIsOneAndHalfPixels` failed before the fix with 2pt vs 1.5pt.
- Green check: `swift test --filter BonsplitTests/testActiveTabIndicatorHeightIsOneAndHalfPixels`
- Green check: `swift test --filter BonsplitTests/testActiveTabIndicatorLeavesTrailingPixelGap`
- cmux parent reload: `./scripts/reload.sh --tag tab15b`

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/3331
