### PR TITLE
Revert portal drop overlay owner

### DIFF
--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -48,20 +48,6 @@ enum PaneDropLifecycle {
     case hovering
 }
 
-enum PaneDropOverlayRouting {
-    static func inlineDropZone(
-        activeDropZone: DropZone?,
-        selectedTabKind: String?,
-        portalDropOverlayTabKinds: Set<String>
-    ) -> DropZone? {
-        guard let selectedTabKind,
-              portalDropOverlayTabKinds.contains(selectedTabKind) else {
-            return activeDropZone
-        }
-        return nil
-    }
-}
-
 private struct PaneDropPlaceholderOverlay: View {
     let zone: DropZone?
     let size: CGSize
@@ -227,20 +213,12 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var contentAreaWithDropZones: some View {
-        PaneDropInteractionContainer(activeDropZone: inlineDropZone) {
+        PaneDropInteractionContainer(activeDropZone: activeDropZone) {
             contentArea
         } dropLayer: { size in
             // Drop zones layer (above content, receives drops and taps)
             dropZonesLayer(size: size)
         }
-    }
-
-    private var inlineDropZone: DropZone? {
-        PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: activeDropZone,
-            selectedTabKind: (pane.selectedTab ?? pane.tabs.first)?.kind,
-            portalDropOverlayTabKinds: bonsplitController.configuration.portalDropOverlayTabKinds
-        )
     }
 
     // MARK: - Content Area

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -53,10 +53,6 @@ public struct BonsplitConfiguration: Sendable {
     /// Controls where new tabs are inserted in the tab list
     public var newTabPosition: NewTabPosition
 
-    /// Tab kind identifiers whose content renders the pane drop overlay from
-    /// `paneDropZone`, above portal-hosted AppKit surfaces.
-    public var portalDropOverlayTabKinds: Set<String>
-
     // MARK: - Appearance
 
     /// Tab bar appearance customization
@@ -89,7 +85,6 @@ public struct BonsplitConfiguration: Sendable {
         autoCloseEmptyPanes: Bool = true,
         contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch,
         newTabPosition: NewTabPosition = .current,
-        portalDropOverlayTabKinds: Set<String> = ["terminal", "browser"],
         appearance: Appearance = .default
     ) {
         self.allowSplits = allowSplits
@@ -100,7 +95,6 @@ public struct BonsplitConfiguration: Sendable {
         self.autoCloseEmptyPanes = autoCloseEmptyPanes
         self.contentViewLifecycle = contentViewLifecycle
         self.newTabPosition = newTabPosition
-        self.portalDropOverlayTabKinds = portalDropOverlayTabKinds
         self.appearance = appearance
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -215,58 +215,6 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(controller.configuration.allowCloseTabs)
     }
 
-    func testDefaultPortalDropOverlayKinds() {
-        let config = BonsplitConfiguration()
-
-        XCTAssertTrue(config.portalDropOverlayTabKinds.contains("terminal"))
-        XCTAssertTrue(config.portalDropOverlayTabKinds.contains("browser"))
-    }
-
-    func testPaneDropOverlayRoutingSuppressesInlineOverlayForPortalKinds() {
-        let portalKinds: Set<String> = ["terminal", "browser"]
-
-        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: .left,
-            selectedTabKind: "browser",
-            portalDropOverlayTabKinds: portalKinds
-        ))
-        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: .right,
-            selectedTabKind: "terminal",
-            portalDropOverlayTabKinds: portalKinds
-        ))
-        XCTAssertEqual(PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: .top,
-            selectedTabKind: "custom",
-            portalDropOverlayTabKinds: portalKinds
-        ), .top)
-        XCTAssertEqual(PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: .bottom,
-            selectedTabKind: nil,
-            portalDropOverlayTabKinds: portalKinds
-        ), .bottom)
-        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: nil,
-            selectedTabKind: "browser",
-            portalDropOverlayTabKinds: portalKinds
-        ))
-    }
-
-    func testPaneDropOverlayRoutingCanBeConfigured() {
-        let config = BonsplitConfiguration(portalDropOverlayTabKinds: ["custom"])
-
-        XCTAssertEqual(PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: .left,
-            selectedTabKind: "browser",
-            portalDropOverlayTabKinds: config.portalDropOverlayTabKinds
-        ), .left)
-        XCTAssertNil(PaneDropOverlayRouting.inlineDropZone(
-            activeDropZone: .left,
-            selectedTabKind: "custom",
-            portalDropOverlayTabKinds: config.portalDropOverlayTabKinds
-        ))
-    }
-
     func testDefaultSplitButtonTooltips() {
         let defaults = BonsplitConfiguration.SplitButtonTooltips.default
         XCTAssertEqual(defaults.newTerminal, "New Terminal")


### PR DESCRIPTION
Reverts https://github.com/manaflow-ai/bonsplit/pull/117 at user request after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the portal drop overlay routing and restores the previous inline drop overlay behavior. Removes the `portalDropOverlayTabKinds` config and related tests.

- **Refactors**
  - Removed `PaneDropOverlayRouting` and `inlineDropZone`; `PaneDropInteractionContainer` now uses `activeDropZone` directly.
  - Removed `portalDropOverlayTabKinds` from `BonsplitConfiguration` and its initializer.
  - Deleted tests for portal overlay routing and defaults.

- **Migration**
  - If you used `portalDropOverlayTabKinds`, remove it from your config; no replacement is needed.

<sup>Written for commit f8c12c54817d25454191cd83090c205c6b778d7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `portalDropOverlayTabKinds` configuration property
* **New Features**
  * Added `newTabPosition` configuration property to control where new tabs are inserted in the tab list (default: current position)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->