### PR TITLE
Route portal drop overlays through content

### DIFF
--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -48,6 +48,20 @@ enum PaneDropLifecycle {
     case hovering
 }
 
+enum PaneDropOverlayRouting {
+    static func inlineDropZone(
+        activeDropZone: DropZone?,
+        selectedTabKind: String?,
+        portalDropOverlayTabKinds: Set<String>
+    ) -> DropZone? {
+        guard let selectedTabKind,
+              portalDropOverlayTabKinds.contains(selectedTabKind) else {
+            return activeDropZone
+        }
+        return nil
+    }
+}
+
 private struct PaneDropPlaceholderOverlay: View {
     let zone: DropZone?
     let size: CGSize
@@ -213,12 +227,20 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var contentAreaWithDropZones: some View {
-        PaneDropInteractionContainer(activeDropZone: activeDropZone) {
+        PaneDropInteractionContainer(activeDropZone: inlineDropZone) {
             contentArea
         } dropLayer: { size in
             // Drop zones layer (above content, receives drops and taps)
             dropZonesLayer(size: size)
         }
+    }
+
+    private var inlineDropZone: DropZone? {
+        PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: activeDropZone,
+            selectedTabKind: (pane.selectedTab ?? pane.tabs.first)?.kind,
+            portalDropOverlayTabKinds: bonsplitController.configuration.portalDropOverlayTabKinds
+        )
     }
 
     // MARK: - Content Area

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -53,6 +53,10 @@ public struct BonsplitConfiguration: Sendable {
     /// Controls where new tabs are inserted in the tab list
     public var newTabPosition: NewTabPosition
 
+    /// Tab kind identifiers whose content renders the pane drop overlay from
+    /// `paneDropZone`, above portal-hosted AppKit surfaces.
+    public var portalDropOverlayTabKinds: Set<String>
+
     // MARK: - Appearance
 
     /// Tab bar appearance customization
@@ -85,6 +89,7 @@ public struct BonsplitConfiguration: Sendable {
         autoCloseEmptyPanes: Bool = true,
         contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch,
         newTabPosition: NewTabPosition = .current,
+        portalDropOverlayTabKinds: Set<String> = ["terminal", "browser"],
         appearance: Appearance = .default
     ) {
         self.allowSplits = allowSplits
@@ -95,6 +100,7 @@ public struct BonsplitConfiguration: Sendable {
         self.autoCloseEmptyPanes = autoCloseEmptyPanes
         self.contentViewLifecycle = contentViewLifecycle
         self.newTabPosition = newTabPosition
+        self.portalDropOverlayTabKinds = portalDropOverlayTabKinds
         self.appearance = appearance
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -215,6 +215,58 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(controller.configuration.allowCloseTabs)
     }
 
+    func testDefaultPortalDropOverlayKinds() {
+        let config = BonsplitConfiguration()
+
+        XCTAssertTrue(config.portalDropOverlayTabKinds.contains("terminal"))
+        XCTAssertTrue(config.portalDropOverlayTabKinds.contains("browser"))
+    }
+
+    func testPaneDropOverlayRoutingSuppressesInlineOverlayForPortalKinds() {
+        let portalKinds: Set<String> = ["terminal", "browser"]
+
+        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: .left,
+            selectedTabKind: "browser",
+            portalDropOverlayTabKinds: portalKinds
+        ))
+        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: .right,
+            selectedTabKind: "terminal",
+            portalDropOverlayTabKinds: portalKinds
+        ))
+        XCTAssertEqual(PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: .top,
+            selectedTabKind: "custom",
+            portalDropOverlayTabKinds: portalKinds
+        ), .top)
+        XCTAssertEqual(PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: .bottom,
+            selectedTabKind: nil,
+            portalDropOverlayTabKinds: portalKinds
+        ), .bottom)
+        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: nil,
+            selectedTabKind: "browser",
+            portalDropOverlayTabKinds: portalKinds
+        ))
+    }
+
+    func testPaneDropOverlayRoutingCanBeConfigured() {
+        let config = BonsplitConfiguration(portalDropOverlayTabKinds: ["custom"])
+
+        XCTAssertEqual(PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: .left,
+            selectedTabKind: "browser",
+            portalDropOverlayTabKinds: config.portalDropOverlayTabKinds
+        ), .left)
+        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
+            activeDropZone: .left,
+            selectedTabKind: "custom",
+            portalDropOverlayTabKinds: config.portalDropOverlayTabKinds
+        ))
+    }
+
     func testDefaultSplitButtonTooltips() {
         let defaults = BonsplitConfiguration.SplitButtonTooltips.default
         XCTAssertEqual(defaults.newTerminal, "New Terminal")


### PR DESCRIPTION
## Summary
- Add `portalDropOverlayTabKinds` to identify tab content that renders pane drop overlays above AppKit portals.
- Suppress Bonsplit's inline drop placeholder for those selected tab kinds while still publishing `paneDropZone` to content.
- Default portal overlay kinds to `terminal` and `browser`.

## Testing
- `swift test`, 114 tests passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes pane drop overlays through tab content for portal-backed tabs to avoid conflicts with AppKit portals. Defaults to `terminal` and `browser`, and can be configured.

- New Features
  - Added `BonsplitConfiguration.portalDropOverlayTabKinds` (default: `["terminal", "browser"]`).
  - Suppress inline pane drop overlay for those kinds, while still publishing `paneDropZone` so content can render the overlay above the portal.
  - Introduced `PaneDropOverlayRouting.inlineDropZone` to compute the effective inline drop zone.

<sup>Written for commit 5b38ac9a049ce1b6216c041d7ac8316958c45781. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `portalDropOverlayTabKinds` configuration option to control which tab types display drop overlays from portal sources. Defaults to "terminal" and "browser" tabs.

* **Tests**
  * Added unit tests verifying drop-overlay configuration and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->