### PR TITLE
Add tab bar visibility configuration for cmux #1083

### DIFF
--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -154,6 +154,7 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true
+    var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
 
     @State private var activeDropZone: DropZone?
@@ -169,12 +170,13 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Tab bar
-            TabBarView(
-                pane: pane,
-                isFocused: isFocused,
-                showSplitButtons: showSplitButtons
-            )
+            if tabBarVisibility.showsTabBar(tabCount: pane.tabs.count) {
+                TabBarView(
+                    pane: pane,
+                    isFocused: isFocused,
+                    showSplitButtons: showSplitButtons
+                )
+            }
 
             // Content area with drop zones
             contentAreaWithDropZones

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -94,6 +94,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true
+    var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
     /// Callback when geometry changes. Bool indicates if change is during active divider drag.
     var onGeometryChange: ((_ isDragging: Bool) -> Void)?
@@ -442,6 +443,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,
+                tabBarVisibility: tabBarVisibility,
                 contentViewLifecycle: contentViewLifecycle
             )
         case .split(let nestedSplitState):
@@ -452,6 +454,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,
+                tabBarVisibility: tabBarVisibility,
                 contentViewLifecycle: contentViewLifecycle,
                 onGeometryChange: onGeometryChange,
                 enableAnimations: enableAnimations,

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -10,6 +10,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
     var showSplitButtons: Bool = true
+    var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
     var onGeometryChange: ((_ isDragging: Bool) -> Void)?
     var enableAnimations: Bool = true
@@ -24,6 +25,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,
+                tabBarVisibility: tabBarVisibility,
                 contentViewLifecycle: contentViewLifecycle
             )
 
@@ -35,6 +37,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,
+                tabBarVisibility: tabBarVisibility,
                 contentViewLifecycle: contentViewLifecycle,
                 onGeometryChange: onGeometryChange,
                 enableAnimations: enableAnimations,
@@ -94,6 +97,7 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true
+    var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
 
     func makeNSView(context: Context) -> NSView {
@@ -103,6 +107,7 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
             showSplitButtons: showSplitButtons,
+            tabBarVisibility: tabBarVisibility,
             contentViewLifecycle: contentViewLifecycle
         )
         let hostingController = NonDraggableHostingController(rootView: paneView)
@@ -143,6 +148,7 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
             showSplitButtons: showSplitButtons,
+            tabBarVisibility: tabBarVisibility,
             contentViewLifecycle: contentViewLifecycle
         )
         context.coordinator.hostingController?.rootView = paneView

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -8,6 +8,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
     var showSplitButtons: Bool = true
+    var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
     var onGeometryChange: ((_ isDragging: Bool) -> Void)?
     var enableAnimations: Bool = true
@@ -45,6 +46,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
             emptyPaneBuilder: emptyPaneBuilder,
             appearance: appearance,
             showSplitButtons: showSplitButtons,
+            tabBarVisibility: tabBarVisibility,
             contentViewLifecycle: contentViewLifecycle,
             onGeometryChange: onGeometryChange,
             enableAnimations: enableAnimations,

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -24,6 +24,24 @@ public enum NewTabPosition: Sendable {
     case end
 }
 
+/// Controls when pane tab bars are shown.
+public enum TabBarVisibility: Sendable, Equatable {
+    /// Always show the pane tab bar, even when the pane has zero or one tab.
+    case always
+
+    /// Show the pane tab bar only when there are multiple tabs to switch between.
+    case multipleTabs
+
+    public func showsTabBar(tabCount: Int) -> Bool {
+        switch self {
+        case .always:
+            return true
+        case .multipleTabs:
+            return tabCount >= 2
+        }
+    }
+}
+
 /// Configuration for the split tab bar appearance and behavior
 public struct BonsplitConfiguration: Sendable {
 
@@ -52,6 +70,9 @@ public struct BonsplitConfiguration: Sendable {
 
     /// Controls where new tabs are inserted in the tab list
     public var newTabPosition: NewTabPosition
+
+    /// Controls when pane tab bars are shown
+    public var tabBarVisibility: TabBarVisibility
 
     // MARK: - Appearance
 
@@ -85,6 +106,7 @@ public struct BonsplitConfiguration: Sendable {
         autoCloseEmptyPanes: Bool = true,
         contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch,
         newTabPosition: NewTabPosition = .current,
+        tabBarVisibility: TabBarVisibility = .always,
         appearance: Appearance = .default
     ) {
         self.allowSplits = allowSplits
@@ -95,6 +117,7 @@ public struct BonsplitConfiguration: Sendable {
         self.autoCloseEmptyPanes = autoCloseEmptyPanes
         self.contentViewLifecycle = contentViewLifecycle
         self.newTabPosition = newTabPosition
+        self.tabBarVisibility = tabBarVisibility
         self.appearance = appearance
     }
 }

--- a/Sources/Bonsplit/Public/BonsplitView.swift
+++ b/Sources/Bonsplit/Public/BonsplitView.swift
@@ -47,6 +47,7 @@ public struct BonsplitView<Content: View, EmptyContent: View>: View {
             },
             appearance: controller.configuration.appearance,
             showSplitButtons: controller.configuration.allowSplits && controller.configuration.appearance.showSplitButtons,
+            tabBarVisibility: controller.configuration.tabBarVisibility,
             contentViewLifecycle: controller.configuration.contentViewLifecycle,
             onGeometryChange: { [weak controller] isDragging in
                 controller?.notifyGeometryChange(isDragging: isDragging)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1454,6 +1454,21 @@ final class BonsplitTests: XCTestCase {
         XCTAssertNil(spy.requestedPaneId)
     }
 
+    @MainActor
+    func testTabBarVisibilityDefaultsToAlways() throws {
+        XCTAssertEqual(BonsplitConfiguration().tabBarVisibility, .always)
+        XCTAssertTrue(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 0, visibility: .always)))
+        XCTAssertTrue(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 1, visibility: .always)))
+        XCTAssertTrue(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 2, visibility: .always)))
+    }
+
+    @MainActor
+    func testMultipleTabsVisibilityHidesPaneBarUntilThereAreMultipleTabs() throws {
+        XCTAssertFalse(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 0, visibility: .multipleTabs)))
+        XCTAssertFalse(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 1, visibility: .multipleTabs)))
+        XCTAssertTrue(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 2, visibility: .multipleTabs)))
+    }
+
     func testIconSaturationKeepsRasterFaviconInColorWhenInactive() {
         XCTAssertEqual(
             TabItemStyling.iconSaturation(hasRasterIcon: true, tabSaturation: 0.0),
@@ -2617,6 +2632,44 @@ final class BonsplitTests: XCTestCase {
     private func waitForDescendant<T: NSView>(
         ofType type: T.Type,
         in root: NSView,
+        timeout: TimeInterval = 1.0,
+        where predicate: (T) -> Bool = { _ in true }
+    ) -> T? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            root.layoutSubtreeIfNeeded()
+            if let match = firstDescendant(
+                ofType: type,
+                in: root,
+                where: predicate
+            ) {
+                return match
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        } while Date() < deadline
+        return firstDescendant(ofType: type, in: root, where: predicate)
+    }
+
+    private func firstDescendant<T: NSView>(
+        ofType type: T.Type,
+        in root: NSView,
+        where predicate: (T) -> Bool
+    ) -> T? {
+        if let match = root as? T, predicate(match) {
+            return match
+        }
+        for subview in root.subviews {
+            if let match = firstDescendant(ofType: type, in: subview, where: predicate) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private func waitForDescendant<T: NSView>(
+        ofType type: T.Type,
+        in root: NSView,
         containingWindowPoint point: NSPoint,
         timeout: TimeInterval = 1.0,
         where predicate: (T) -> Bool = { _ in true }
@@ -3298,6 +3351,64 @@ final class BonsplitTests: XCTestCase {
         contentView.layoutSubtreeIfNeeded()
 
         return extract(hostingView)
+    }
+
+    @MainActor
+    private func renderedPaneContainerHasTabBar(
+        tabCount: Int,
+        visibility: TabBarVisibility
+    ) -> Bool? {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(tabBarVisibility: visibility)
+        )
+        guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
+
+        let tabs = (0..<tabCount).map { index in
+            TabItem(title: "Tab \(index + 1)", icon: nil)
+        }
+        pane.tabs = tabs
+        pane.selectedTabId = tabs.first?.id
+
+        let size = NSSize(width: 320, height: 180)
+        let hostingView = NSHostingView(
+            rootView: PaneContainerView(
+                pane: pane,
+                controller: controller.internalController,
+                contentBuilder: { _, _ in Color.clear },
+                emptyPaneBuilder: { _ in Color.clear },
+                showSplitButtons: false,
+                tabBarVisibility: visibility
+            )
+            .environment(controller)
+            .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else { return nil }
+
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        return waitForDescendant(
+            ofType: TabBarDragZoneView.DragNSView.self,
+            in: hostingView,
+            timeout: 0.1
+        ) != nil
     }
 
     @MainActor


### PR DESCRIPTION
Adds a Bonsplit tab bar visibility policy so hosts can hide pane tab bars until there are multiple tabs.

This supports manaflow-ai/cmux#1083.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a setting to control when pane tab bars are shown. Lets hosts hide the tab bar until there are multiple tabs, addressing cmux#1083.

- **New Features**
  - Introduced `TabBarVisibility` with `.always` and `.multipleTabs` (default is `.always`).
  - Added `tabBarVisibility` to `BonsplitConfiguration` and threaded it through `BonsplitView` and internal container views.
  - `PaneContainerView` now conditionally renders the tab bar based on the selected policy and tab count.
  - Added tests for default behavior and the multiple-tabs rule.

<sup>Written for commit 4404ce10b143b6f9822b999f2fd05292d83273a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added configurable tab bar visibility settings to control when the pane tab bar appears. Choose to always display the tab bar or show it only when multiple tabs are present. Defaults to always visible, preserving current behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->