### PR TITLE
Fix right/left pane nav skipping adjacent stacked sub-tree

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -440,10 +440,14 @@ final class SplitViewController {
             return (c.paneId, overlap, distance)
         }
 
-        // Sort: prefer more overlap, then closer distance
+        // Sort: prefer closer distance, then more overlap as a tiebreak.
+        // A farther pane that happens to span more of the perpendicular axis must
+        // not beat an immediately adjacent neighbor — otherwise navigating past a
+        // sub-tree (e.g. a stacked split) skips its halves and lands on whatever
+        // pane is beyond it.
         let sorted = scored.sorted { a, b in
-            if abs(a.1 - b.1) > epsilon { return a.1 > b.1 }
-            return a.2 < b.2
+            if abs(a.2 - b.2) > epsilon { return a.2 < b.2 }
+            return a.1 > b.1
         }
 
         return sorted.first?.0

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -220,7 +220,7 @@ final class BonsplitTests: XCTestCase {
     /// not jump over it to the full-height P3 — even though P3 has more
     /// perpendicular overlap with P1.
     @MainActor
-    func testNavigateRightDoesNotSkipAdjacentStackedPane() {
+    func testNavigateRightDoesNotSkipAdjacentStackedPane() throws {
         let controller = BonsplitController()
         let p1 = controller.focusedPaneId!
 
@@ -228,11 +228,28 @@ final class BonsplitTests: XCTestCase {
         let p3 = controller.splitPane(p2, orientation: .horizontal, withTab: nil)!
         let p2Bottom = controller.splitPane(p2, orientation: .vertical, withTab: nil)!
 
-        let neighbor = controller.adjacentPane(to: p1, direction: .right)
+        let neighbor = try XCTUnwrap(controller.adjacentPane(to: p1, direction: .right))
 
-        XCTAssertNotNil(neighbor)
         XCTAssertNotEqual(neighbor, p3, "Right-navigation skipped the adjacent stacked pane and landed on the far pane.")
         XCTAssertTrue(neighbor == p2 || neighbor == p2Bottom, "Right-navigation should land in the stacked sub-tree (P2-top or P2-bottom).")
+    }
+
+    /// Mirror of the right-navigation case: same `[ P1 | (P2-top / P2-bottom) | P3 ]`
+    /// layout, but going left from P3. The shared `findBestNeighbor` sort must
+    /// also pick the adjacent stacked sub-tree (P2) over the farther full-height P1.
+    @MainActor
+    func testNavigateLeftDoesNotSkipAdjacentStackedPane() throws {
+        let controller = BonsplitController()
+        let p1 = controller.focusedPaneId!
+
+        let p2 = controller.splitPane(p1, orientation: .horizontal, withTab: nil)!
+        let p3 = controller.splitPane(p2, orientation: .horizontal, withTab: nil)!
+        let p2Bottom = controller.splitPane(p2, orientation: .vertical, withTab: nil)!
+
+        let neighbor = try XCTUnwrap(controller.adjacentPane(to: p3, direction: .left))
+
+        XCTAssertNotEqual(neighbor, p1, "Left-navigation skipped the adjacent stacked pane and landed on the far pane.")
+        XCTAssertTrue(neighbor == p2 || neighbor == p2Bottom, "Left-navigation should land in the stacked sub-tree (P2-top or P2-bottom).")
     }
 
     func testDefaultSplitButtonTooltips() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -215,6 +215,26 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(controller.configuration.allowCloseTabs)
     }
 
+    /// Layout: [ P1 | (P2-top / P2-bottom) | P3 ]
+    /// Going right from P1 must land in the adjacent stacked sub-tree (P2),
+    /// not jump over it to the full-height P3 — even though P3 has more
+    /// perpendicular overlap with P1.
+    @MainActor
+    func testNavigateRightDoesNotSkipAdjacentStackedPane() {
+        let controller = BonsplitController()
+        let p1 = controller.focusedPaneId!
+
+        let p2 = controller.splitPane(p1, orientation: .horizontal, withTab: nil)!
+        let p3 = controller.splitPane(p2, orientation: .horizontal, withTab: nil)!
+        let p2Bottom = controller.splitPane(p2, orientation: .vertical, withTab: nil)!
+
+        let neighbor = controller.adjacentPane(to: p1, direction: .right)
+
+        XCTAssertNotNil(neighbor)
+        XCTAssertNotEqual(neighbor, p3, "Right-navigation skipped the adjacent stacked pane and landed on the far pane.")
+        XCTAssertTrue(neighbor == p2 || neighbor == p2Bottom, "Right-navigation should land in the stacked sub-tree (P2-top or P2-bottom).")
+    }
+
     func testDefaultSplitButtonTooltips() {
         let defaults = BonsplitConfiguration.SplitButtonTooltips.default
         XCTAssertEqual(defaults.newTerminal, "New Terminal")


### PR DESCRIPTION
When using keyboard nav, if u have a vertical split next to u and u press right, sometimes it just **skips the split** and yeets u over to the pane after it.

https://github.com/user-attachments/assets/3d1a006e-b3b2-40b6-ba6a-aa6151a3c040
> Notice how you skip over the middle pane

reason: the sort was overlap first, distance second. so a far away tall pane with lots of overlap was beating the pane literally right next to u. lol.

fix: distance first, overlap as the tiebreaker. now right-nav goes into the thing thats actually closest.

## test
added `testNavigateRightDoesNotSkipAdjacentStackedPane`. layout is `[ P1 | (P2-top / P2-bottom) | P3 ]`. going right from P1 should land in P2 (top or bottom), not skip to P3. before: skipped to P3. after: doesnt. nice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782001123&installation_id=133855650&pr_number=128&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F128&signature=14438dd5d205b20ca12226c0be0d941aa82f5ac16b38eb839e67ff527c47113b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pane navigation so horizontal moves don’t skip an adjacent stacked split. We now pick the closest pane first and use perpendicular overlap only as a tiebreaker.

- **Bug Fixes**
  - Sort candidate panes by distance first, then overlap; prevents skipping a stacked sub-tree (e.g., `[ P1 | (P2-top / P2-bottom) | P3 ]`).
  - Tests: added right and left cases to lock this behavior; use `XCTUnwrap` so a nil neighbor fails fast.

<sup>Written for commit dbd9bd5f002e4b3701b893399c8fbb359fd0cb3e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/128?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus navigation to correctly identify and select adjacent panes, preventing navigation from incorrectly skipping nearby panes in complex layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->