### PR TITLE
Fix minimal tab drag edge hit testing

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -168,11 +168,7 @@ enum TabBarColors {
             return activeTabBackground
         }
         if appearance.usesSharedBackdrop {
-            let semanticBackground = semanticTabBarBackgroundColor(for: appearance) ?? custom
-            let overlayColor = semanticBackground.isBonsplitLightColor
-                ? NSColor.black.withAlphaComponent(0.06)
-                : NSColor.white.withAlphaComponent(0.08)
-            return Color(nsColor: overlayColor)
+            return .clear
         }
         let adjusted = custom.isBonsplitLightColor
             ? custom.bonsplitDarken(by: 0.065)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -97,6 +97,25 @@ public enum BonsplitTabItemHitRegionRegistry {
     }
 }
 
+enum BonsplitTabItemHitTesting {
+    static let horizontalSlop: CGFloat = 2
+    static let verticalSlop: CGFloat = 6
+
+    static func containsTabLaneHit(
+        localPoint: NSPoint,
+        tabFrames: [CGRect],
+        bounds: NSRect
+    ) -> Bool {
+        guard bounds.insetBy(dx: 0, dy: -verticalSlop).contains(localPoint) else {
+            return false
+        }
+        return tabFrames.contains { frame in
+            localPoint.x >= frame.minX - horizontalSlop
+                && localPoint.x <= frame.maxX + horizontalSlop
+        }
+    }
+}
+
 private struct TabItemHitRegionView: NSViewRepresentable {
     func makeNSView(context: Context) -> RegionNSView {
         RegionNSView()
@@ -150,7 +169,12 @@ private struct TabItemHitRegionView: NSViewRepresentable {
         }
 
         nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
-            hitBounds.insetBy(dx: -2, dy: -2).contains(localPoint)
+            hitBounds
+                .insetBy(
+                    dx: -BonsplitTabItemHitTesting.horizontalSlop,
+                    dy: -BonsplitTabItemHitTesting.verticalSlop
+                )
+                .contains(localPoint)
         }
 
         override func hitTest(_ point: NSPoint) -> NSView? {
@@ -2464,8 +2488,11 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         }
 
         nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
-            let paddedFrames = tabFrames.map { $0.insetBy(dx: -2, dy: -2) }
-            return paddedFrames.contains { $0.contains(localPoint) }
+            BonsplitTabItemHitTesting.containsTabLaneHit(
+                localPoint: localPoint,
+                tabFrames: tabFrames,
+                bounds: bounds
+            )
         }
 
         override func updateTrackingAreas() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1264,6 +1264,28 @@ final class BonsplitTests: XCTestCase {
         XCTAssertLessThan(hoverAlpha, 0.12)
     }
 
+    func testSharedBackdropActiveTabBackgroundIsClear() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(
+                backgroundHex: "#272822",
+                tabBarBackgroundHex: "#00000000",
+                splitButtonBackdropHex: "#00000000",
+                paneBackgroundHex: "#00000000"
+            ),
+            usesSharedBackdrop: true
+        )
+        let active = NSColor(TabBarColors.activeTabBackground(for: appearance)).usingColorSpace(.sRGB)!
+
+        var alpha: CGFloat = 1
+        active.getRed(nil, green: nil, blue: nil, alpha: &alpha)
+
+        XCTAssertLessThan(
+            alpha,
+            0.01,
+            "Shared-backdrop selected tabs should rely on the active indicator instead of a hover-like fill"
+        )
+    }
+
     func testSplitActionPressedStateUsesHigherContrast() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(backgroundHex: "#272822")
@@ -1714,6 +1736,15 @@ final class BonsplitTests: XCTestCase {
             "A short-titled tab must own the full configured visible tab width so minimal-mode drags do not become window drags"
         )
 
+        let topEdgeTabPoint = hostingView.convert(
+            NSPoint(x: appearance.tabMinWidth - 20, y: appearance.tabBarHeight + 3),
+            to: nil
+        )
+        XCTAssertTrue(
+            BonsplitTabItemHitRegionRegistry.containsWindowPoint(topEdgeTabPoint, in: window),
+            "A tab's horizontal lane must own near-titlebar-edge drags so minimal-mode top-edge tab drags do not become window drags"
+        )
+
         let emptyChromePoint = hostingView.convert(
             NSPoint(x: appearance.tabMinWidth + 30, y: verticalCenter),
             to: nil
@@ -1721,6 +1752,15 @@ final class BonsplitTests: XCTestCase {
         XCTAssertFalse(
             BonsplitTabItemHitRegionRegistry.containsWindowPoint(emptyChromePoint, in: window),
             "Empty tab-strip chrome after the configured tab remains available for app-window dragging"
+        )
+
+        let topEdgeEmptyChromePoint = hostingView.convert(
+            NSPoint(x: appearance.tabMinWidth + 30, y: appearance.tabBarHeight + 3),
+            to: nil
+        )
+        XCTAssertFalse(
+            BonsplitTabItemHitRegionRegistry.containsWindowPoint(topEdgeEmptyChromePoint, in: window),
+            "Near-titlebar-edge empty chrome after the tab should remain available for app-window dragging"
         )
     }
 


### PR DESCRIPTION
## Summary
- Keep tab hit ownership across the near-titlebar edge in shared-backdrop/minimal tab bars so tab drags do not fall through to app-window dragging.
- Clear the shared-backdrop active tab fill so the selected tab does not retain a hover-like gray highlight.
- Add runtime tests covering edge hit ownership and shared-backdrop active background color.

## Verification
- Not run locally; this repository uses CI for tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab drag hit testing so minimal/shared-backdrop tabs keep hit ownership near the titlebar edge and don’t fall through to window dragging. Also clears the active tab fill in shared-backdrop mode to remove the hover-like gray highlight.

- **Bug Fixes**
  - Keep tab-lane hit ownership across the near-titlebar edge in minimal/shared-backdrop mode.
  - Return `.clear` for shared-backdrop active tab background in `TabBarColors`.
  - Add tests for edge hit behavior and active tab background alpha.

<sup>Written for commit c39e2ce07f719d24510fe11d89b8186176a31e86. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed active tab background color rendering to ensure proper visual appearance in certain display modes.

* **Refactor**
  * Improved the tab interaction hit detection system for more reliable and accurate click and drag handling across various user interactions.

* **Tests**
  * Added comprehensive test coverage for active tab appearance rendering verification and tab interaction hit-region behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->