### PR TITLE
Fix tab indicator selection chrome

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarButtonAnimationPolicy.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarButtonAnimationPolicy.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum TabBarButtonAnimationPolicy {
+    static let disablesIncidentalButtonAnimations = false
+}

--- a/Sources/Bonsplit/Internal/Styling/TabBarButtonAnimationPolicy.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarButtonAnimationPolicy.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-enum TabBarButtonAnimationPolicy {
-    static let disablesIncidentalButtonAnimations = true
-}

--- a/Sources/Bonsplit/Internal/Styling/TabBarButtonAnimationPolicy.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarButtonAnimationPolicy.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 enum TabBarButtonAnimationPolicy {
-    static let disablesIncidentalButtonAnimations = false
+    static let disablesIncidentalButtonAnimations = true
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1019,7 +1019,7 @@ struct TabBarView: View {
             splitButtonBackdropChrome
                 .opacity(shouldShowSplitButtons ? 1 : 0)
                 .allowsHitTesting(false)
-                .animation(.easeInOut(duration: 0.14), value: shouldShowSplitButtons)
+                .tabBarButtonAnimationsDisabled()
         }
         .overlay(maskedTabBarBottomSeparatorChrome)
         .overlay {
@@ -1050,10 +1050,10 @@ struct TabBarView: View {
             onDoubleClick: {
                 performNewTerminalSplitButtonAction()
             },
-            onHoverChanged: { isHoveringTabBar = $0 }
+            onHoverChanged: { updateTabBarHover($0) }
         ))
         .overlay(
-            TabBarHoverTrackingView { isHoveringTabBar = $0 }
+            TabBarHoverTrackingView { updateTabBarHover($0) }
         )
         .overlay(
             TabBarManualReorderTrackingView(
@@ -1103,6 +1103,12 @@ struct TabBarView: View {
     }
 
     // MARK: - Tab Item
+
+    private func updateTabBarHover(_ hovering: Bool) {
+        withTransaction(Transaction(animation: nil)) {
+            isHoveringTabBar = hovering
+        }
+    }
 
     @ViewBuilder
     private func tabItem(for tab: TabItem, at index: Int) -> some View {
@@ -1360,8 +1366,8 @@ struct TabBarView: View {
                 .saturation(tabBarSaturation)
                 .opacity(shouldShowSplitButtons ? 1 : 0)
                 .allowsHitTesting(shouldShowSplitButtons)
-            .frame(height: tabBarHeight, alignment: .trailing)
-            .animation(.easeInOut(duration: 0.14), value: shouldShowSplitButtons)
+                .frame(height: tabBarHeight, alignment: .trailing)
+                .tabBarButtonAnimationsDisabled()
         }
     }
 
@@ -1863,7 +1869,7 @@ private struct SplitActionButtonStyle: ButtonStyle {
             .contentShape(Rectangle())
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
             .opacity(configuration.isPressed ? 0.72 : 1.0)
-            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+            .tabBarButtonAnimationsDisabled()
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1656,6 +1656,7 @@ struct TabBarView: View {
         }
         .frame(width: laneWidth, height: tabBarHeight, alignment: .trailing)
         .contentShape(Rectangle())
+        .compositingGroup()
         .clipped()
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -478,7 +478,7 @@ struct TabBarLayout: Equatable {
     }
 
     var maximumSplitButtonLaneWidth: CGFloat {
-        guard availableWidth > 0 else { return fullSplitButtonLaneWidth }
+        guard availableWidth > 0 else { return 0 }
         let fractionLimit = availableWidth * TabBarStyling.maximumSplitButtonLaneWidthFraction
         return max(fractionLimit, trailingWhitespaceBeforeSplitButtonLane)
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -485,7 +485,8 @@ struct TabBarLayout: Equatable {
 
     var trailingWhitespaceBeforeSplitButtonLane: CGFloat {
         guard availableWidth > 0,
-              let tabContentWidthExcludingSplitButtonLane else {
+              let tabContentWidthExcludingSplitButtonLane,
+              tabContentWidthExcludingSplitButtonLane > 0 else {
             return 0
         }
         return max(0, availableWidth - tabContentWidthExcludingSplitButtonLane)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -47,16 +47,6 @@ public enum BonsplitTabBarHitRegionRegistry {
     }
 }
 
-private struct SelectedTabFramePreferenceKey: PreferenceKey {
-    static let defaultValue: CGRect? = nil
-
-    static func reduce(value: inout CGRect?, nextValue: () -> CGRect?) {
-        if let next = nextValue() {
-            value = next
-        }
-    }
-}
-
 private struct TabFramePreferenceKey: PreferenceKey {
     static let defaultValue: [UUID: CGRect] = [:]
 
@@ -249,6 +239,14 @@ enum TabBarStyling {
 
     static func splitActionButtonImage(from data: Data) -> NSImage? {
         SplitActionButtonImageCache.shared.image(for: data)
+    }
+
+    static func selectedTabFrame(
+        selectedTabId: UUID?,
+        tabFrames: [UUID: CGRect]
+    ) -> CGRect? {
+        guard let selectedTabId else { return nil }
+        return tabFrames[selectedTabId]
     }
 
     enum ScrollTarget: Equatable {
@@ -762,7 +760,6 @@ struct TabBarView: View {
     @State private var scrollOffset: CGFloat = 0
     @State private var contentWidth: CGFloat = 0
     @State private var containerWidth: CGFloat = 0
-    @State private var selectedTabFrameInBar: CGRect?
     @State private var tabFramesInBar: [UUID: CGRect] = [:]
     @State private var measuredSplitButtonLaneWidth: CGFloat = 0
     @State private var splitButtonScrollOffset: CGFloat = 0
@@ -847,6 +844,13 @@ struct TabBarView: View {
 
     private var trailingTabContentInset: CGFloat {
         tabBarLayout.trailingTabContentInset
+    }
+
+    private var selectedTabFrameInBar: CGRect? {
+        TabBarStyling.selectedTabFrame(
+            selectedTabId: pane.selectedTabId,
+            tabFrames: tabFramesInBar
+        )
     }
 
     private var leadingScrollAnchorId: String {
@@ -1088,11 +1092,10 @@ struct TabBarView: View {
         .onAppear {
             controlKeyMonitor.start()
         }
-        .onPreferenceChange(SelectedTabFramePreferenceKey.self) { frame in
-            selectedTabFrameInBar = frame
-        }
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
-            tabFramesInBar = frames
+            withTransaction(Transaction(animation: nil)) {
+                tabFramesInBar = frames
+            }
         }
         .onPreferenceChange(SplitButtonLaneWidthPreferenceKey.self) { width in
             measuredSplitButtonLaneWidth = width
@@ -1167,10 +1170,6 @@ struct TabBarView: View {
             GeometryReader { geometry in
                 let frame = geometry.frame(in: .named("tabBar"))
                 Color.clear
-                    .preference(
-                        key: SelectedTabFramePreferenceKey.self,
-                        value: pane.selectedTabId == tab.id ? frame : nil
-                    )
                     .preference(
                         key: TabFramePreferenceKey.self,
                         value: [tab.id: frame]

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1494,6 +1494,12 @@ struct TabBarView: View {
     private var splitButtonChrome: some View {
         if shouldRenderSplitButtons {
             splitButtons
+                .frame(width: splitButtonsBackdropWidth, height: tabBarHeight, alignment: .trailing)
+                .mask {
+                    Rectangle()
+                        .frame(width: splitButtonsBackdropWidth, height: tabBarHeight)
+                }
+                .clipped()
                 .saturation(tabBarSaturation)
                 .opacity(shouldShowSplitButtons ? 1 : 0)
                 .allowsHitTesting(shouldShowSplitButtons)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -9,6 +9,13 @@ extension View {
     func tabControlShortcutHintVisibilityAnimation<Value: Equatable>(value: Value) -> some View {
         animation(TabControlShortcutHintAnimation.visibility, value: value)
     }
+
+    func tabBarButtonAnimationsDisabled() -> some View {
+        transaction { transaction in
+            transaction.animation = nil
+            transaction.disablesAnimations = true
+        }
+    }
 }
 
 private enum TabControlShortcutHintDebugSettings {
@@ -164,10 +171,13 @@ struct TabItemView: View {
                     }
                     .buttonStyle(.plain)
                     .onHover { hovering in
-                        isZoomHovered = hovering
+                        withTransaction(Transaction(animation: nil)) {
+                            isZoomHovered = hovering
+                        }
                     }
                     .saturation(saturation)
                     .accessibilityLabel("Exit zoom")
+                    .tabBarButtonAnimationsDisabled()
                 }
             }
 
@@ -201,8 +211,9 @@ struct TabItemView: View {
             onSelect()
         }
         .onHover { hovering in
-            // Keep icon rendering stable while hovering; only accessory/background elements animate.
-            isHovered = hovering
+            withTransaction(Transaction(animation: nil)) {
+                isHovered = hovering
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(tab.title)
@@ -426,14 +437,15 @@ struct TabItemView: View {
                 }
                 .buttonStyle(.plain)
                 .onHover { hovering in
-                    isCloseHovered = hovering
+                    withTransaction(Transaction(animation: nil)) {
+                        isCloseHovered = hovering
+                    }
                 }
                 .saturation(saturation)
             }
         }
         .frame(width: accessorySlotSize, height: accessorySlotSize)
-        .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: isHovered)
-        .animation(.easeInOut(duration: TabBarMetrics.hoverDuration), value: isCloseHovered)
+        .tabBarButtonAnimationsDisabled()
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -13,7 +13,6 @@ extension View {
     func tabBarButtonAnimationsDisabled() -> some View {
         transaction { transaction in
             transaction.animation = nil
-            transaction.disablesAnimations = true
         }
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3458,9 +3458,9 @@ final class BonsplitTests: XCTestCase {
             maximumBrightness(
                 in: hostingView,
                 sampleRect: NSRect(
-                    x: 100,
+                    x: size.width - splitButtonLaneWidth - 16,
                     y: 5,
-                    width: size.width - splitButtonLaneWidth - 108,
+                    width: 8,
                     height: size.height - 10
                 )
             )

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3600,6 +3600,7 @@ final class BonsplitTests: XCTestCase {
         return renderedTabBarValue(
             isFocused: true,
             appearance: appearance,
+            size: NSSize(width: 320, height: TabBarMetrics.barHeight),
             configurePane: { pane in
                 let leading = TabItem(title: "", icon: nil)
                 let selected = TabItem(title: "", icon: nil)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -223,13 +223,6 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(defaults.splitDown, "Split Down")
     }
 
-    func testTabBarButtonChromeDisablesIncidentalAnimations() {
-        XCTAssertTrue(
-            TabBarButtonAnimationPolicy.disablesIncidentalButtonAnimations,
-            "Tab bar button hover/press/visibility chrome must not animate; rapid shortcut tab selection should not inherit stale button animation transactions."
-        )
-    }
-
     func testDefaultSplitActionButtons() {
         XCTAssertEqual(
             BonsplitConfiguration.SplitActionButton.defaults,
@@ -602,6 +595,56 @@ final class BonsplitTests: XCTestCase {
             indicatorFrame?.maxX ?? 0,
             239,
             accuracy: 0.001
+        )
+    }
+
+    func testTabBarSelectedChromeFrameFollowsCurrentSelection() {
+        let firstTabId = UUID()
+        let secondTabId = UUID()
+        let layout = TabBarLayout(
+            tabBarHeight: 28,
+            splitButtonCount: 0,
+            splitButtonLaneVisible: false,
+            reservesSplitButtonLane: false
+        )
+        let frames = [
+            firstTabId: CGRect(x: 12, y: 0, width: 120, height: 28),
+            secondTabId: CGRect(x: 144, y: 0, width: 96, height: 28),
+        ]
+        let totalWidth: CGFloat = 300
+
+        let firstSelectedFrame = TabBarStyling.selectedTabFrame(
+            selectedTabId: firstTabId,
+            tabFrames: frames
+        )
+        let secondSelectedFrame = TabBarStyling.selectedTabFrame(
+            selectedTabId: secondTabId,
+            tabFrames: frames
+        )
+        let firstIndicatorFrame = layout.selectedIndicatorFrame(
+            selectedTabFrame: firstSelectedFrame,
+            totalWidth: totalWidth
+        )
+        let secondIndicatorFrame = layout.selectedIndicatorFrame(
+            selectedTabFrame: secondSelectedFrame,
+            totalWidth: totalWidth
+        )
+
+        XCTAssertEqual(firstIndicatorFrame?.minX, frames[firstTabId]?.minX)
+        XCTAssertEqual(
+            secondIndicatorFrame?.minX,
+            frames[secondTabId]?.minX,
+            "Selected tab chrome must be derived from the current selected tab id, not a cached frame from a previous selection."
+        )
+        let nilSelectedFrame = TabBarStyling.selectedTabFrame(
+            selectedTabId: nil,
+            tabFrames: frames
+        )
+        XCTAssertNil(
+            layout.selectedIndicatorFrame(
+                selectedTabFrame: nilSelectedFrame,
+                totalWidth: totalWidth
+            )
         )
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -408,7 +408,6 @@ final class BonsplitTests: XCTestCase {
             + (3 * TabBarStyling.splitButtonsSpacing)
         let layout = TabBarLayout(
             tabBarHeight: 28,
-            availableWidth: 800,
             splitButtonCount: 4,
             splitButtonLaneVisible: true,
             reservesSplitButtonLane: true,
@@ -424,6 +423,7 @@ final class BonsplitTests: XCTestCase {
     func testTabBarLayoutExpandsForMeasuredSplitButtonLaneWidth() {
         let layout = TabBarLayout(
             tabBarHeight: 28,
+            availableWidth: 800,
             splitButtonCount: 4,
             splitButtonLaneVisible: true,
             reservesSplitButtonLane: true,

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3450,7 +3450,7 @@ final class BonsplitTests: XCTestCase {
             showSplitButtons: true,
             size: size,
             configurePane: { pane in
-                let tabs = (0..<8).map { _ in TabItem(title: "", icon: nil) }
+                let tabs = (0..<16).map { _ in TabItem(title: "", icon: nil) }
                 pane.tabs = tabs
                 pane.selectedTabId = tabs.first?.id
             }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -451,6 +451,22 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(layout.splitButtonLaneOverflowsViewport)
     }
 
+    func testTabBarLayoutDoesNotTreatZeroTabContentAsTrailingWhitespace() {
+        let layout = TabBarLayout(
+            tabBarHeight: 28,
+            availableWidth: 240,
+            tabContentWidthExcludingSplitButtonLane: 0,
+            splitButtonCount: 12,
+            splitButtonLaneVisible: true,
+            reservesSplitButtonLane: true,
+            measuredSplitButtonLaneWidth: 400
+        )
+
+        XCTAssertEqual(layout.maximumSplitButtonLaneWidth, 60)
+        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, 60)
+        XCTAssertEqual(layout.trailingTabContentInset, 60)
+    }
+
     func testTabBarLayoutUsesTrailingWhitespaceBeforeClippingSplitButtons() {
         let measuredWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: 10)
         let layout = TabBarLayout(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -408,6 +408,7 @@ final class BonsplitTests: XCTestCase {
             + (3 * TabBarStyling.splitButtonsSpacing)
         let layout = TabBarLayout(
             tabBarHeight: 28,
+            availableWidth: 800,
             splitButtonCount: 4,
             splitButtonLaneVisible: true,
             reservesSplitButtonLane: true,

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -223,6 +223,13 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(defaults.splitDown, "Split Down")
     }
 
+    func testTabBarButtonChromeDisablesIncidentalAnimations() {
+        XCTAssertTrue(
+            TabBarButtonAnimationPolicy.disablesIncidentalButtonAnimations,
+            "Tab bar button hover/press/visibility chrome must not animate; rapid shortcut tab selection should not inherit stale button animation transactions."
+        )
+    }
+
     func testDefaultSplitActionButtons() {
         XCTAssertEqual(
             BonsplitConfiguration.SplitActionButton.defaults,


### PR DESCRIPTION
## Summary
- Merges the tab indicator glitch fix onto the current Bonsplit main line.
- Keeps minimal-mode tab hit-region handling from main while deriving selected chrome from the current selected tab id and measured tab frames.
- Suppresses incidental tab-bar hover/press/visibility animations so selection chrome snaps immediately during rapid switching.

## Testing
- Not run locally per cmux repo policy; this PR is opened to satisfy protected-branch flow for the cmux submodule pointer.

Supports manaflow-ai/cmux#3969.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tab indicator so it always follows the current selection and snaps instantly during rapid switches. Disables tab-bar button animations and hard-contains the split action lane to prevent flicker, bleed, and startup layout jumps.

- **Bug Fixes**
  - Derive the indicator frame from `pane.selectedTabId` and measured tab frames via `TabBarStyling.selectedTabFrame(...)`, removing `SelectedTabFramePreferenceKey`. Added a unit test confirming it tracks the current selection and returns nil when none is selected.
  - Disable button/hover/press animations with `.tabBarButtonAnimationsDisabled()` and use no-animation transactions for hover tracking and tab-frame preference updates (including split buttons).
  - Contain the split action lane: mask and hard-clip it, frame it to the backdrop width, disable its visibility animations, return 0 width when the container is unmeasured, and ignore zero tab-content width when computing whitespace. Added tests for the zero-width and crowded-overflow cases, and updated the overflow sampler to check the lane edge.

<sup>Written for commit e093031f8d21daefc19d3a6bfd725ca8556798fb. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/125?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tab bar animation handling to prevent unnecessary animations during tab selection and hover interactions.
  * Improved tab hover state updates with more precise animation control.

* **Tests**
  * Added test to verify tab bar selected indicator positioning follows the currently selected tab.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->