### PR TITLE
Fix split action lane clipping before empty tab space

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -365,7 +365,16 @@ struct TabBarLayout: Equatable {
 
     var maximumSplitButtonLaneWidth: CGFloat {
         guard availableWidth > 0 else { return fullSplitButtonLaneWidth }
-        return availableWidth * TabBarStyling.maximumSplitButtonLaneWidthFraction
+        let fractionLimit = availableWidth * TabBarStyling.maximumSplitButtonLaneWidthFraction
+        return max(fractionLimit, trailingWhitespaceBeforeSplitButtonLane)
+    }
+
+    var trailingWhitespaceBeforeSplitButtonLane: CGFloat {
+        guard availableWidth > 0,
+              let tabContentWidthExcludingSplitButtonLane else {
+            return 0
+        }
+        return max(0, availableWidth - tabContentWidthExcludingSplitButtonLane)
     }
 
     var visibleSplitButtonLaneWidth: CGFloat {
@@ -764,6 +773,7 @@ struct TabBarView: View {
     @State private var dropLifecycle: TabDropLifecycle = .idle
     @State private var scrollOffset: CGFloat = 0
     @State private var contentWidth: CGFloat = 0
+    @State private var tabContentWidthExcludingSplitButtonLane: CGFloat?
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
     @State private var tabFramesInBar: [UUID: CGRect] = [:]
@@ -806,6 +816,7 @@ struct TabBarView: View {
         TabBarLayout(
             tabBarHeight: appearance.tabBarHeight,
             availableWidth: containerWidth,
+            tabContentWidthExcludingSplitButtonLane: tabContentWidthExcludingSplitButtonLane,
             splitButtonCount: visibleSplitButtons.count,
             splitButtonLaneVisible: shouldShowSplitButtons,
             reservesSplitButtonLane: showSplitButtons && !isMinimalMode,
@@ -947,13 +958,11 @@ struct TabBarView: View {
                             GeometryReader { contentGeo in
                                 Color.clear
                                     .onChange(of: contentGeo.frame(in: .named("tabScroll"))) { _, newFrame in
-                                        scrollOffset = -newFrame.minX
-                                        contentWidth = newFrame.width
+                                        updateTabScrollContent(frame: newFrame)
                                     }
                                     .onAppear {
                                         let frame = contentGeo.frame(in: .named("tabScroll"))
-                                        scrollOffset = -frame.minX
-                                        contentWidth = frame.width
+                                        updateTabScrollContent(frame: frame)
                                     }
                             }
                         )
@@ -1537,6 +1546,12 @@ struct TabBarView: View {
     private func updateSplitButtonScrollContent(frame: CGRect) {
         splitButtonScrollOffset = max(0, -frame.minX)
         splitButtonContentWidth = frame.width
+    }
+
+    private func updateTabScrollContent(frame: CGRect) {
+        scrollOffset = -frame.minX
+        contentWidth = frame.width
+        tabContentWidthExcludingSplitButtonLane = max(0, frame.width - tabBarLayout.trailingTabContentInset)
     }
 
     @ViewBuilder

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -329,6 +329,7 @@ enum TabBarStyling {
 struct TabBarLayout: Equatable {
     let barHeight: CGFloat
     let availableWidth: CGFloat
+    let tabContentWidthExcludingSplitButtonLane: CGFloat?
     let splitButtonCount: Int
     let splitButtonLaneVisible: Bool
     let reservesSplitButtonLane: Bool
@@ -337,6 +338,7 @@ struct TabBarLayout: Equatable {
     init(
         tabBarHeight: CGFloat,
         availableWidth: CGFloat = 0,
+        tabContentWidthExcludingSplitButtonLane: CGFloat? = nil,
         splitButtonCount: Int,
         splitButtonLaneVisible: Bool,
         reservesSplitButtonLane: Bool,
@@ -344,6 +346,7 @@ struct TabBarLayout: Equatable {
     ) {
         self.barHeight = max(1, tabBarHeight)
         self.availableWidth = max(0, availableWidth)
+        self.tabContentWidthExcludingSplitButtonLane = tabContentWidthExcludingSplitButtonLane.map { max(0, $0) }
         self.splitButtonCount = max(0, splitButtonCount)
         self.splitButtonLaneVisible = splitButtonLaneVisible
         self.reservesSplitButtonLane = reservesSplitButtonLane

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3115,9 +3115,9 @@ final class BonsplitTests: XCTestCase {
             showSplitButtons: true,
             size: size,
             configurePane: { pane in
-                let selected = TabItem(title: "", icon: nil)
-                pane.tabs = [selected]
-                pane.selectedTabId = selected.id
+                let tabs = (0..<8).map { _ in TabItem(title: "", icon: nil) }
+                pane.tabs = tabs
+                pane.selectedTabId = tabs.first?.id
             }
         ) { hostingView in
             maximumBrightness(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -422,6 +422,24 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(layout.splitButtonLaneOverflowsViewport)
     }
 
+    func testTabBarLayoutUsesTrailingWhitespaceBeforeClippingSplitButtons() {
+        let measuredWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: 10)
+        let layout = TabBarLayout(
+            tabBarHeight: 28,
+            availableWidth: 930,
+            tabContentWidthExcludingSplitButtonLane: 300,
+            splitButtonCount: 10,
+            splitButtonLaneVisible: true,
+            reservesSplitButtonLane: true,
+            measuredSplitButtonLaneWidth: measuredWidth
+        )
+
+        XCTAssertEqual(layout.maximumSplitButtonLaneWidth, 630)
+        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, measuredWidth)
+        XCTAssertEqual(layout.trailingTabContentInset, measuredWidth)
+        XCTAssertFalse(layout.splitButtonLaneOverflowsViewport)
+    }
+
     func testTabBarLayoutKeepsMeasuredLaneWhenItFitsQuarterOfAvailableWidth() {
         let layout = TabBarLayout(
             tabBarHeight: 28,


### PR DESCRIPTION
## Summary
- add a layout regression covering split action buttons using trailing empty tab-bar space before clipping
- let the split action lane expand into measured trailing whitespace before falling back to the fractional cap

## Testing
- Not run locally; cmux workspace instructions prohibit local test runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the split action lane to use trailing empty tab bar space before the fractional cap to prevent early clipping of split buttons. Addresses Linear issue 4110.

- **Bug Fixes**
  - Use trailing whitespace to raise `maximumSplitButtonLaneWidth` when it exceeds the fraction cap.
  - Track and pass `tabContentWidthExcludingSplitButtonLane` from tab scroll geometry into layout.
  - Add tests for whitespace behavior and keep the overflow fixture crowded to avoid false positives.

<sup>Written for commit e1d9954a027aa35afe003b0ebdbf81875258e171. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab bar split-button lane width calculations to prevent overflow and ensure correct viewport positioning.

* **Tests**
  * Added test coverage validating split-button lane width constraints and positioning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/123)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->