### PR TITLE
Route tab header zoom through host hook

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1148,7 +1148,7 @@ struct TabBarView: View {
                 }
             },
             onZoomToggle: {
-                _ = splitViewController.togglePaneZoom(pane.id)
+                _ = controller.requestTabZoomToggle(for: TabID(id: tab.id), inPane: pane.id)
             },
             onContextAction: { action in
                 controller.requestTabContextAction(action, for: TabID(id: tab.id), inPane: pane.id)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -197,9 +197,7 @@ struct TabItemView: View {
             onContextAction: onContextAction,
             onMoveDestination: onMoveDestination
         ))
-        .onTapGesture {
-            onSelect()
-        }
+        .gesture(selectionOrZoomGesture)
         .onHover { hovering in
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering
@@ -209,6 +207,16 @@ struct TabItemView: View {
         .accessibilityValue(accessibilityValue)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .safeHelp(tab.title)
+    }
+
+    private var selectionOrZoomGesture: some Gesture {
+        TapGesture(count: 2)
+            .onEnded {
+                onZoomToggle()
+            }
+            .exclusively(before: TapGesture(count: 1).onEnded {
+                onSelect()
+            })
     }
 
     private func glyphSize(for iconName: String) -> CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -197,7 +197,14 @@ struct TabItemView: View {
             onContextAction: onContextAction,
             onMoveDestination: onMoveDestination
         ))
-        .gesture(selectionOrZoomGesture)
+        .onTapGesture {
+            onSelect()
+        }
+        .simultaneousGesture(
+            TapGesture(count: 2).onEnded {
+                onZoomToggle()
+            }
+        )
         .onHover { hovering in
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering
@@ -207,16 +214,6 @@ struct TabItemView: View {
         .accessibilityValue(accessibilityValue)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .safeHelp(tab.title)
-    }
-
-    private var selectionOrZoomGesture: some Gesture {
-        TapGesture(count: 2)
-            .onEnded {
-                onZoomToggle()
-            }
-            .exclusively(before: TapGesture(count: 1).onEnded {
-                onSelect()
-            })
     }
 
     private func glyphSize(for iconName: String) -> CGFloat {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -81,6 +81,10 @@ public final class BonsplitController {
     /// Internal host-driven closes should not use this hook.
     @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Void)?
 
+    /// Called when the user explicitly requests to toggle zoom from tab chrome.
+    /// When set, the host owns the full toggle and should return whether it succeeded.
+    @ObservationIgnored public var onTabZoomToggleRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Bool)?
+
     // MARK: - Internal State
 
     internal var internalController: SplitViewController
@@ -645,6 +649,18 @@ public final class BonsplitController {
         let targetPaneId = paneId ?? focusedPaneId
         guard let targetPaneId else { return false }
         return internalController.togglePaneZoom(targetPaneId)
+    }
+
+    /// Request a tab-chrome zoom toggle for a specific tab.
+    /// Hosts can intercept this to run their own focus/layout reconciliation.
+    @discardableResult
+    public func requestTabZoomToggle(for tabId: TabID, inPane paneId: PaneID) -> Bool {
+        guard let (pane, _) = findTabInternal(tabId),
+              pane.id == paneId else { return false }
+        if let onTabZoomToggleRequest {
+            return onTabZoomToggleRequest(tabId, paneId)
+        }
+        return togglePaneZoom(inPane: paneId)
     }
 
     // MARK: - Context Menu Shortcut Hints

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -83,7 +83,7 @@ public final class BonsplitController {
 
     /// Called when the user explicitly requests to toggle zoom from tab chrome.
     /// When set, the host owns the full toggle and should return whether it succeeded.
-    @ObservationIgnored public var onTabZoomToggleRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Bool)?
+    @ObservationIgnored public var onTabZoomToggleRequest: (@MainActor (_ tabId: TabID, _ paneId: PaneID) -> Bool)?
 
     // MARK: - Internal State
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1243,6 +1243,42 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testRequestTabZoomToggleUsesHostHandler() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Zoom target")!
+        var requestedTabId: TabID?
+        var requestedPaneId: PaneID?
+        controller.onTabZoomToggleRequest = { tabId, paneId in
+            requestedTabId = tabId
+            requestedPaneId = paneId
+            return true
+        }
+
+        XCTAssertTrue(controller.requestTabZoomToggle(for: tabId, inPane: pane))
+
+        XCTAssertEqual(requestedTabId, tabId)
+        XCTAssertEqual(requestedPaneId, pane)
+        XCTAssertNil(controller.zoomedPaneId)
+    }
+
+    @MainActor
+    func testRequestTabZoomToggleFallsBackToInternalZoom() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Zoom target")!
+        guard controller.splitPane(pane, orientation: .horizontal) != nil else {
+            return XCTFail("Expected splitPane to create a new pane")
+        }
+
+        XCTAssertTrue(controller.requestTabZoomToggle(for: tabId, inPane: pane))
+        XCTAssertEqual(controller.zoomedPaneId, pane)
+
+        XCTAssertTrue(controller.requestTabZoomToggle(for: tabId, inPane: pane))
+        XCTAssertNil(controller.zoomedPaneId)
+    }
+
+    @MainActor
     func testSplitClearsExistingPaneZoom() {
         let controller = BonsplitController()
         guard let originalPane = controller.focusedPaneId else {


### PR DESCRIPTION
## Summary
- add a host-owned tab zoom toggle request hook
- route tab header double-click and the zoom badge through the hook
- keep Bonsplit fallback zoom behavior when no host hook is installed

## Verification
- git diff --check
- local tests not run per cmux no-local-tests instruction

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes tab header zoom requests (double-click and zoom badge) through a host-owned hook so hosts can run focus/portal reconciliation; falls back to internal zoom when unset. Also improves tab bar layout so the action lane uses trailing whitespace before clipping. Addresses issue-3824 (double-click to zoom pane).

- **New Features**
  - Added `onTabZoomToggleRequest` on `BonsplitController` (`@MainActor`, returns Bool).
  - Added `requestTabZoomToggle(for:inPane:)` and wired tab chrome (badge and double-click) to use it.
  - Tab header gestures: single-click selects instantly; double-click toggles zoom.

- **Bug Fixes**
  - Split/action button lane now consumes trailing whitespace before applying width limits, preventing premature clipping and overflow.

<sup>Written for commit b5dd1f03993b70d3aa4b079e347d557323844e67. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/119?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Double-tap on tab items toggles pane zoom.
  * Apps can intercept and control tab-zoom requests via a new host handler.

* **Bug Fixes**
  * Improved tab bar layout and scrolling measurement to prevent split-button overflow and ensure consistent tab content sizing.

* **Tests**
  * Added tests for zoom interception/fallback behavior and tab-bar layout sizing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->