### PR TITLE
Fix empty tab bar click handling

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1022,6 +1022,20 @@ struct TabBarView: View {
                 .animation(.easeInOut(duration: 0.14), value: shouldShowSplitButtons)
         }
         .overlay(maskedTabBarBottomSeparatorChrome)
+        .overlay {
+            TabBarDragZoneView(
+                hitRegion: .trailingEmptyChrome(
+                    tabFrames: Array(tabFramesInBar.values),
+                    reservedTrailingWidth: shouldRenderSplitButtons ? splitButtonsBackdropWidth : 0
+                ),
+                isMinimalMode: isMinimalMode,
+                isFocusedPane: isFocused,
+                onSingleClick: focusPaneFromTabBarChrome
+            ) {
+                performNewTerminalSplitButtonAction()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
         .overlay(alignment: .trailing) {
             splitButtonChrome
                 .frame(width: splitButtonsBackdropWidth, height: tabBarHeight, alignment: .trailing)
@@ -2428,6 +2442,12 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 }
 
 struct TabBarDragZoneView: NSViewRepresentable {
+    enum HitRegion {
+        case entireBounds
+        case trailingEmptyChrome(tabFrames: [CGRect], reservedTrailingWidth: CGFloat)
+    }
+
+    var hitRegion: HitRegion = .entireBounds
     let isMinimalMode: Bool
     let isFocusedPane: Bool
     let onSingleClick: () -> Bool
@@ -2435,6 +2455,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> DragNSView {
         let view = DragNSView()
+        view.hitRegion = hitRegion
         view.isMinimalMode = isMinimalMode
         view.isFocusedPane = isFocusedPane
         view.onSingleClick = onSingleClick
@@ -2445,6 +2466,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: DragNSView, context: Context) {
+        nsView.hitRegion = hitRegion
         nsView.isMinimalMode = isMinimalMode
         nsView.isFocusedPane = isFocusedPane
         nsView.onSingleClick = onSingleClick
@@ -2452,6 +2474,8 @@ struct TabBarDragZoneView: NSViewRepresentable {
     }
 
     final class DragNSView: NSView {
+        var hitRegion = HitRegion.entireBounds
+        var hitTestEventTypeOverride: NSEvent.EventType?
         var isMinimalMode = false
         var isFocusedPane = false
         var onSingleClick: (() -> Bool)?
@@ -2472,7 +2496,8 @@ struct TabBarDragZoneView: NSViewRepresentable {
         override var mouseDownCanMoveWindow: Bool { false }
 
         override func hitTest(_ point: NSPoint) -> NSView? {
-            return bounds.contains(point) ? self : nil
+            guard shouldCaptureHit(at: point) else { return nil }
+            return self
         }
 
         override func mouseDown(with event: NSEvent) {
@@ -2490,38 +2515,24 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 return
             }
 
-            // Standard (non-minimal) mode: a click in the empty trailing area
-            // should create a new tab on the very first click, not require a
-            // double-click. We dedupe subsequent clicks of the same gesture so
-            // a real double-click doesn't create two tabs back-to-back.
             if !isMinimalMode {
                 clearPendingWindowDrag()
-                if event.clickCount == 1 {
+                if event.clickCount >= 2 {
                     if onDoubleClick?() == true {
 #if DEBUG
-                        dlog("tab.bar.dragZone.singleClick action=newTab")
+                        dlog("tab.bar.dragZone.doubleClick action=newTab")
 #endif
                         return
                     }
-                    super.mouseDown(with: event)
-                    return
                 }
-                // clickCount >= 2: same gesture as a click we already acted on.
 #if DEBUG
-                dlog("tab.bar.dragZone.click skipped reason=dedupeStandardMode clickCount=\(event.clickCount)")
+                dlog("tab.bar.dragZone.click skipped reason=standardSingleClick clickCount=\(event.clickCount)")
 #endif
                 return
             }
 
             if event.clickCount >= 2 {
                 clearPendingWindowDrag()
-                if onDoubleClick?() == true {
-#if DEBUG
-                    dlog("tab.bar.dragZone.doubleClick action=newTab")
-#endif
-                    return
-                }
-
 #if DEBUG
                 dlog("tab.bar.dragZone.doubleClick action=titlebar")
 #endif
@@ -2539,6 +2550,31 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
             pendingWindowDragEvent = event
             pendingWindowDragStart = event.locationInWindow
+        }
+
+        private func shouldCaptureHit(at point: NSPoint) -> Bool {
+            guard bounds.contains(point) else { return false }
+            switch hitRegion {
+            case .entireBounds:
+                return true
+            case .trailingEmptyChrome(let tabFrames, let reservedTrailingWidth):
+                guard isMouseDownOrDragCandidate else { return false }
+                let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
+                guard point.x < trailingLimit else { return false }
+                let paddedFrames = tabFrames.map { $0.insetBy(dx: -2, dy: -2) }
+                guard !paddedFrames.contains(where: { $0.contains(point) }) else { return false }
+                let startX = paddedFrames.map(\.maxX).max() ?? bounds.minX
+                return point.x >= startX
+            }
+        }
+
+        private var isMouseDownOrDragCandidate: Bool {
+            switch hitTestEventTypeOverride ?? NSApp.currentEvent?.type {
+            case .leftMouseDown, .leftMouseDragged, .leftMouseUp:
+                return true
+            default:
+                return false
+            }
         }
 
         override func mouseDragged(with event: NSEvent) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2517,6 +2517,18 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
             if !isMinimalMode {
                 clearPendingWindowDrag()
+                if event.clickCount == 1 {
+                    if !isFocusedPane, onSingleClick?() == true {
+#if DEBUG
+                        dlog("tab.bar.dragZone.focusPane")
+#endif
+                    } else {
+#if DEBUG
+                        dlog("tab.bar.dragZone.click skipped reason=standardSingleClick clickCount=\(event.clickCount)")
+#endif
+                    }
+                    return
+                }
                 if event.clickCount >= 2 {
                     if onDoubleClick?() == true {
 #if DEBUG
@@ -2526,7 +2538,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
                     }
                 }
 #if DEBUG
-                dlog("tab.bar.dragZone.click skipped reason=standardSingleClick clickCount=\(event.clickCount)")
+                dlog("tab.bar.dragZone.click skipped reason=standardUnhandledClick clickCount=\(event.clickCount)")
 #endif
                 return
             }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2413,6 +2413,50 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarDragZoneSingleClickFocusesInactivePaneInStandardMode() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+        view.isMinimalMode = false
+        view.isFocusedPane = false
+
+        var focused = false
+        var newTabCount = 0
+        var dragged = false
+        view.onSingleClick = {
+            focused = true
+            return true
+        }
+        view.onDoubleClick = {
+            newTabCount += 1
+            return true
+        }
+        view.performWindowDrag = { _ in
+            dragged = true
+            return true
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
+        view.mouseDown(with: event)
+
+        XCTAssertTrue(focused, "Standard-mode inactive-pane single click should focus the pane")
+        XCTAssertEqual(newTabCount, 0, "Standard-mode inactive-pane single click should not create a tab")
+        XCTAssertFalse(dragged, "Standard-mode inactive-pane single click should not begin a window drag")
+    }
+
+    @MainActor
     func testTabBarDragZoneStandardModeDoubleClickCreatesOnlyOneTab() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.isMinimalMode = false

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2289,7 +2289,7 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testTabBarDragZoneSingleClickDoesNotBlockLaterDoubleClickInMinimalMode() throws {
+    func testTabBarDragZoneMinimalModeNeverRequestsNewTabAfterSingleThenDoubleClick() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.isMinimalMode = true
         view.isFocusedPane = true
@@ -2332,12 +2332,12 @@ final class BonsplitTests: XCTestCase {
         view.mouseUp(with: firstUp)
         view.mouseDown(with: doubleClick)
 
-        XCTAssertTrue(requestedNewTab, "A prior single click must not leave the drag zone unable to handle double-clicks")
+        XCTAssertFalse(requestedNewTab, "Minimal-mode drag zone double-clicks must not request new tabs")
         XCTAssertFalse(dragged, "A plain click followed by a double-click should not start a window drag")
     }
 
     @MainActor
-    func testTabBarDragZoneDoubleClickRequestsNewTabInMinimalMode() throws {
+    func testTabBarDragZoneDoubleClickDoesNotRequestNewTabInMinimalMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.isMinimalMode = true
         view.isFocusedPane = true
@@ -2370,12 +2370,12 @@ final class BonsplitTests: XCTestCase {
         let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 2)
         view.mouseDown(with: event)
 
-        XCTAssertTrue(requestedNewTab, "Minimal-mode drag zone double-click should request the new-tab action")
+        XCTAssertFalse(requestedNewTab, "Minimal-mode drag zone double-click should behave like titlebar chrome, not new-tab chrome")
         XCTAssertFalse(dragged, "Minimal-mode double-click should not start a window drag")
     }
 
     @MainActor
-    func testTabBarDragZoneSingleClickRequestsNewTabInStandardMode() throws {
+    func testTabBarDragZoneSingleClickDoesNotRequestNewTabInStandardMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.isMinimalMode = false
         view.isFocusedPane = true
@@ -2408,7 +2408,7 @@ final class BonsplitTests: XCTestCase {
         let event = try makeLeftMouseDownEvent(in: view, at: NSPoint(x: 20, y: 15), clickCount: 1)
         view.mouseDown(with: event)
 
-        XCTAssertEqual(newTabCount, 1, "Standard-mode drag zone single click should immediately request a new tab")
+        XCTAssertEqual(newTabCount, 0, "Standard-mode drag zone single click should wait for a double-click before creating a tab")
         XCTAssertFalse(dragged, "Standard-mode drag zone single click should not begin a window drag")
     }
 
@@ -2451,7 +2451,35 @@ final class BonsplitTests: XCTestCase {
         view.mouseUp(with: firstUp)
         view.mouseDown(with: secondDown)
 
-        XCTAssertEqual(newTabCount, 1, "A standard-mode double-click must only create one tab; the clickCount=2 follow-up should be deduped")
+        XCTAssertEqual(newTabCount, 1, "A standard-mode double-click should create exactly one tab")
+    }
+
+    @MainActor
+    func testTabBarTrailingEmptyChromeCapturesOnlyEmptyArea() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        view.hitRegion = .trailingEmptyChrome(
+            tabFrames: [CGRect(x: 10, y: 0, width: 90, height: 30)],
+            reservedTrailingWidth: 48
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        view.hitTestEventTypeOverride = .leftMouseDown
+        XCTAssertNil(view.hitTest(NSPoint(x: 40, y: 15)), "The empty chrome catcher must not cover tabs")
+        XCTAssertNil(view.hitTest(NSPoint(x: 300, y: 15)), "The empty chrome catcher must not cover the action button lane")
+        XCTAssertIdentical(view.hitTest(NSPoint(x: 140, y: 15)), view)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- make empty tab-bar chrome create new tabs only on standard-mode double-click
- keep minimal-mode empty tab-bar double-clicks on titlebar behavior
- focus inactive standard panes on empty-chrome single-click
- cover the empty chrome hit zone and click policy with Bonsplit tests

## Testing
- `swift test --filter BonsplitTests/testTabBarDragZone`, 7 tests passed
- `swift test`, 111 tests passed
- hosted Bonsplit PR checks passed

## Checklist
- [x] Regression tests added
- [x] Review feedback addressed or resolved
- [x] CI green
