### PR TITLE
Defer tab move menu destinations

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1148,7 +1148,7 @@ struct TabBarView: View {
                 }
             },
             onZoomToggle: {
-                _ = splitViewController.togglePaneZoom(pane.id)
+                _ = controller.requestTabZoomToggle(for: TabID(id: tab.id), inPane: pane.id)
             },
             onContextAction: { action in
                 controller.requestTabContextAction(action, for: TabID(id: tab.id), inPane: pane.id)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -365,7 +365,16 @@ struct TabBarLayout: Equatable {
 
     var maximumSplitButtonLaneWidth: CGFloat {
         guard availableWidth > 0 else { return fullSplitButtonLaneWidth }
-        return availableWidth * TabBarStyling.maximumSplitButtonLaneWidthFraction
+        let fractionLimit = availableWidth * TabBarStyling.maximumSplitButtonLaneWidthFraction
+        return max(fractionLimit, trailingWhitespaceBeforeSplitButtonLane)
+    }
+
+    var trailingWhitespaceBeforeSplitButtonLane: CGFloat {
+        guard availableWidth > 0,
+              let tabContentWidthExcludingSplitButtonLane else {
+            return 0
+        }
+        return max(0, availableWidth - tabContentWidthExcludingSplitButtonLane)
     }
 
     var visibleSplitButtonLaneWidth: CGFloat {
@@ -764,6 +773,7 @@ struct TabBarView: View {
     @State private var dropLifecycle: TabDropLifecycle = .idle
     @State private var scrollOffset: CGFloat = 0
     @State private var contentWidth: CGFloat = 0
+    @State private var tabContentWidthExcludingSplitButtonLane: CGFloat?
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
     @State private var tabFramesInBar: [UUID: CGRect] = [:]
@@ -806,6 +816,7 @@ struct TabBarView: View {
         TabBarLayout(
             tabBarHeight: appearance.tabBarHeight,
             availableWidth: containerWidth,
+            tabContentWidthExcludingSplitButtonLane: tabContentWidthExcludingSplitButtonLane,
             splitButtonCount: visibleSplitButtons.count,
             splitButtonLaneVisible: shouldShowSplitButtons,
             reservesSplitButtonLane: showSplitButtons && !isMinimalMode,
@@ -947,13 +958,11 @@ struct TabBarView: View {
                             GeometryReader { contentGeo in
                                 Color.clear
                                     .onChange(of: contentGeo.frame(in: .named("tabScroll"))) { _, newFrame in
-                                        scrollOffset = -newFrame.minX
-                                        contentWidth = newFrame.width
+                                        updateTabScrollContent(frame: newFrame)
                                     }
                                     .onAppear {
                                         let frame = contentGeo.frame(in: .named("tabScroll"))
-                                        scrollOffset = -frame.minX
-                                        contentWidth = frame.width
+                                        updateTabScrollContent(frame: frame)
                                     }
                             }
                         )
@@ -1537,6 +1546,12 @@ struct TabBarView: View {
     private func updateSplitButtonScrollContent(frame: CGRect) {
         splitButtonScrollOffset = max(0, -frame.minX)
         splitButtonContentWidth = frame.width
+    }
+
+    private func updateTabScrollContent(frame: CGRect) {
+        scrollOffset = -frame.minX
+        contentWidth = frame.width
+        tabContentWidthExcludingSplitButtonLane = max(0, frame.width - tabBarLayout.trailingTabContentInset)
     }
 
     @ViewBuilder

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -329,6 +329,7 @@ enum TabBarStyling {
 struct TabBarLayout: Equatable {
     let barHeight: CGFloat
     let availableWidth: CGFloat
+    let tabContentWidthExcludingSplitButtonLane: CGFloat?
     let splitButtonCount: Int
     let splitButtonLaneVisible: Bool
     let reservesSplitButtonLane: Bool
@@ -337,6 +338,7 @@ struct TabBarLayout: Equatable {
     init(
         tabBarHeight: CGFloat,
         availableWidth: CGFloat = 0,
+        tabContentWidthExcludingSplitButtonLane: CGFloat? = nil,
         splitButtonCount: Int,
         splitButtonLaneVisible: Bool,
         reservesSplitButtonLane: Bool,
@@ -344,6 +346,7 @@ struct TabBarLayout: Equatable {
     ) {
         self.barHeight = max(1, tabBarHeight)
         self.availableWidth = max(0, availableWidth)
+        self.tabContentWidthExcludingSplitButtonLane = tabContentWidthExcludingSplitButtonLane.map { max(0, $0) }
         self.splitButtonCount = max(0, splitButtonCount)
         self.splitButtonLaneVisible = splitButtonLaneVisible
         self.reservesSplitButtonLane = reservesSplitButtonLane

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -733,7 +733,6 @@ struct TabContextMenuState {
     let canMoveToRightPane: Bool
     let isZoomed: Bool
     let hasSplits: Bool
-    let moveDestinations: [TabContextMoveDestination]
     let shortcuts: [TabContextAction: KeyboardShortcut]
 
     var canMarkAsUnread: Bool {
@@ -1124,6 +1123,9 @@ struct TabBarView: View {
             showsControlShortcutHint: showsControlShortcutHints,
             shortcutModifierSymbol: controlKeyMonitor.shortcutModifierSymbol,
             contextMenuState: contextMenuState,
+            moveDestinationsProvider: {
+                controller.tabContextMoveDestinationsProvider?(TabID(id: tab.id), pane.id) ?? []
+            },
             onSelect: {
                 // Tab selection must be instant. Animating this transaction causes the pane
                 // content (often swapped via opacity) to crossfade, which is undesirable for
@@ -1219,7 +1221,6 @@ struct TabBarView: View {
             canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
             isZoomed: splitViewController.zoomedPaneId == pane.id,
             hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
-            moveDestinations: controller.tabContextMoveDestinationsProvider?(TabID(id: tab.id), pane.id) ?? [],
             shortcuts: controller.contextMenuShortcuts
         )
     }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -197,9 +197,7 @@ struct TabItemView: View {
             onContextAction: onContextAction,
             onMoveDestination: onMoveDestination
         ))
-        .onTapGesture {
-            onSelect()
-        }
+        .gesture(selectionOrZoomGesture)
         .onHover { hovering in
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering
@@ -209,6 +207,16 @@ struct TabItemView: View {
         .accessibilityValue(accessibilityValue)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .safeHelp(tab.title)
+    }
+
+    private var selectionOrZoomGesture: some Gesture {
+        TapGesture(count: 2)
+            .onEnded {
+                onZoomToggle()
+            }
+            .exclusively(before: TapGesture(count: 1).onEnded {
+                onSelect()
+            })
     }
 
     private func glyphSize(for iconName: String) -> CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -197,7 +197,14 @@ struct TabItemView: View {
             onContextAction: onContextAction,
             onMoveDestination: onMoveDestination
         ))
-        .gesture(selectionOrZoomGesture)
+        .onTapGesture {
+            onSelect()
+        }
+        .simultaneousGesture(
+            TapGesture(count: 2).onEnded {
+                onZoomToggle()
+            }
+        )
         .onHover { hovering in
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering
@@ -207,16 +214,6 @@ struct TabItemView: View {
         .accessibilityValue(accessibilityValue)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .safeHelp(tab.title)
-    }
-
-    private var selectionOrZoomGesture: some Gesture {
-        TapGesture(count: 2)
-            .onEnded {
-                onZoomToggle()
-            }
-            .exclusively(before: TapGesture(count: 1).onEnded {
-                onSelect()
-            })
     }
 
     private func glyphSize(for iconName: String) -> CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -58,6 +58,7 @@ struct TabItemView: View {
     let showsControlShortcutHint: Bool
     let shortcutModifierSymbol: String
     let contextMenuState: TabContextMenuState
+    let moveDestinationsProvider: () -> [TabContextMoveDestination]
     let onSelect: () -> Void
     let onClose: () -> Void
     let onZoomToggle: () -> Void
@@ -193,7 +194,11 @@ struct TabItemView: View {
             onClose()
         }))
         .background(TabContextMenuPresenter(
-            snapshot: TabContextMenuSnapshot(tabId: tab.id, state: contextMenuState),
+            snapshot: TabContextMenuSnapshot(
+                tabId: tab.id,
+                state: contextMenuState,
+                moveDestinationsProvider: moveDestinationsProvider
+            ),
             onContextAction: onContextAction,
             onMoveDestination: onMoveDestination
         ))
@@ -561,6 +566,7 @@ private struct MiddleClickMonitorView: NSViewRepresentable {
 struct TabContextMenuSnapshot {
     let tabId: UUID
     let state: TabContextMenuState
+    let moveDestinationsProvider: () -> [TabContextMoveDestination]
 }
 
 final class TabContextMenuActionTarget: NSObject {
@@ -635,7 +641,7 @@ enum TabContextMenuBuilder {
             to: menu
         )
 
-        menu.addItem(moveSubmenuItem(state: state, target: target))
+        menu.addItem(moveSubmenuItem(snapshot: snapshot, target: target))
 
         if state.isTerminal {
             addAction(
@@ -749,9 +755,11 @@ enum TabContextMenuBuilder {
     }
 
     private static func moveSubmenuItem(
-        state: TabContextMenuState,
+        snapshot: TabContextMenuSnapshot,
         target: TabContextMenuActionTarget
     ) -> NSMenuItem {
+        let state = snapshot.state
+        let moveDestinations = snapshot.moveDestinationsProvider()
         let item = NSMenuItem(
             title: localized("tabContext.moveTab", defaultValue: "Move Tab"),
             action: nil,
@@ -767,7 +775,7 @@ enum TabContextMenuBuilder {
             target: target,
             to: submenu
         )
-        for destination in state.moveDestinations {
+        for destination in moveDestinations {
             let destinationItem = NSMenuItem(
                 title: destination.title,
                 action: #selector(TabContextMenuActionTarget.performMoveDestination(_:)),
@@ -779,7 +787,7 @@ enum TabContextMenuBuilder {
             submenu.addItem(destinationItem)
         }
         item.submenu = submenu
-        item.isEnabled = state.canMoveToNewWorkspace || !state.moveDestinations.isEmpty
+        item.isEnabled = state.canMoveToNewWorkspace || !moveDestinations.isEmpty
         return item
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -81,6 +81,10 @@ public final class BonsplitController {
     /// Internal host-driven closes should not use this hook.
     @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Void)?
 
+    /// Called when the user explicitly requests to toggle zoom from tab chrome.
+    /// When set, the host owns the full toggle and should return whether it succeeded.
+    @ObservationIgnored public var onTabZoomToggleRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Bool)?
+
     // MARK: - Internal State
 
     internal var internalController: SplitViewController
@@ -645,6 +649,18 @@ public final class BonsplitController {
         let targetPaneId = paneId ?? focusedPaneId
         guard let targetPaneId else { return false }
         return internalController.togglePaneZoom(targetPaneId)
+    }
+
+    /// Request a tab-chrome zoom toggle for a specific tab.
+    /// Hosts can intercept this to run their own focus/layout reconciliation.
+    @discardableResult
+    public func requestTabZoomToggle(for tabId: TabID, inPane paneId: PaneID) -> Bool {
+        guard let (pane, _) = findTabInternal(tabId),
+              pane.id == paneId else { return false }
+        if let onTabZoomToggleRequest {
+            return onTabZoomToggleRequest(tabId, paneId)
+        }
+        return togglePaneZoom(inPane: paneId)
     }
 
     // MARK: - Context Menu Shortcut Hints

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -83,7 +83,7 @@ public final class BonsplitController {
 
     /// Called when the user explicitly requests to toggle zoom from tab chrome.
     /// When set, the host owns the full toggle and should return whether it succeeded.
-    @ObservationIgnored public var onTabZoomToggleRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Bool)?
+    @ObservationIgnored public var onTabZoomToggleRequest: (@MainActor (_ tabId: TabID, _ paneId: PaneID) -> Bool)?
 
     // MARK: - Internal State
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3115,9 +3115,9 @@ final class BonsplitTests: XCTestCase {
             showSplitButtons: true,
             size: size,
             configurePane: { pane in
-                let selected = TabItem(title: "", icon: nil)
-                pane.tabs = [selected]
-                pane.selectedTabId = selected.id
+                let tabs = (0..<8).map { _ in TabItem(title: "", icon: nil) }
+                pane.tabs = tabs
+                pane.selectedTabId = tabs.first?.id
             }
         ) { hostingView in
             maximumBrightness(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -422,6 +422,24 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(layout.splitButtonLaneOverflowsViewport)
     }
 
+    func testTabBarLayoutUsesTrailingWhitespaceBeforeClippingSplitButtons() {
+        let measuredWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: 10)
+        let layout = TabBarLayout(
+            tabBarHeight: 28,
+            availableWidth: 930,
+            tabContentWidthExcludingSplitButtonLane: 300,
+            splitButtonCount: 10,
+            splitButtonLaneVisible: true,
+            reservesSplitButtonLane: true,
+            measuredSplitButtonLaneWidth: measuredWidth
+        )
+
+        XCTAssertEqual(layout.maximumSplitButtonLaneWidth, 630)
+        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, measuredWidth)
+        XCTAssertEqual(layout.trailingTabContentInset, measuredWidth)
+        XCTAssertFalse(layout.splitButtonLaneOverflowsViewport)
+    }
+
     func testTabBarLayoutKeepsMeasuredLaneWhenItFitsQuarterOfAvailableWidth() {
         let layout = TabBarLayout(
             tabBarHeight: 28,

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1243,6 +1243,42 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testRequestTabZoomToggleUsesHostHandler() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Zoom target")!
+        var requestedTabId: TabID?
+        var requestedPaneId: PaneID?
+        controller.onTabZoomToggleRequest = { tabId, paneId in
+            requestedTabId = tabId
+            requestedPaneId = paneId
+            return true
+        }
+
+        XCTAssertTrue(controller.requestTabZoomToggle(for: tabId, inPane: pane))
+
+        XCTAssertEqual(requestedTabId, tabId)
+        XCTAssertEqual(requestedPaneId, pane)
+        XCTAssertNil(controller.zoomedPaneId)
+    }
+
+    @MainActor
+    func testRequestTabZoomToggleFallsBackToInternalZoom() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Zoom target")!
+        guard controller.splitPane(pane, orientation: .horizontal) != nil else {
+            return XCTFail("Expected splitPane to create a new pane")
+        }
+
+        XCTAssertTrue(controller.requestTabZoomToggle(for: tabId, inPane: pane))
+        XCTAssertEqual(controller.zoomedPaneId, pane)
+
+        XCTAssertTrue(controller.requestTabZoomToggle(for: tabId, inPane: pane))
+        XCTAssertNil(controller.zoomedPaneId)
+    }
+
+    @MainActor
     func testSplitClearsExistingPaneZoom() {
         let controller = BonsplitController()
         guard let originalPane = controller.focusedPaneId else {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1326,16 +1326,24 @@ final class BonsplitTests: XCTestCase {
             canMoveToRightPane: true,
             isZoomed: false,
             hasSplits: true,
-            moveDestinations: [
-                TabContextMoveDestination(id: "workspace:abc", title: "Workspace A", isEnabled: false)
-            ],
             shortcuts: [:]
         )
-        let snapshot = TabContextMenuSnapshot(tabId: UUID(), state: state)
+        var moveDestinationRequestCount = 0
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: state,
+            moveDestinationsProvider: {
+                moveDestinationRequestCount += 1
+                return [
+                    TabContextMoveDestination(id: "workspace:abc", title: "Workspace A", isEnabled: false)
+                ]
+            }
+        )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
         let moveItem = menu.items.first { $0.title == "Move Tab" }
 
+        XCTAssertEqual(moveDestinationRequestCount, 1)
         XCTAssertNotNil(moveItem)
         XCTAssertTrue(moveItem?.isEnabled ?? false)
         XCTAssertEqual(moveItem?.submenu?.items.map(\.title), ["Move Tab to New Workspace", "Workspace A"])


### PR DESCRIPTION
This supports manaflow-ai/cmux#4101 by moving tab move-destination enumeration out of TabBarView body/render work. Destinations are now resolved only when AppKit builds the context menu, which avoids cross-window workspace scans during terminal churn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer resolving tab move destinations until the context menu opens, route tab-header zoom through a host-owned hook, and let the split-button lane use empty tab bar space before clipping. This reduces TabBarView work, prevents premature overflow, and keeps zoom flows consistent with manaflow-ai/cmux#4101.

- **New Features**
  - Added `BonsplitController.requestTabZoomToggle(for:inPane:)` with `onTabZoomToggleRequest` (@MainActor). Double-click on a tab header calls this; falls back to internal zoom when no handler is set. Tests cover both paths.
  - Build the Move Tab submenu lazily via a `moveDestinationsProvider` on `TabItemView`/`TabContextMenuSnapshot`; enabled state comes from the provider result. Tests verify single evaluation and correct items.

- **Bug Fixes**
  - Split-button lane now uses trailing whitespace before applying the max-width fraction cap, avoiding early overflow.
  - Track `tabContentWidthExcludingSplitButtonLane` via geometry and pass it into `TabBarLayout` to compute the new limit. Tests cover the trailing-whitespace behavior.

<sup>Written for commit 210cb388a94d691608e077f9bc8f99393c1679ea. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/122?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tab context menu performance by refactoring to compute destination options dynamically when needed, rather than precomputing them upfront. This improves efficiency in tab operations and menu interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/122)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->