### PR TITLE
Fix compact pane tab visual width

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -98,7 +98,9 @@ public enum BonsplitTabItemHitRegionRegistry {
 }
 
 enum BonsplitTabItemHitTesting {
-    static let horizontalSlop: CGFloat = 2
+    // Hit-test rect is intentionally larger than visual chrome. Do not bump
+    // visible tab padding/width to fix drag affordance; see cmux #4290 / #4433.
+    static let horizontalSlop: CGFloat = 10
     static let verticalSlop: CGFloat = 6
 
     static func containsTabLaneHit(
@@ -2797,7 +2799,9 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 guard isMouseDownOrDragCandidate else { return false }
                 let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
                 guard point.x < trailingLimit else { return false }
-                let paddedFrames = tabFrames.map { $0.insetBy(dx: -2, dy: -2) }
+                let paddedFrames = tabFrames.map {
+                    $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
+                }
                 guard !paddedFrames.contains(where: { $0.contains(point) }) else { return false }
                 let startX = paddedFrames.map(\.maxX).max() ?? bounds.minX
                 return point.x >= startX
@@ -2814,7 +2818,9 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
                 guard trailingLimit > bounds.minX else { return [] }
 
-                let paddedFrames = tabFrames.map { $0.insetBy(dx: -2, dy: -2) }
+                let paddedFrames = tabFrames.map {
+                    $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
+                }
                 let startX = max(bounds.minX, paddedFrames.map(\.maxX).max() ?? bounds.minX)
                 guard trailingLimit > startX else { return [] }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -41,7 +41,7 @@ enum TabItemStyling {
     }
 
     static func tabWidthRange(for appearance: BonsplitConfiguration.Appearance) -> ClosedRange<CGFloat> {
-        let minimum = max(1, appearance.tabMinWidth)
+        let minimum = max(1, TabBarMetrics.tabMinWidth)
         let maximum = max(minimum, appearance.tabMaxWidth)
         return minimum...maximum
     }
@@ -200,7 +200,7 @@ struct TabItemView: View {
         )
         .background(tabBackground.saturation(saturation))
         .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
-        .contentShape(Rectangle())
+        .contentShape(Rectangle().inset(by: -BonsplitTabItemHitTesting.horizontalSlop))
         // Middle click to close (macOS convention).
         // Uses an AppKit event monitor so it doesn't interfere with left click selection or drag/reorder.
         .background(MiddleClickMonitorView(onMiddleClick: {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1688,7 +1688,7 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testShortConfiguredTabOwnsFullConfiguredHitWidth() {
+    func testShortConfiguredTabKeepsCompactChromeWithExpandedHitSlop() {
         let appearance = BonsplitConfiguration.Appearance(
             tabMinWidth: 140,
             tabMaxWidth: 220,
@@ -1727,17 +1727,18 @@ final class BonsplitTests: XCTestCase {
         contentView.layoutSubtreeIfNeeded()
 
         let verticalCenter = appearance.tabBarHeight / 2
-        let configuredTabPoint = hostingView.convert(
-            NSPoint(x: appearance.tabMinWidth - 20, y: verticalCenter),
+        let compactTabHitEdge = TabBarMetrics.tabMinWidth + BonsplitTabItemHitTesting.horizontalSlop
+        let expandedHitPoint = hostingView.convert(
+            NSPoint(x: compactTabHitEdge - 2, y: verticalCenter),
             to: nil
         )
         XCTAssertTrue(
-            BonsplitTabItemHitRegionRegistry.containsWindowPoint(configuredTabPoint, in: window),
-            "A short-titled tab must own the full configured visible tab width so minimal-mode drags do not become window drags"
+            BonsplitTabItemHitRegionRegistry.containsWindowPoint(expandedHitPoint, in: window),
+            "A short-titled tab should keep compact visible chrome while owning a small expanded hit rect for minimal-mode drags"
         )
 
         let topEdgeTabPoint = hostingView.convert(
-            NSPoint(x: appearance.tabMinWidth - 20, y: appearance.tabBarHeight + 3),
+            NSPoint(x: compactTabHitEdge - 2, y: appearance.tabBarHeight + 3),
             to: nil
         )
         XCTAssertTrue(
@@ -1746,7 +1747,7 @@ final class BonsplitTests: XCTestCase {
         )
 
         let emptyChromePoint = hostingView.convert(
-            NSPoint(x: appearance.tabMinWidth + 30, y: verticalCenter),
+            NSPoint(x: compactTabHitEdge + 24, y: verticalCenter),
             to: nil
         )
         XCTAssertFalse(
@@ -1755,7 +1756,7 @@ final class BonsplitTests: XCTestCase {
         )
 
         let topEdgeEmptyChromePoint = hostingView.convert(
-            NSPoint(x: appearance.tabMinWidth + 30, y: appearance.tabBarHeight + 3),
+            NSPoint(x: compactTabHitEdge + 24, y: appearance.tabBarHeight + 3),
             to: nil
         )
         XCTAssertFalse(
@@ -2115,12 +2116,12 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
-    func testTabWidthRangeUsesAppearanceMinimum() {
+    func testTabWidthRangeKeepsCompactVisualMinimum() {
         let range = TabItemStyling.tabWidthRange(
             for: BonsplitConfiguration.Appearance(tabMinWidth: 140, tabMaxWidth: 220)
         )
 
-        XCTAssertEqual(range.lowerBound, 140)
+        XCTAssertEqual(range.lowerBound, TabBarMetrics.tabMinWidth)
         XCTAssertEqual(range.upperBound, 220)
     }
 
@@ -2137,7 +2138,7 @@ final class BonsplitTests: XCTestCase {
 
         XCTAssertEqual(
             width,
-            BonsplitConfiguration.Appearance.default.tabMinWidth - TabBarMetrics.activeIndicatorTrailingInset,
+            TabBarMetrics.tabMinWidth - TabBarMetrics.activeIndicatorTrailingInset,
             accuracy: 0.5
         )
     }
@@ -2917,7 +2918,7 @@ final class BonsplitTests: XCTestCase {
 
         XCTAssertEqual(
             view.windowDragCursorRectsForCurrentState(),
-            [NSRect(x: 102, y: 0, width: 170, height: 30)],
+            [NSRect(x: 110, y: 0, width: 162, height: 30)],
             "Minimal mode should show the open-hand cursor only in empty chrome after the tab frames and before action buttons"
         )
     }
@@ -3163,7 +3164,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     private func renderedTabBarIndicatorWidth(isFocused: Bool) -> CGFloat? {
         renderedTabBarValue(isFocused: isFocused) { hostingView in
-            let sampleRect = NSRect(x: 0, y: 0, width: 180, height: 4)
+            let sampleRect = NSRect(x: 0, y: 0, width: 80, height: 4)
             return highSaturationWidth(in: hostingView, sampleRect: sampleRect)
         }
     }
@@ -3665,7 +3666,7 @@ final class BonsplitTests: XCTestCase {
                 pane.selectedTabId = selected.id
             }
         ) { hostingView in
-            let separatorX = BonsplitConfiguration.Appearance.default.tabMinWidth - 0.5
+            let separatorX = TabBarMetrics.tabMinWidth - 0.5
             guard let top = renderedColorInViewCoordinates(in: hostingView, at: NSPoint(x: separatorX, y: 4))?
                 .usingColorSpace(.sRGB)?
                 .alphaComponent,


### PR DESCRIPTION
## Summary\n- restores compact visible pane tab chrome instead of applying the configured drag-hit minimum as visual width\n- keeps #4290-style drag affordance via expanded tab hit-test slop and matching empty-chrome cursor exclusion\n- updates Bonsplit layout tests to distinguish visible chrome width from drag hit width\n\n## Testing\n- Not run locally, per cmux repo policy; CI is the validation gate.\n\nPart of manaflow-ai/cmux#4433.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores compact visual width for pane tabs while keeping drag-friendly hit areas. Addresses manaflow-ai/cmux#4433 and preserves the #4290 drag affordance without widening the tab chrome.

- **Bug Fixes**
  - Keep compact visual min width via `TabBarMetrics.tabMinWidth`; don’t stretch tab chrome to the configured min.
  - Expand tab hit rect by 10px using `BonsplitTabItemHitTesting.horizontalSlop` in both `contentShape` and drag-zone checks; align empty-chrome window-drag cursor region to match.
  - Update tests to assert compact chrome + expanded hit slop, adjust expected cursor rects, and validate indicator width.

<sup>Written for commit 97c4094592e555c8b2f733e698c1037c3bfbf480. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded tappable/clickable area around tabs for improved usability and easier interaction.
  * Enhanced cursor feedback consistency to match updated tab hit-testing regions.
  * Refined tab width sizing calculations for better visual layout consistency.

* **Tests**
  * Updated test suite to reflect new tab geometry metrics and interaction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->