### PR TITLE
Trim selected tab left separator

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -17,6 +17,7 @@ enum TabBarMetrics {
     static let tabSpacing: CGFloat = 0
     static let activeIndicatorHeight: CGFloat = 1.5
     static let activeIndicatorTrailingInset: CGFloat = 1
+    static let selectedTabLeftSeparatorBottomInset: CGFloat = 1
 
     // MARK: - Tab Content
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -663,12 +663,17 @@ struct TabBarView: View {
     private func tabItem(for tab: TabItem, at index: Int) -> some View {
         let contextMenuState = contextMenuState(for: tab, at: index)
         let showsZoomIndicator = splitViewController.zoomedPaneId == pane.id && pane.selectedTabId == tab.id
+        let isImmediatelyBeforeSelected = pane.tabs.indices.contains(index + 1)
+            && pane.tabs[index + 1].id == pane.selectedTabId
         TabItemView(
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
             showsZoomIndicator: showsZoomIndicator,
             appearance: appearance,
             saturation: tabBarSaturation,
+            trailingSeparatorBottomInset: isImmediatelyBeforeSelected
+                ? TabBarMetrics.selectedTabLeftSeparatorBottomInset
+                : 0,
             controlShortcutDigit: tabControlShortcutDigit(for: index, tabCount: pane.tabs.count),
             allowsShortcutHints: isFocused && splitViewController.tabShortcutHintsEnabled,
             showsControlShortcutHint: showsControlShortcutHints,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -52,6 +52,7 @@ struct TabItemView: View {
     let showsZoomIndicator: Bool
     let appearance: BonsplitConfiguration.Appearance
     let saturation: Double
+    let trailingSeparatorBottomInset: CGFloat
     let controlShortcutDigit: Int?
     let allowsShortcutHints: Bool
     let showsControlShortcutHint: Bool
@@ -366,6 +367,7 @@ struct TabItemView: View {
                 Rectangle()
                     .fill(TabBarColors.separator(for: appearance))
                     .frame(width: 1)
+                    .padding(.bottom, max(0, trailingSeparatorBottomInset))
             }
         }
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1432,6 +1432,17 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testSelectedTabLeftSeparatorDoesNotOverlapBottomSeparator() {
+        guard let alphas = renderedSelectedTabLeftSeparatorAlphas() else {
+            XCTFail("Expected rendered selected tab separator alphas")
+            return
+        }
+
+        XCTAssertGreaterThan(alphas.top, 0.3)
+        XCTAssertEqual(alphas.bottom, alphas.top, accuracy: 0.08)
+    }
+
+    @MainActor
     func testInactiveSelectedTabIndicatorUsesDesaturatedAccent() {
         guard let focusedSaturation = renderedTabBarIndicatorSaturation(isFocused: true),
               let unfocusedSaturation = renderedTabBarIndicatorSaturation(isFocused: false) else {
@@ -2057,12 +2068,73 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    private func renderedTabBarValue<T>(isFocused: Bool, extract: (NSView) -> T?) -> T? {
-        let controller = BonsplitController()
+    private func renderedSelectedTabLeftSeparatorAlphas() -> (top: CGFloat, bottom: CGFloat)? {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(
+                backgroundHex: "#00000000",
+                tabBarBackgroundHex: "#00000000",
+                borderHex: "#FFFFFF80"
+            )
+        )
+        return renderedTabBarValue(
+            isFocused: true,
+            appearance: appearance,
+            configurePane: { pane in
+                let leading = TabItem(title: "", icon: nil)
+                let selected = TabItem(title: "", icon: nil)
+                pane.tabs = [leading, selected]
+                pane.selectedTabId = selected.id
+            }
+        ) { hostingView in
+            let separatorX = TabBarMetrics.tabMinWidth - 0.5
+            guard let top = renderedColorInViewCoordinates(in: hostingView, at: NSPoint(x: separatorX, y: 4))?
+                .usingColorSpace(.sRGB)?
+                .alphaComponent,
+                  let bottom = renderedColorInViewCoordinates(
+                    in: hostingView,
+                    at: NSPoint(x: separatorX, y: TabBarMetrics.barHeight - 0.5)
+                  )?
+                .usingColorSpace(.sRGB)?
+                .alphaComponent else {
+                return nil
+            }
+            return (top: top, bottom: bottom)
+        }
+    }
+
+    @MainActor
+    private func renderedColorInViewCoordinates(in view: NSView, at point: NSPoint) -> NSColor? {
+        let integralBounds = view.bounds.integral
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: integralBounds) else { return nil }
+        bitmap.size = integralBounds.size
+        view.cacheDisplay(in: integralBounds, to: bitmap)
+        let scaleX = CGFloat(bitmap.pixelsWide) / max(1, integralBounds.width)
+        let scaleY = CGFloat(bitmap.pixelsHigh) / max(1, integralBounds.height)
+        let x = Int((point.x * scaleX).rounded(.down))
+        let y = Int((point.y * scaleY).rounded(.down))
+        guard x >= 0,
+              y >= 0,
+              x < bitmap.pixelsWide,
+              y < bitmap.pixelsHigh else { return nil }
+        return bitmap.colorAt(x: x, y: y)
+    }
+
+    @MainActor
+    private func renderedTabBarValue<T>(
+        isFocused: Bool,
+        appearance: BonsplitConfiguration.Appearance = .default,
+        configurePane: ((PaneState) -> Void)? = nil,
+        extract: (NSView) -> T?
+    ) -> T? {
+        let controller = BonsplitController(configuration: BonsplitConfiguration(appearance: appearance))
         guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
-        let tab = TabItem(title: "", icon: nil)
-        pane.tabs = [tab]
-        pane.selectedTabId = tab.id
+        if let configurePane {
+            configurePane(pane)
+        } else {
+            let tab = TabItem(title: "", icon: nil)
+            pane.tabs = [tab]
+            pane.selectedTabId = tab.id
+        }
 
         let size = NSSize(width: 160, height: TabBarMetrics.barHeight)
         let hostingView = NSHostingView(


### PR DESCRIPTION
## Summary\n- trim the tab separator that forms the selected tab's left edge by one point at the bottom\n- add a rendering regression for the separator/bottom-bar overlap\n\n## Tests\n- swift test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim the selected tab’s left separator by 1pt at the bottom to prevent overlap with the bottom bar. Adds a rendering regression test to guard against visual bleed.

- **Bug Fixes**
  - Add `TabBarMetrics.selectedTabLeftSeparatorBottomInset = 1` and apply it as bottom padding to the trailing separator of the tab immediately before the selected tab via `trailingSeparatorBottomInset` in `TabItemView`.
  - Add a pixel-precision test that verifies the selected tab’s left separator doesn’t overlap the bottom separator.

<sup>Written for commit adb31289853e7a9303ac2d3fb44c390e7f3b228e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/112?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tab bar separator rendering to prevent visual overlap when tabs are selected.

* **Tests**
  * Added UI rendering tests for tab separator validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->