### PR TITLE
Support file drops on tab bar targets

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -122,13 +122,19 @@ final class SplitViewController {
     // MARK: - Split Operations
 
     /// Split the specified pane in the given orientation
-    func splitPane(_ paneId: PaneID, orientation: SplitOrientation, with newTab: TabItem? = nil) {
+    func splitPane(
+        _ paneId: PaneID,
+        orientation: SplitOrientation,
+        with newTab: TabItem? = nil,
+        initialDividerPosition: CGFloat? = nil
+    ) {
         clearPaneZoom()
         rootNode = splitNodeRecursively(
             node: rootNode,
             targetPaneId: paneId,
             orientation: orientation,
-            newTab: newTab
+            newTab: newTab,
+            initialDividerPosition: initialDividerPosition
         )
     }
 
@@ -136,7 +142,8 @@ final class SplitViewController {
         node: SplitNode,
         targetPaneId: PaneID,
         orientation: SplitOrientation,
-        newTab: TabItem?
+        newTab: TabItem?,
+        initialDividerPosition: CGFloat?
     ) -> SplitNode {
         switch node {
         case .pane(let paneState):
@@ -157,7 +164,7 @@ final class SplitViewController {
                     // Keep the model at its steady-state ratio. The view layer can still animate
                     // from an edge via animationOrigin, but the model should never represent a
                     // fully-collapsed pane (which can get stuck under view reparenting timing).
-                    dividerPosition: 0.5,
+                    dividerPosition: normalizedInitialDividerPosition(initialDividerPosition),
                     animationOrigin: .fromSecond  // New pane slides in from right/bottom
                 )
 
@@ -173,27 +180,36 @@ final class SplitViewController {
                 node: splitState.first,
                 targetPaneId: targetPaneId,
                 orientation: orientation,
-                newTab: newTab
+                newTab: newTab,
+                initialDividerPosition: initialDividerPosition
             )
             splitState.second = splitNodeRecursively(
                 node: splitState.second,
                 targetPaneId: targetPaneId,
                 orientation: orientation,
-                newTab: newTab
+                newTab: newTab,
+                initialDividerPosition: initialDividerPosition
             )
             return .split(splitState)
         }
     }
 
     /// Split a pane with a specific tab, optionally inserting the new pane first
-    func splitPaneWithTab(_ paneId: PaneID, orientation: SplitOrientation, tab: TabItem, insertFirst: Bool) {
+    func splitPaneWithTab(
+        _ paneId: PaneID,
+        orientation: SplitOrientation,
+        tab: TabItem,
+        insertFirst: Bool,
+        initialDividerPosition: CGFloat? = nil
+    ) {
         clearPaneZoom()
         rootNode = splitNodeWithTabRecursively(
             node: rootNode,
             targetPaneId: paneId,
             orientation: orientation,
             tab: tab,
-            insertFirst: insertFirst
+            insertFirst: insertFirst,
+            initialDividerPosition: initialDividerPosition
         )
     }
 
@@ -202,7 +218,8 @@ final class SplitViewController {
         targetPaneId: PaneID,
         orientation: SplitOrientation,
         tab: TabItem,
-        insertFirst: Bool
+        insertFirst: Bool,
+        initialDividerPosition: CGFloat?
     ) -> SplitNode {
         switch node {
         case .pane(let paneState):
@@ -218,7 +235,7 @@ final class SplitViewController {
                         orientation: orientation,
                         first: .pane(newPane),
                         second: .pane(paneState),
-                        dividerPosition: 0.5,
+                        dividerPosition: normalizedInitialDividerPosition(initialDividerPosition),
                         animationOrigin: .fromFirst
                     )
                 } else {
@@ -227,7 +244,7 @@ final class SplitViewController {
                         orientation: orientation,
                         first: .pane(paneState),
                         second: .pane(newPane),
-                        dividerPosition: 0.5,
+                        dividerPosition: normalizedInitialDividerPosition(initialDividerPosition),
                         animationOrigin: .fromSecond
                     )
                 }
@@ -245,17 +262,24 @@ final class SplitViewController {
                 targetPaneId: targetPaneId,
                 orientation: orientation,
                 tab: tab,
-                insertFirst: insertFirst
+                insertFirst: insertFirst,
+                initialDividerPosition: initialDividerPosition
             )
             splitState.second = splitNodeWithTabRecursively(
                 node: splitState.second,
                 targetPaneId: targetPaneId,
                 orientation: orientation,
                 tab: tab,
-                insertFirst: insertFirst
+                insertFirst: insertFirst,
+                initialDividerPosition: initialDividerPosition
             )
             return .split(splitState)
         }
+    }
+
+    private func normalizedInitialDividerPosition(_ position: CGFloat?) -> CGFloat {
+        guard let position else { return 0.5 }
+        return min(max(position, 0.1), 0.9)
     }
 
     /// Close a pane and collapse the split

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -980,7 +980,7 @@ struct TabBarView: View {
                                 performNewTerminalSplitButtonAction()
                             }
                             .frame(width: trailing + 30, height: tabBarHeight)
-                            .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+                            .onDrop(of: [.tabTransfer, .fileURL], delegate: TabDropDelegate(
                                 targetIndex: pane.tabs.count,
                                 pane: pane,
                                 bonsplitController: controller,
@@ -1162,7 +1162,7 @@ struct TabBarView: View {
         } preview: {
             TabDragPreview(tab: tab, appearance: appearance)
         }
-        .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+        .onDrop(of: [.tabTransfer, .fileURL], delegate: TabDropDelegate(
             targetIndex: index,
             pane: pane,
             bonsplitController: controller,
@@ -1310,7 +1310,7 @@ struct TabBarView: View {
             performNewTerminalSplitButtonAction()
         }
         .frame(width: 30, height: tabBarHeight)
-        .onDrop(of: [.tabTransfer], delegate: TabDropDelegate(
+        .onDrop(of: [.tabTransfer, .fileURL], delegate: TabDropDelegate(
             targetIndex: pane.tabs.count,
             pane: pane,
             bonsplitController: controller,
@@ -3043,21 +3043,21 @@ struct TabDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            guard let transfer = decodeTransfer(from: info),
-                  transfer.isFromCurrentProcess else {
-                return false
+            if let transfer = decodeTransfer(from: info),
+               transfer.isFromCurrentProcess {
+                let request = BonsplitController.ExternalTabDropRequest(
+                    tabId: TabID(id: transfer.tab.id),
+                    sourcePaneId: PaneID(id: transfer.sourcePaneId),
+                    destination: .insert(targetPane: pane.id, targetIndex: targetIndex)
+                )
+                let handled = bonsplitController.onExternalTabDrop?(request) ?? false
+                if handled {
+                    clearDropState()
+                }
+                return handled
             }
-            let request = BonsplitController.ExternalTabDropRequest(
-                tabId: TabID(id: transfer.tab.id),
-                sourcePaneId: PaneID(id: transfer.sourcePaneId),
-                destination: .insert(targetPane: pane.id, targetIndex: targetIndex)
-            )
-            let handled = bonsplitController.onExternalTabDrop?(request) ?? false
-            if handled {
-                dropLifecycle = .idle
-                dropTargetIndex = nil
-            }
-            return handled
+
+            return performFileDrop(info: info)
         }
 
         // Execute synchronously when possible so the dragged tab disappears immediately.
@@ -3086,8 +3086,7 @@ struct TabDropDelegate: DropDelegate {
         // Clear visual state immediately to prevent lingering indicators.
         // Must happen synchronously before returning, not in async callback.
         // Setting dropLifecycle to idle prevents dropUpdated from re-setting dropTargetIndex.
-        dropLifecycle = .idle
-        dropTargetIndex = nil
+        clearDropState()
         controller.draggingTab = nil
         controller.dragSourcePaneId = nil
         controller.activeDragTab = nil
@@ -3131,7 +3130,7 @@ struct TabDropDelegate: DropDelegate {
 #if DEBUG
             dlog("tab.dropUpdated.skip pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex) reason=lifecycle_idle")
 #endif
-            return DropProposal(operation: .move)
+            return DropProposal(operation: dropOperation(for: info))
         }
         // Only update if this is the active target, and suppress same-pane no-op indicators.
         if shouldSuppressIndicatorForNoopSamePaneDrop() {
@@ -3147,7 +3146,7 @@ struct TabDropDelegate: DropDelegate {
             "dropTarget=\(dropTargetIndex.map(String.init) ?? "nil")"
         )
 #endif
-        return DropProposal(operation: .move)
+        return DropProposal(operation: dropOperation(for: info))
     }
 
     func validateDrop(info: DropInfo) -> Bool {
@@ -3158,11 +3157,13 @@ struct TabDropDelegate: DropDelegate {
 #endif
             return false
         }
-        // The custom UTType alone is sufficient — only Bonsplit tab drags produce it.
-        // Do NOT gate on draggingTab != nil: @Observable changes from createItemProvider
-        // may not have propagated to the drop delegate yet, causing false rejections.
-        let hasType = info.hasItemsConforming(to: [.tabTransfer])
-        guard hasType else { return false }
+        let hasTabTransfer = info.hasItemsConforming(to: [.tabTransfer])
+        let hasFileURL = info.hasItemsConforming(to: [.fileURL])
+        guard hasTabTransfer || hasFileURL else { return false }
+
+        if hasFileURL, !hasTabTransfer {
+            return canHandleFileDrop(info: info)
+        }
 
         // Local drags use in-memory state and are always same-process.
         if controller.activeDragTab != nil || controller.draggingTab != nil {
@@ -3179,10 +3180,43 @@ struct TabDropDelegate: DropDelegate {
         let hasActive = controller.activeDragTab != nil
         dlog(
             "tab.validateDrop pane=\(pane.id.id.uuidString.prefix(5)) " +
-            "allowed=\(hasType ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
+            "allowed=\(hasTabTransfer ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
         )
 #endif
         return true
+    }
+
+    private func clearDropState() {
+        dropLifecycle = .idle
+        dropTargetIndex = nil
+    }
+
+    private func dropOperation(for info: DropInfo) -> DropOperation {
+        info.hasItemsConforming(to: [.fileURL]) && !info.hasItemsConforming(to: [.tabTransfer]) ? .copy : .move
+    }
+
+    private func canHandleFileDrop(info: DropInfo) -> Bool {
+        guard info.hasItemsConforming(to: [.fileURL]) else { return false }
+        guard bonsplitController.onExternalFileDrop != nil || controller.onFileDrop != nil else { return false }
+        return UnifiedPaneDropDelegate.hasReadableFileURLs()
+    }
+
+    private func performFileDrop(info: DropInfo) -> Bool {
+        guard canHandleFileDrop(info: info) else { return false }
+        let urls = UnifiedPaneDropDelegate.fileURLs(from: NSPasteboard(name: .drag))
+        guard !urls.isEmpty else { return false }
+
+        let destination: BonsplitController.ExternalTabDropRequest.Destination = .insert(
+            targetPane: pane.id,
+            targetIndex: targetIndex
+        )
+        let handled = bonsplitController.onExternalFileDrop?(
+            BonsplitController.ExternalFileDropRequest(urls: urls, destination: destination)
+        ) ?? controller.onFileDrop?(urls, pane.id) ?? false
+        if handled {
+            clearDropState()
+        }
+        return handled
     }
 
     private func shouldSuppressIndicatorForNoopSamePaneDrop() -> Bool {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -393,7 +393,8 @@ public final class BonsplitController {
     public func splitPane(
         _ paneId: PaneID? = nil,
         orientation: SplitOrientation,
-        withTab tab: Tab? = nil
+        withTab tab: Tab? = nil,
+        initialDividerPosition: CGFloat? = nil
     ) -> PaneID? {
         guard configuration.allowSplits else { return nil }
 
@@ -427,7 +428,8 @@ public final class BonsplitController {
         internalController.splitPane(
             PaneID(id: targetPaneId.id),
             orientation: orientation,
-            with: internalTab
+            with: internalTab,
+            initialDividerPosition: initialDividerPosition
         )
 
         // Find new pane (will be focused after split)
@@ -457,7 +459,8 @@ public final class BonsplitController {
         _ paneId: PaneID? = nil,
         orientation: SplitOrientation,
         withTab tab: Tab,
-        insertFirst: Bool
+        insertFirst: Bool,
+        initialDividerPosition: CGFloat? = nil
     ) -> PaneID? {
         guard configuration.allowSplits else { return nil }
 
@@ -487,7 +490,8 @@ public final class BonsplitController {
             PaneID(id: targetPaneId.id),
             orientation: orientation,
             tab: internalTab,
-            insertFirst: insertFirst
+            insertFirst: insertFirst,
+            initialDividerPosition: initialDividerPosition
         )
 
         let newPaneId = focusedPaneId!


### PR DESCRIPTION
## Summary
- let tab bar drop zones accept Finder file URLs as copy drops
- route tabbar file drops through the existing external file-drop request path
- preserve existing Bonsplit tab-transfer behavior and keep initial divider sizing available to cmux

## Tests
- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-filedrop3-unit -only-testing:cmuxTests/PortalTabDragRoutingTests -only-testing:cmuxTests/FileDropOverlayViewTests
- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-filedrop3-unit -only-testing:cmuxTests/WorkspaceSplitStartupCommandTests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support dropping Finder file URLs onto tab bar targets as copy drops, routed through the external file-drop path. Adds an optional initial divider position to split APIs to preserve cmux’s initial sizing; existing tab transfer behavior is unchanged.

- **New Features**
  - Tab bar drop zones accept `.fileURL` in addition to `.tabTransfer`; files use copy, tabs use move.
  - File drops call `BonsplitController.onExternalFileDrop` (fallback to `controller.onFileDrop`) with an insert destination at the target index.
  - Added `initialDividerPosition` to `BonsplitController.splitPane` and `splitPane(withTab:insertFirst:)`, clamped to 0.1–0.9 to keep splits stable.

<sup>Written for commit aa4f69723ea1a5a59df9dc0c9e7bbdfb1f96abc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Set custom initial divider positions when creating split panes; specified values are automatically clamped to the 0.1–0.9 range and default to 0.5 when unspecified.
  * Enhanced drag-and-drop support for tab bars now accepts both internal tab transfers and external file drops, with intelligent operation detection for seamless interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->