### PR TITLE
Show inline rename selection highlight

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -777,6 +777,7 @@ struct TabBarView: View {
     @State private var containerWidth: CGFloat = 0
     @State private var selectedTabFrameInBar: CGRect?
     @State private var tabFramesInBar: [UUID: CGRect] = [:]
+    @State private var inlineRenamingTabId: UUID?
     @State private var measuredSplitButtonLaneWidth: CGFloat = 0
     @State private var splitButtonScrollOffset: CGFloat = 0
     @State private var splitButtonContentWidth: CGFloat = 0
@@ -1075,7 +1076,16 @@ struct TabBarView: View {
                 tabFrames: tabFramesInBar,
                 dropTargetIndex: $dropTargetIndex,
                 dropLifecycle: $dropLifecycle
-            )
+            ) { tabId in
+#if DEBUG
+                dlog("tab.doubleClick.rename pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tabId.uuidString.prefix(5))")
+#endif
+                withTransaction(Transaction(animation: nil)) {
+                    pane.selectTab(tabId)
+                    controller.focusPane(pane.id)
+                }
+                inlineRenamingTabId = tabId
+            }
         )
         .background(
             TabBarHostWindowReader { window in
@@ -1106,6 +1116,11 @@ struct TabBarView: View {
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
             tabFramesInBar = frames
         }
+        .onChange(of: pane.tabs.map(\.id)) { _, tabIds in
+            if let inlineRenamingTabId, !tabIds.contains(inlineRenamingTabId) {
+                self.inlineRenamingTabId = nil
+            }
+        }
         .onPreferenceChange(SplitButtonLaneWidthPreferenceKey.self) { width in
             measuredSplitButtonLaneWidth = width
         }
@@ -1125,6 +1140,7 @@ struct TabBarView: View {
         TabItemView(
             tab: tab,
             isSelected: pane.selectedTabId == tab.id,
+            isInlineRenaming: inlineRenamingTabId == tab.id,
             showsZoomIndicator: showsZoomIndicator,
             appearance: appearance,
             saturation: tabBarSaturation,
@@ -1161,6 +1177,13 @@ struct TabBarView: View {
             },
             onZoomToggle: {
                 _ = controller.requestTabZoomToggle(for: TabID(id: tab.id), inPane: pane.id)
+            },
+            onInlineRenameCommit: { title in
+                inlineRenamingTabId = nil
+                controller.requestInlineTabRename(title, for: TabID(id: tab.id), inPane: pane.id)
+            },
+            onInlineRenameCancel: {
+                inlineRenamingTabId = nil
             },
             onContextAction: { action in
                 controller.requestTabContextAction(action, for: TabID(id: tab.id), inPane: pane.id)
@@ -2006,6 +2029,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
     let tabFrames: [UUID: CGRect]
     @Binding var dropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
+    let onTabDoubleClick: (UUID) -> Void
 
     func makeNSView(context: Context) -> ManualReorderNSView {
         let view = ManualReorderNSView()
@@ -2026,17 +2050,28 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             dropTargetIndex = targetIndex
             dropLifecycle = lifecycle
         }
+        view.onTabDoubleClick = onTabDoubleClick
     }
 
     final class ManualReorderNSView: NSView {
+        private struct ClickRecord {
+            let windowNumber: Int
+            let tabId: UUID
+            let clickCount: Int
+            let timestamp: TimeInterval
+            let locationInWindow: NSPoint
+        }
+
         weak var pane: PaneState?
         weak var bonsplitController: BonsplitController?
         weak var splitViewController: SplitViewController?
         var tabFrames: [UUID: CGRect] = [:]
         var onDropStateChanged: ((Int?, TabDropLifecycle) -> Void)?
+        var onTabDoubleClick: ((UUID) -> Void)?
 
         private var localMouseMonitor: Any?
         private var session: ManualDragSession?
+        private var lastClick: ClickRecord?
 
         private static let dragStartDistanceSquared: CGFloat = 16
         private static let trailingDropSlop: CGFloat = 30
@@ -2097,23 +2132,24 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
 
             switch event.type {
             case .leftMouseDown:
-                beginTrackingIfNeeded(at: point)
+                beginTrackingIfNeeded(at: point, event: event, window: window)
             case .leftMouseDragged:
                 updateTracking(at: point)
             case .leftMouseUp:
-                finishTracking()
+                finishTracking(event: event)
             default:
                 break
             }
         }
 
-        private func beginTrackingIfNeeded(at point: NSPoint) {
+        private func beginTrackingIfNeeded(at point: NSPoint, event: NSEvent, window: NSWindow) {
             guard bounds.contains(point),
                   let pane,
                   let splitViewController,
                   splitViewController.isInteractive,
                   let source = tab(at: point, in: pane) else {
                 clearManualDrag()
+                lastClick = nil
                 return
             }
 
@@ -2121,6 +2157,13 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 sourceTab: source,
                 sourcePaneId: pane.id,
                 startPoint: point,
+                clickRecord: ClickRecord(
+                    windowNumber: window.windowNumber,
+                    tabId: source.id,
+                    clickCount: event.clickCount,
+                    timestamp: event.timestamp,
+                    locationInWindow: event.locationInWindow
+                ),
                 currentTargetIndex: nil,
                 didStartDrag: false
             )
@@ -2133,6 +2176,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             let dy = point.y - session.startPoint.y
             if !session.didStartDrag {
                 guard dx * dx + dy * dy >= Self.dragStartDistanceSquared else { return }
+                lastClick = nil
                 beginManualDrag(for: session)
                 session.didStartDrag = true
             }
@@ -2149,7 +2193,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             }
         }
 
-        private func finishTracking() {
+        private func finishTracking(event: NSEvent) {
             guard let session else {
                 clearManualDrag()
                 return
@@ -2158,6 +2202,11 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             defer {
                 clearControllerDragStateIfNeeded(sourceTabId: session.sourceTab.id)
                 clearManualDrag()
+            }
+
+            if !session.didStartDrag {
+                finishClick(session.clickRecord, mouseUpEvent: event)
+                return
             }
 
             guard session.didStartDrag,
@@ -2173,6 +2222,50 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 pane.moveTab(from: currentSourceIndex, to: targetIndex)
                 bonsplitController.focusPane(pane.id)
             }
+        }
+
+        private func finishClick(_ click: ClickRecord, mouseUpEvent event: NSEvent) {
+            let dx = event.locationInWindow.x - click.locationInWindow.x
+            let dy = event.locationInWindow.y - click.locationInWindow.y
+            guard hypot(dx, dy) <= 6 else {
+                lastClick = nil
+                return
+            }
+
+            if formsDoubleClick(click) {
+                lastClick = nil
+                onTabDoubleClick?(click.tabId)
+            } else {
+                lastClick = click
+            }
+        }
+
+        private func formsDoubleClick(_ click: ClickRecord) -> Bool {
+            if click.clickCount >= 2 {
+                return true
+            }
+
+            guard let lastClick,
+                  lastClick.windowNumber == click.windowNumber,
+                  lastClick.tabId == click.tabId else {
+                return false
+            }
+
+            let allowedInterval = NSEvent.doubleClickInterval + syntheticDoubleClickTolerance
+            let elapsed = click.timestamp - lastClick.timestamp
+            guard elapsed >= 0, elapsed <= allowedInterval else { return false }
+
+            let dx = click.locationInWindow.x - lastClick.locationInWindow.x
+            let dy = click.locationInWindow.y - lastClick.locationInWindow.y
+            return hypot(dx, dy) <= 6
+        }
+
+        private var syntheticDoubleClickTolerance: TimeInterval {
+#if DEBUG
+            0.15
+#else
+            0
+#endif
         }
 
         private func beginManualDrag(for session: ManualDragSession) {
@@ -2252,6 +2345,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             let sourceTab: TabItem
             let sourcePaneId: PaneID
             let startPoint: NSPoint
+            let clickRecord: ClickRecord
             var currentTargetIndex: Int?
             var didStartDrag: Bool
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1076,16 +1076,7 @@ struct TabBarView: View {
                 tabFrames: tabFramesInBar,
                 dropTargetIndex: $dropTargetIndex,
                 dropLifecycle: $dropLifecycle
-            ) { tabId in
-#if DEBUG
-                dlog("tab.doubleClick.rename pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tabId.uuidString.prefix(5))")
-#endif
-                withTransaction(Transaction(animation: nil)) {
-                    pane.selectTab(tabId)
-                    controller.focusPane(pane.id)
-                }
-                inlineRenamingTabId = tabId
-            }
+            )
         )
         .background(
             TabBarHostWindowReader { window in
@@ -1177,6 +1168,16 @@ struct TabBarView: View {
             },
             onZoomToggle: {
                 _ = controller.requestTabZoomToggle(for: TabID(id: tab.id), inPane: pane.id)
+            },
+            onInlineRenameRequest: {
+#if DEBUG
+                dlog("tab.doubleClick.rename pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5))")
+#endif
+                withTransaction(Transaction(animation: nil)) {
+                    pane.selectTab(tab.id)
+                    controller.focusPane(pane.id)
+                }
+                inlineRenamingTabId = tab.id
             },
             onInlineRenameCommit: { title in
                 inlineRenamingTabId = nil
@@ -2029,7 +2030,6 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
     let tabFrames: [UUID: CGRect]
     @Binding var dropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
-    let onTabDoubleClick: (UUID) -> Void
 
     func makeNSView(context: Context) -> ManualReorderNSView {
         let view = ManualReorderNSView()
@@ -2050,28 +2050,17 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             dropTargetIndex = targetIndex
             dropLifecycle = lifecycle
         }
-        view.onTabDoubleClick = onTabDoubleClick
     }
 
     final class ManualReorderNSView: NSView {
-        private struct ClickRecord {
-            let windowNumber: Int
-            let tabId: UUID
-            let clickCount: Int
-            let timestamp: TimeInterval
-            let locationInWindow: NSPoint
-        }
-
         weak var pane: PaneState?
         weak var bonsplitController: BonsplitController?
         weak var splitViewController: SplitViewController?
         var tabFrames: [UUID: CGRect] = [:]
         var onDropStateChanged: ((Int?, TabDropLifecycle) -> Void)?
-        var onTabDoubleClick: ((UUID) -> Void)?
 
         private var localMouseMonitor: Any?
         private var session: ManualDragSession?
-        private var lastClick: ClickRecord?
 
         private static let dragStartDistanceSquared: CGFloat = 16
         private static let trailingDropSlop: CGFloat = 30
@@ -2132,24 +2121,23 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
 
             switch event.type {
             case .leftMouseDown:
-                beginTrackingIfNeeded(at: point, event: event, window: window)
+                beginTrackingIfNeeded(at: point)
             case .leftMouseDragged:
                 updateTracking(at: point)
             case .leftMouseUp:
-                finishTracking(event: event)
+                finishTracking()
             default:
                 break
             }
         }
 
-        private func beginTrackingIfNeeded(at point: NSPoint, event: NSEvent, window: NSWindow) {
+        private func beginTrackingIfNeeded(at point: NSPoint) {
             guard bounds.contains(point),
                   let pane,
                   let splitViewController,
                   splitViewController.isInteractive,
                   let source = tab(at: point, in: pane) else {
                 clearManualDrag()
-                lastClick = nil
                 return
             }
 
@@ -2157,13 +2145,6 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 sourceTab: source,
                 sourcePaneId: pane.id,
                 startPoint: point,
-                clickRecord: ClickRecord(
-                    windowNumber: window.windowNumber,
-                    tabId: source.id,
-                    clickCount: event.clickCount,
-                    timestamp: event.timestamp,
-                    locationInWindow: event.locationInWindow
-                ),
                 currentTargetIndex: nil,
                 didStartDrag: false
             )
@@ -2176,7 +2157,6 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             let dy = point.y - session.startPoint.y
             if !session.didStartDrag {
                 guard dx * dx + dy * dy >= Self.dragStartDistanceSquared else { return }
-                lastClick = nil
                 beginManualDrag(for: session)
                 session.didStartDrag = true
             }
@@ -2193,7 +2173,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             }
         }
 
-        private func finishTracking(event: NSEvent) {
+        private func finishTracking() {
             guard let session else {
                 clearManualDrag()
                 return
@@ -2202,11 +2182,6 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             defer {
                 clearControllerDragStateIfNeeded(sourceTabId: session.sourceTab.id)
                 clearManualDrag()
-            }
-
-            if !session.didStartDrag {
-                finishClick(session.clickRecord, mouseUpEvent: event)
-                return
             }
 
             guard session.didStartDrag,
@@ -2222,50 +2197,6 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 pane.moveTab(from: currentSourceIndex, to: targetIndex)
                 bonsplitController.focusPane(pane.id)
             }
-        }
-
-        private func finishClick(_ click: ClickRecord, mouseUpEvent event: NSEvent) {
-            let dx = event.locationInWindow.x - click.locationInWindow.x
-            let dy = event.locationInWindow.y - click.locationInWindow.y
-            guard hypot(dx, dy) <= 6 else {
-                lastClick = nil
-                return
-            }
-
-            if formsDoubleClick(click) {
-                lastClick = nil
-                onTabDoubleClick?(click.tabId)
-            } else {
-                lastClick = click
-            }
-        }
-
-        private func formsDoubleClick(_ click: ClickRecord) -> Bool {
-            if click.clickCount >= 2 {
-                return true
-            }
-
-            guard let lastClick,
-                  lastClick.windowNumber == click.windowNumber,
-                  lastClick.tabId == click.tabId else {
-                return false
-            }
-
-            let allowedInterval = NSEvent.doubleClickInterval + syntheticDoubleClickTolerance
-            let elapsed = click.timestamp - lastClick.timestamp
-            guard elapsed >= 0, elapsed <= allowedInterval else { return false }
-
-            let dx = click.locationInWindow.x - lastClick.locationInWindow.x
-            let dy = click.locationInWindow.y - lastClick.locationInWindow.y
-            return hypot(dx, dy) <= 6
-        }
-
-        private var syntheticDoubleClickTolerance: TimeInterval {
-#if DEBUG
-            0.15
-#else
-            0
-#endif
         }
 
         private func beginManualDrag(for session: ManualDragSession) {
@@ -2345,7 +2276,6 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             let sourceTab: TabItem
             let sourcePaneId: PaneID
             let startPoint: NSPoint
-            let clickRecord: ClickRecord
             var currentTargetIndex: Int?
             var didStartDrag: Bool
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1179,9 +1179,9 @@ struct TabBarView: View {
                 }
                 inlineRenamingTabId = tab.id
             },
-            onInlineRenameCommit: { title in
+            onInlineRenameCommit: { title, initialTitle in
                 inlineRenamingTabId = nil
-                controller.requestInlineTabRename(title, for: TabID(id: tab.id), inPane: pane.id)
+                controller.requestInlineTabRename(title, initialTitle: initialTitle, for: TabID(id: tab.id), inPane: pane.id)
             },
             onInlineRenameCancel: {
                 inlineRenamingTabId = nil

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -48,7 +48,9 @@ enum TabItemStyling {
 private struct InlineTabRenameField: NSViewRepresentable {
     let initialTitle: String
     let fontSize: CGFloat
+    let textColor: NSColor
     let height: CGFloat
+    let onTextChange: (String) -> Void
     let onCommit: (String) -> Void
     let onCancel: () -> Void
 
@@ -165,6 +167,20 @@ private struct InlineTabRenameField: NSViewRepresentable {
 
         func attach(to field: NSTextField) {
             installOutsideClickMonitor(for: field)
+            configureFieldEditor(for: field)
+        }
+
+        func configureFieldEditor(for field: NSTextField) {
+            guard let fieldEditor = field.currentEditor() as? NSTextView else { return }
+            fieldEditor.textContainerInset = .zero
+            fieldEditor.textContainer?.lineFragmentPadding = 0
+            fieldEditor.font = field.font
+            fieldEditor.textColor = .clear
+            fieldEditor.insertionPointColor = parent.textColor
+            fieldEditor.selectedTextAttributes = [
+                .foregroundColor: NSColor.clear,
+                .backgroundColor: NSColor.clear,
+            ]
         }
 
         func finishCommit(_ title: String) {
@@ -184,6 +200,12 @@ private struct InlineTabRenameField: NSViewRepresentable {
         func controlTextDidEndEditing(_ obj: Notification) {
             guard let field = obj.object as? NSTextField else { return }
             finishCommit(field.stringValue)
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            parent.onTextChange(field.stringValue)
+            configureFieldEditor(for: field)
         }
 
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
@@ -241,6 +263,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
         field.drawsBackground = false
         field.focusRingType = .none
         field.font = .systemFont(ofSize: fontSize)
+        field.textColor = .clear
         field.lineBreakMode = .byTruncatingTail
         field.cell?.usesSingleLineMode = true
         field.cell?.wraps = false
@@ -254,11 +277,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
             guard !coordinator.didFinish else { return }
             coordinator.attach(to: field)
             field.selectText(nil)
-            if let fieldEditor = field.currentEditor() as? NSTextView {
-                fieldEditor.textContainerInset = .zero
-                fieldEditor.textContainer?.lineFragmentPadding = 0
-                fieldEditor.font = field.font
-            }
+            coordinator.configureFieldEditor(for: field)
         }
 
         return host
@@ -268,7 +287,9 @@ private struct InlineTabRenameField: NSViewRepresentable {
         context.coordinator.parent = self
         let field = host.field
         field.font = .systemFont(ofSize: fontSize)
+        field.textColor = .clear
         host.contentHeight = height
+        context.coordinator.configureFieldEditor(for: field)
         if field.currentEditor() == nil, field.stringValue != initialTitle {
             field.stringValue = initialTitle
         }
@@ -307,6 +328,7 @@ struct TabItemView: View {
     @State private var lastLoadingStoppedAt: Date?
     @State private var renderedFaviconData: Data?
     @State private var renderedFaviconImage: NSImage?
+    @State private var inlineRenameDraftTitle: String?
     @AppStorage(TabControlShortcutHintDebugSettings.xKey) private var controlShortcutHintXOffset = TabControlShortcutHintDebugSettings.defaultX
     @AppStorage(TabControlShortcutHintDebugSettings.yKey) private var controlShortcutHintYOffset = TabControlShortcutHintDebugSettings.defaultY
     @AppStorage(TabControlShortcutHintDebugSettings.alwaysShowKey) private var alwaysShowShortcutHints = TabControlShortcutHintDebugSettings.defaultAlwaysShow
@@ -367,17 +389,30 @@ struct TabItemView: View {
 
                 if isInlineRenaming {
                     titleLabel
-                        .hidden()
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .overlay(alignment: .leading) {
                             InlineTabRenameField(
-                                initialTitle: tab.title,
+                                initialTitle: inlineRenameDraftTitle ?? tab.title,
                                 fontSize: appearance.tabTitleFontSize,
+                                textColor: titleTextNSColor,
                                 height: titleLineHeight,
-                                onCommit: onInlineRenameCommit,
-                                onCancel: onInlineRenameCancel
+                                onTextChange: { inlineRenameDraftTitle = $0 },
+                                onCommit: { title in
+                                    inlineRenameDraftTitle = nil
+                                    onInlineRenameCommit(title)
+                                },
+                                onCancel: {
+                                    inlineRenameDraftTitle = nil
+                                    onInlineRenameCancel()
+                                }
                             )
                             .frame(minWidth: 44, maxWidth: .infinity, minHeight: titleLineHeight, maxHeight: titleLineHeight)
+                        }
+                        .onAppear {
+                            inlineRenameDraftTitle = tab.title
+                        }
+                        .onDisappear {
+                            inlineRenameDraftTitle = nil
                         }
                         .layoutPriority(1)
                 } else {
@@ -503,15 +538,30 @@ struct TabItemView: View {
         return max(1, ceil(font.boundingRectForFont.height))
     }
 
+    private var displayedTitle: String {
+        if isInlineRenaming {
+            return inlineRenameDraftTitle ?? tab.title
+        }
+        return tab.title
+    }
+
+    private var titleTextColor: Color {
+        isSelected
+            ? TabBarColors.activeText(for: appearance)
+            : TabBarColors.inactiveText(for: appearance)
+    }
+
+    private var titleTextNSColor: NSColor {
+        isSelected
+            ? TabBarColors.nsColorActiveText(for: appearance)
+            : TabBarColors.nsColorInactiveText(for: appearance)
+    }
+
     private var titleLabel: some View {
-        Text(tab.title)
+        Text(displayedTitle)
             .font(.system(size: appearance.tabTitleFontSize))
             .lineLimit(1)
-            .foregroundStyle(
-                isSelected
-                    ? TabBarColors.activeText(for: appearance)
-                    : TabBarColors.inactiveText(for: appearance)
-            )
+            .foregroundStyle(titleTextColor)
             .saturation(saturation)
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -48,26 +48,50 @@ enum TabItemStyling {
 private struct InlineTabRenameField: NSViewRepresentable {
     let initialTitle: String
     let fontSize: CGFloat
+    let height: CGFloat
     let onCommit: (String) -> Void
     let onCancel: () -> Void
+
+    private final class InlineRenameTextField: NSTextField {
+        var fixedHeight: CGFloat = 16 {
+            didSet { invalidateIntrinsicContentSize() }
+        }
+
+        override var intrinsicContentSize: NSSize {
+            var size = super.intrinsicContentSize
+            size.height = fixedHeight
+            return size
+        }
+    }
 
     final class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: InlineTabRenameField
         var didFinish = false
+        private var outsideClickMonitor: Any?
 
         init(parent: InlineTabRenameField) {
             self.parent = parent
         }
 
+        deinit {
+            removeOutsideClickMonitor()
+        }
+
+        func attach(to field: NSTextField) {
+            installOutsideClickMonitor(for: field)
+        }
+
         func finishCommit(_ title: String) {
             guard !didFinish else { return }
             didFinish = true
+            removeOutsideClickMonitor()
             parent.onCommit(title)
         }
 
         func finishCancel() {
             guard !didFinish else { return }
             didFinish = true
+            removeOutsideClickMonitor()
             parent.onCancel()
         }
 
@@ -90,6 +114,33 @@ private struct InlineTabRenameField: NSViewRepresentable {
                 return false
             }
         }
+
+        private func installOutsideClickMonitor(for field: NSTextField) {
+            guard outsideClickMonitor == nil else { return }
+            outsideClickMonitor = NSEvent.addLocalMonitorForEvents(
+                matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+            ) { [weak self, weak field] event in
+                guard let self, let field, !self.didFinish else { return event }
+                guard !self.event(event, isInside: field) else { return event }
+
+                self.finishCommit(field.stringValue)
+                field.window?.makeFirstResponder(nil)
+                return event
+            }
+        }
+
+        private func removeOutsideClickMonitor() {
+            if let outsideClickMonitor {
+                NSEvent.removeMonitor(outsideClickMonitor)
+                self.outsideClickMonitor = nil
+            }
+        }
+
+        private func event(_ event: NSEvent, isInside field: NSTextField) -> Bool {
+            guard let window = field.window, event.window === window else { return false }
+            let point = field.convert(event.locationInWindow, from: nil)
+            return field.bounds.contains(point)
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -97,7 +148,8 @@ private struct InlineTabRenameField: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> NSTextField {
-        let field = NSTextField(string: initialTitle)
+        let field = InlineRenameTextField(string: initialTitle)
+        field.fixedHeight = height
         field.delegate = context.coordinator
         field.isBordered = false
         field.isBezeled = false
@@ -109,9 +161,12 @@ private struct InlineTabRenameField: NSViewRepresentable {
         field.cell?.wraps = false
         field.cell?.isScrollable = true
         field.setAccessibilityIdentifier("paneTab.inlineRenameField")
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         DispatchQueue.main.async {
             guard !context.coordinator.didFinish else { return }
+            context.coordinator.attach(to: field)
             field.window?.makeFirstResponder(field)
             field.currentEditor()?.selectAll(nil)
         }
@@ -122,6 +177,9 @@ private struct InlineTabRenameField: NSViewRepresentable {
     func updateNSView(_ field: NSTextField, context: Context) {
         context.coordinator.parent = self
         field.font = .systemFont(ofSize: fontSize)
+        if let field = field as? InlineRenameTextField {
+            field.fixedHeight = height
+        }
         if field.currentEditor() == nil, field.stringValue != initialTitle {
             field.stringValue = initialTitle
         }
@@ -222,10 +280,11 @@ struct TabItemView: View {
                     InlineTabRenameField(
                         initialTitle: tab.title,
                         fontSize: appearance.tabTitleFontSize,
+                        height: titleLineHeight,
                         onCommit: onInlineRenameCommit,
                         onCancel: onInlineRenameCancel
                     )
-                    .frame(minWidth: 44, maxWidth: .infinity, minHeight: 18, maxHeight: 22)
+                    .frame(minWidth: 44, maxWidth: .infinity, minHeight: titleLineHeight, maxHeight: titleLineHeight)
                     .layoutPriority(1)
                 } else {
                     Text(tab.title)
@@ -351,6 +410,11 @@ struct TabItemView: View {
 
     private var tabHeight: CGFloat {
         max(1, appearance.tabBarHeight)
+    }
+
+    private var titleLineHeight: CGFloat {
+        let font = NSFont.systemFont(ofSize: appearance.tabTitleFontSize)
+        return max(16, ceil(font.boundingRectForFont.height))
     }
 
     private func shortcutHintWidth(for label: String) -> CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -145,6 +145,7 @@ struct TabItemView: View {
     let onSelect: () -> Void
     let onClose: () -> Void
     let onZoomToggle: () -> Void
+    let onInlineRenameRequest: () -> Void
     let onInlineRenameCommit: (String) -> Void
     let onInlineRenameCancel: () -> Void
     let onContextAction: (TabContextAction) -> Void
@@ -297,6 +298,11 @@ struct TabItemView: View {
         .onTapGesture {
             onSelect()
         }
+        .simultaneousGesture(
+            TapGesture(count: 2).onEnded {
+                onInlineRenameRequest()
+            }
+        )
         .onHover { hovering in
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -45,10 +45,94 @@ enum TabItemStyling {
     }
 }
 
+private struct InlineTabRenameField: NSViewRepresentable {
+    let initialTitle: String
+    let fontSize: CGFloat
+    let onCommit: (String) -> Void
+    let onCancel: () -> Void
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: InlineTabRenameField
+        var didFinish = false
+
+        init(parent: InlineTabRenameField) {
+            self.parent = parent
+        }
+
+        func finishCommit(_ title: String) {
+            guard !didFinish else { return }
+            didFinish = true
+            parent.onCommit(title)
+        }
+
+        func finishCancel() {
+            guard !didFinish else { return }
+            didFinish = true
+            parent.onCancel()
+        }
+
+        func controlTextDidEndEditing(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            finishCommit(field.stringValue)
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            switch commandSelector {
+            case #selector(NSResponder.insertNewline(_:)):
+                guard !textView.hasMarkedText() else { return false }
+                finishCommit(textView.string)
+                return true
+            case #selector(NSResponder.cancelOperation(_:)):
+                guard !textView.hasMarkedText() else { return false }
+                finishCancel()
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField(string: initialTitle)
+        field.delegate = context.coordinator
+        field.isBordered = false
+        field.isBezeled = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = .systemFont(ofSize: fontSize)
+        field.lineBreakMode = .byTruncatingTail
+        field.cell?.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.cell?.isScrollable = true
+        field.setAccessibilityIdentifier("paneTab.inlineRenameField")
+
+        DispatchQueue.main.async {
+            guard !context.coordinator.didFinish else { return }
+            field.window?.makeFirstResponder(field)
+            field.currentEditor()?.selectAll(nil)
+        }
+
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Context) {
+        context.coordinator.parent = self
+        field.font = .systemFont(ofSize: fontSize)
+        if field.currentEditor() == nil, field.stringValue != initialTitle {
+            field.stringValue = initialTitle
+        }
+    }
+}
+
 /// Individual tab view with icon, title, close button, and dirty indicator
 struct TabItemView: View {
     let tab: TabItem
     let isSelected: Bool
+    let isInlineRenaming: Bool
     let showsZoomIndicator: Bool
     let appearance: BonsplitConfiguration.Appearance
     let saturation: Double
@@ -61,6 +145,8 @@ struct TabItemView: View {
     let onSelect: () -> Void
     let onClose: () -> Void
     let onZoomToggle: () -> Void
+    let onInlineRenameCommit: (String) -> Void
+    let onInlineRenameCancel: () -> Void
     let onContextAction: (TabContextAction) -> Void
     let onMoveDestination: (String) -> Void
 
@@ -131,15 +217,26 @@ struct TabItemView: View {
                 }
                 .onChange(of: tab.icon) { _ in updateGlobeFallback() }
 
-                Text(tab.title)
-                    .font(.system(size: appearance.tabTitleFontSize))
-                    .lineLimit(1)
-                    .foregroundStyle(
-                        isSelected
-                            ? TabBarColors.activeText(for: appearance)
-                            : TabBarColors.inactiveText(for: appearance)
+                if isInlineRenaming {
+                    InlineTabRenameField(
+                        initialTitle: tab.title,
+                        fontSize: appearance.tabTitleFontSize,
+                        onCommit: onInlineRenameCommit,
+                        onCancel: onInlineRenameCancel
                     )
-                    .saturation(saturation)
+                    .frame(minWidth: 44, maxWidth: .infinity, minHeight: 18, maxHeight: 22)
+                    .layoutPriority(1)
+                } else {
+                    Text(tab.title)
+                        .font(.system(size: appearance.tabTitleFontSize))
+                        .lineLimit(1)
+                        .foregroundStyle(
+                            isSelected
+                                ? TabBarColors.activeText(for: appearance)
+                                : TabBarColors.inactiveText(for: appearance)
+                        )
+                        .saturation(saturation)
+                }
 
                 if showsZoomIndicator {
                     Button {
@@ -200,16 +297,11 @@ struct TabItemView: View {
         .onTapGesture {
             onSelect()
         }
-        .simultaneousGesture(
-            TapGesture(count: 2).onEnded {
-                onZoomToggle()
-            }
-        )
         .onHover { hovering in
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: isInlineRenaming ? .contain : .combine)
         .accessibilityLabel(tab.title)
         .accessibilityValue(accessibilityValue)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
@@ -876,12 +968,13 @@ private struct TabContextMenuPresenter: NSViewRepresentable {
 
         let coordinator = context.coordinator
         coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.rightMouseDown, .leftMouseDown]) { [weak coordinator] event in
-            guard event.type == .rightMouseDown || event.modifierFlags.contains(.control) else { return event }
             guard let coordinator, let view = coordinator.view, let window = view.window else { return event }
             guard event.window === window else { return event }
 
             let point = view.convert(event.locationInWindow, from: nil)
             guard view.bounds.contains(point) else { return event }
+
+            guard event.type == .rightMouseDown || event.modifierFlags.contains(.control) else { return event }
 
             coordinator.presentMenu(at: point, in: view)
             return nil

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -394,7 +394,6 @@ struct TabItemView: View {
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering
         }
-        .accessibilityIdentifier("paneTab.\(tab.id.uuidString)")
         .accessibilityElement(children: isInlineRenaming ? .contain : .combine)
         .accessibilityLabel(tab.title)
         .accessibilityValue(accessibilityValue)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -52,7 +52,12 @@ private struct InlineTabRenameField: NSViewRepresentable {
     let onCommit: (String) -> Void
     let onCancel: () -> Void
 
-    fileprivate final class InlineRenameTextField: NSTextField {}
+    fileprivate final class InlineRenameTextField: NSTextField {
+        override class var cellClass: AnyClass? {
+            get { InlineRenameTextFieldCell.self }
+            set {}
+        }
+    }
 
     fileprivate final class InlineRenameTextFieldCell: NSTextFieldCell {
         override func drawingRect(forBounds rect: NSRect) -> NSRect {
@@ -229,9 +234,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
     }
 
     fileprivate func makeNSView(context: Context) -> InlineRenameHostView {
-        let field = InlineRenameTextField(frame: .zero)
-        field.cell = InlineRenameTextFieldCell(textCell: initialTitle)
-        field.stringValue = initialTitle
+        let field = InlineRenameTextField(string: initialTitle)
         field.delegate = context.coordinator
         field.isBordered = false
         field.isBezeled = false

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -394,6 +394,7 @@ struct TabItemView: View {
             // Keep icon rendering stable while hovering; only accessory/background elements animate.
             isHovered = hovering
         }
+        .accessibilityIdentifier("paneTab.\(tab.id.uuidString)")
         .accessibilityElement(children: isInlineRenaming ? .contain : .combine)
         .accessibilityLabel(tab.title)
         .accessibilityValue(accessibilityValue)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -54,6 +54,57 @@ private struct InlineTabRenameField: NSViewRepresentable {
 
     fileprivate final class InlineRenameTextField: NSTextField {}
 
+    fileprivate final class InlineRenameTextFieldCell: NSTextFieldCell {
+        override func drawingRect(forBounds rect: NSRect) -> NSRect {
+            textRect(forBounds: rect)
+        }
+
+        override func edit(
+            withFrame rect: NSRect,
+            in controlView: NSView,
+            editor textObj: NSText,
+            delegate: Any?,
+            event: NSEvent?
+        ) {
+            super.edit(
+                withFrame: textRect(forBounds: rect),
+                in: controlView,
+                editor: textObj,
+                delegate: delegate,
+                event: event
+            )
+        }
+
+        override func select(
+            withFrame rect: NSRect,
+            in controlView: NSView,
+            editor textObj: NSText,
+            delegate: Any?,
+            start selStart: Int,
+            length selLength: Int
+        ) {
+            super.select(
+                withFrame: textRect(forBounds: rect),
+                in: controlView,
+                editor: textObj,
+                delegate: delegate,
+                start: selStart,
+                length: selLength
+            )
+        }
+
+        private func textRect(forBounds rect: NSRect) -> NSRect {
+            guard let font else {
+                let fallback = super.drawingRect(forBounds: rect)
+                return NSRect(x: rect.minX, y: fallback.minY, width: rect.width, height: fallback.height)
+            }
+
+            let lineHeight = min(max(1, ceil(font.boundingRectForFont.height)), max(1, rect.height))
+            let lineY = rect.minY + floor((rect.height - lineHeight) / 2)
+            return NSRect(x: rect.minX, y: lineY, width: rect.width, height: lineHeight)
+        }
+    }
+
     fileprivate final class InlineRenameHostView: NSView {
         let field: InlineRenameTextField
         var contentHeight: CGFloat {
@@ -83,10 +134,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
 
         override func layout() {
             super.layout()
-            let naturalFieldHeight = max(1, ceil(field.intrinsicContentSize.height))
-            let fieldHeight = min(naturalFieldHeight, max(1, bounds.height))
-            let fieldY = floor((bounds.height - fieldHeight) / 2)
-            field.frame = NSRect(x: 0, y: fieldY, width: bounds.width, height: fieldHeight)
+            field.frame = bounds
         }
 
         override func viewDidMoveToWindow() {
@@ -181,7 +229,9 @@ private struct InlineTabRenameField: NSViewRepresentable {
     }
 
     fileprivate func makeNSView(context: Context) -> InlineRenameHostView {
-        let field = InlineRenameTextField(string: initialTitle)
+        let field = InlineRenameTextField(frame: .zero)
+        field.cell = InlineRenameTextFieldCell(textCell: initialTitle)
+        field.stringValue = initialTitle
         field.delegate = context.coordinator
         field.isBordered = false
         field.isBezeled = false
@@ -201,6 +251,11 @@ private struct InlineTabRenameField: NSViewRepresentable {
             guard !coordinator.didFinish else { return }
             coordinator.attach(to: field)
             field.selectText(nil)
+            if let fieldEditor = field.currentEditor() as? NSTextView {
+                fieldEditor.textContainerInset = .zero
+                fieldEditor.textContainer?.lineFragmentPadding = 0
+                fieldEditor.font = field.font
+            }
         }
 
         return host

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -277,25 +277,22 @@ struct TabItemView: View {
                 .onChange(of: tab.icon) { _ in updateGlobeFallback() }
 
                 if isInlineRenaming {
-                    InlineTabRenameField(
-                        initialTitle: tab.title,
-                        fontSize: appearance.tabTitleFontSize,
-                        height: titleLineHeight,
-                        onCommit: onInlineRenameCommit,
-                        onCancel: onInlineRenameCancel
-                    )
-                    .frame(minWidth: 44, maxWidth: .infinity, minHeight: titleLineHeight, maxHeight: titleLineHeight)
+                    ZStack(alignment: .leading) {
+                        titleLabel
+                            .hidden()
+                        InlineTabRenameField(
+                            initialTitle: tab.title,
+                            fontSize: appearance.tabTitleFontSize,
+                            height: titleLineHeight,
+                            onCommit: onInlineRenameCommit,
+                            onCancel: onInlineRenameCancel
+                        )
+                        .frame(minWidth: 44, maxWidth: .infinity, minHeight: titleLineHeight, maxHeight: titleLineHeight)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .layoutPriority(1)
                 } else {
-                    Text(tab.title)
-                        .font(.system(size: appearance.tabTitleFontSize))
-                        .lineLimit(1)
-                        .foregroundStyle(
-                            isSelected
-                                ? TabBarColors.activeText(for: appearance)
-                                : TabBarColors.inactiveText(for: appearance)
-                        )
-                        .saturation(saturation)
+                    titleLabel
                 }
 
                 if showsZoomIndicator {
@@ -414,7 +411,19 @@ struct TabItemView: View {
 
     private var titleLineHeight: CGFloat {
         let font = NSFont.systemFont(ofSize: appearance.tabTitleFontSize)
-        return max(16, ceil(font.boundingRectForFont.height))
+        return max(1, ceil(font.boundingRectForFont.height))
+    }
+
+    private var titleLabel: some View {
+        Text(tab.title)
+            .font(.system(size: appearance.tabTitleFontSize))
+            .lineLimit(1)
+            .foregroundStyle(
+                isSelected
+                    ? TabBarColors.activeText(for: appearance)
+                    : TabBarColors.inactiveText(for: appearance)
+            )
+            .saturation(saturation)
     }
 
     private func shortcutHintWidth(for label: String) -> CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -52,15 +52,48 @@ private struct InlineTabRenameField: NSViewRepresentable {
     let onCommit: (String) -> Void
     let onCancel: () -> Void
 
-    private final class InlineRenameTextField: NSTextField {
-        var fixedHeight: CGFloat = 16 {
-            didSet { invalidateIntrinsicContentSize() }
+    fileprivate final class InlineRenameTextField: NSTextField {}
+
+    fileprivate final class InlineRenameHostView: NSView {
+        let field: InlineRenameTextField
+        var contentHeight: CGFloat {
+            didSet {
+                invalidateIntrinsicContentSize()
+                needsLayout = true
+            }
+        }
+        var onAttachToWindow: ((NSTextField) -> Void)?
+        private var didRequestInitialFocus = false
+
+        init(field: InlineRenameTextField, contentHeight: CGFloat) {
+            self.field = field
+            self.contentHeight = contentHeight
+            super.init(frame: .zero)
+            addSubview(field)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            nil
         }
 
         override var intrinsicContentSize: NSSize {
-            var size = super.intrinsicContentSize
-            size.height = fixedHeight
-            return size
+            NSSize(width: NSView.noIntrinsicMetric, height: contentHeight)
+        }
+
+        override func layout() {
+            super.layout()
+            let naturalFieldHeight = max(1, ceil(field.intrinsicContentSize.height))
+            let fieldHeight = min(naturalFieldHeight, max(1, bounds.height))
+            let fieldY = floor((bounds.height - fieldHeight) / 2)
+            field.frame = NSRect(x: 0, y: fieldY, width: bounds.width, height: fieldHeight)
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard window != nil, !didRequestInitialFocus else { return }
+            didRequestInitialFocus = true
+            onAttachToWindow?(field)
         }
     }
 
@@ -147,9 +180,8 @@ private struct InlineTabRenameField: NSViewRepresentable {
         Coordinator(parent: self)
     }
 
-    func makeNSView(context: Context) -> NSTextField {
+    fileprivate func makeNSView(context: Context) -> InlineRenameHostView {
         let field = InlineRenameTextField(string: initialTitle)
-        field.fixedHeight = height
         field.delegate = context.coordinator
         field.isBordered = false
         field.isBezeled = false
@@ -164,22 +196,21 @@ private struct InlineTabRenameField: NSViewRepresentable {
         field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         field.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
-        DispatchQueue.main.async {
-            guard !context.coordinator.didFinish else { return }
-            context.coordinator.attach(to: field)
-            field.window?.makeFirstResponder(field)
-            field.currentEditor()?.selectAll(nil)
+        let host = InlineRenameHostView(field: field, contentHeight: height)
+        host.onAttachToWindow = { [coordinator = context.coordinator] field in
+            guard !coordinator.didFinish else { return }
+            coordinator.attach(to: field)
+            field.selectText(nil)
         }
 
-        return field
+        return host
     }
 
-    func updateNSView(_ field: NSTextField, context: Context) {
+    fileprivate func updateNSView(_ host: InlineRenameHostView, context: Context) {
         context.coordinator.parent = self
+        let field = host.field
         field.font = .systemFont(ofSize: fontSize)
-        if let field = field as? InlineRenameTextField {
-            field.fixedHeight = height
-        }
+        host.contentHeight = height
         if field.currentEditor() == nil, field.stringValue != initialTitle {
             field.stringValue = initialTitle
         }
@@ -277,20 +308,20 @@ struct TabItemView: View {
                 .onChange(of: tab.icon) { _ in updateGlobeFallback() }
 
                 if isInlineRenaming {
-                    ZStack(alignment: .leading) {
-                        titleLabel
-                            .hidden()
-                        InlineTabRenameField(
-                            initialTitle: tab.title,
-                            fontSize: appearance.tabTitleFontSize,
-                            height: titleLineHeight,
-                            onCommit: onInlineRenameCommit,
-                            onCancel: onInlineRenameCancel
-                        )
-                        .frame(minWidth: 44, maxWidth: .infinity, minHeight: titleLineHeight, maxHeight: titleLineHeight)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .layoutPriority(1)
+                    titleLabel
+                        .hidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .overlay(alignment: .leading) {
+                            InlineTabRenameField(
+                                initialTitle: tab.title,
+                                fontSize: appearance.tabTitleFontSize,
+                                height: titleLineHeight,
+                                onCommit: onInlineRenameCommit,
+                                onCancel: onInlineRenameCancel
+                            )
+                            .frame(minWidth: 44, maxWidth: .infinity, minHeight: titleLineHeight, maxHeight: titleLineHeight)
+                        }
+                        .layoutPriority(1)
                 } else {
                     titleLabel
                 }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -179,7 +179,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
             fieldEditor.insertionPointColor = parent.textColor
             fieldEditor.selectedTextAttributes = [
                 .foregroundColor: NSColor.clear,
-                .backgroundColor: NSColor.clear,
+                .backgroundColor: NSColor.selectedTextBackgroundColor.withAlphaComponent(0.42),
             ]
         }
 
@@ -314,7 +314,7 @@ struct TabItemView: View {
     let onClose: () -> Void
     let onZoomToggle: () -> Void
     let onInlineRenameRequest: () -> Void
-    let onInlineRenameCommit: (String) -> Void
+    let onInlineRenameCommit: (String, String) -> Void
     let onInlineRenameCancel: () -> Void
     let onContextAction: (TabContextAction) -> Void
     let onMoveDestination: (String) -> Void
@@ -328,6 +328,7 @@ struct TabItemView: View {
     @State private var lastLoadingStoppedAt: Date?
     @State private var renderedFaviconData: Data?
     @State private var renderedFaviconImage: NSImage?
+    @State private var inlineRenameInitialTitle: String?
     @State private var inlineRenameDraftTitle: String?
     @AppStorage(TabControlShortcutHintDebugSettings.xKey) private var controlShortcutHintXOffset = TabControlShortcutHintDebugSettings.defaultX
     @AppStorage(TabControlShortcutHintDebugSettings.yKey) private var controlShortcutHintYOffset = TabControlShortcutHintDebugSettings.defaultY
@@ -392,16 +393,19 @@ struct TabItemView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .overlay(alignment: .leading) {
                             InlineTabRenameField(
-                                initialTitle: inlineRenameDraftTitle ?? tab.title,
+                                initialTitle: inlineRenameInitialTitle ?? tab.title,
                                 fontSize: appearance.tabTitleFontSize,
                                 textColor: titleTextNSColor,
                                 height: titleLineHeight,
                                 onTextChange: { inlineRenameDraftTitle = $0 },
                                 onCommit: { title in
+                                    let initialTitle = inlineRenameInitialTitle ?? tab.title
+                                    inlineRenameInitialTitle = nil
                                     inlineRenameDraftTitle = nil
-                                    onInlineRenameCommit(title)
+                                    onInlineRenameCommit(title, initialTitle)
                                 },
                                 onCancel: {
+                                    inlineRenameInitialTitle = nil
                                     inlineRenameDraftTitle = nil
                                     onInlineRenameCancel()
                                 }
@@ -409,9 +413,11 @@ struct TabItemView: View {
                             .frame(minWidth: 44, maxWidth: .infinity, minHeight: titleLineHeight, maxHeight: titleLineHeight)
                         }
                         .onAppear {
+                            inlineRenameInitialTitle = tab.title
                             inlineRenameDraftTitle = tab.title
                         }
                         .onDisappear {
+                            inlineRenameInitialTitle = nil
                             inlineRenameDraftTitle = nil
                         }
                         .layoutPriority(1)
@@ -540,7 +546,7 @@ struct TabItemView: View {
 
     private var displayedTitle: String {
         if isInlineRenaming {
-            return inlineRenameDraftTitle ?? tab.title
+            return inlineRenameDraftTitle ?? inlineRenameInitialTitle ?? tab.title
         }
         return tab.title
     }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -611,6 +611,7 @@ struct TabItemView: View {
             .foregroundStyle(titleTextColor)
             .opacity(isInlineRenaming && inlineRenameShowsNativeText ? 0 : 1)
             .saturation(saturation)
+            .frame(minHeight: titleLineHeight, maxHeight: titleLineHeight, alignment: .leading)
     }
 
     private func shortcutHintWidth(for label: String) -> CGFloat {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -62,6 +62,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
     let fontSize: CGFloat
     let textColor: NSColor
     let height: CGFloat
+    let showsNativeText: Bool
     let onTextChange: (String) -> Void
     let onCommit: (String) -> Void
     let onCancel: () -> Void
@@ -184,13 +185,24 @@ private struct InlineTabRenameField: NSViewRepresentable {
 
         func configureFieldEditor(for field: NSTextField) {
             guard let fieldEditor = field.currentEditor() as? NSTextView else { return }
+            let textColor = parent.showsNativeText ? parent.textColor : .clear
             fieldEditor.textContainerInset = .zero
             fieldEditor.textContainer?.lineFragmentPadding = 0
             fieldEditor.font = field.font
-            fieldEditor.textColor = .clear
+            fieldEditor.textColor = textColor
             fieldEditor.insertionPointColor = parent.textColor
             fieldEditor.selectedTextAttributes = [
-                .foregroundColor: NSColor.clear,
+                .foregroundColor: textColor,
+                .backgroundColor: NSColor.selectedTextBackgroundColor.withAlphaComponent(0.42),
+            ]
+        }
+
+        func showNativeTextImmediately(for field: NSTextField) {
+            guard let fieldEditor = field.currentEditor() as? NSTextView else { return }
+            field.textColor = parent.textColor
+            fieldEditor.textColor = parent.textColor
+            fieldEditor.selectedTextAttributes = [
+                .foregroundColor: parent.textColor,
                 .backgroundColor: NSColor.selectedTextBackgroundColor.withAlphaComponent(0.42),
             ]
         }
@@ -217,7 +229,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
         func controlTextDidChange(_ obj: Notification) {
             guard let field = obj.object as? NSTextField else { return }
             parent.onTextChange(field.stringValue)
-            configureFieldEditor(for: field)
+            showNativeTextImmediately(for: field)
         }
 
         func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
@@ -275,7 +287,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
         field.drawsBackground = false
         field.focusRingType = .none
         field.font = .systemFont(ofSize: fontSize)
-        field.textColor = .clear
+        field.textColor = showsNativeText ? textColor : .clear
         field.lineBreakMode = .byTruncatingTail
         field.cell?.usesSingleLineMode = true
         field.cell?.wraps = false
@@ -299,7 +311,7 @@ private struct InlineTabRenameField: NSViewRepresentable {
         context.coordinator.parent = self
         let field = host.field
         field.font = .systemFont(ofSize: fontSize)
-        field.textColor = .clear
+        field.textColor = showsNativeText ? textColor : .clear
         host.contentHeight = height
         context.coordinator.configureFieldEditor(for: field)
         if field.currentEditor() == nil, field.stringValue != initialTitle {
@@ -342,6 +354,7 @@ struct TabItemView: View {
     @State private var renderedFaviconImage: NSImage?
     @State private var inlineRenameInitialTitle: String?
     @State private var inlineRenameDraftTitle: String?
+    @State private var inlineRenameShowsNativeText = false
     @AppStorage(TabControlShortcutHintDebugSettings.xKey) private var controlShortcutHintXOffset = TabControlShortcutHintDebugSettings.defaultX
     @AppStorage(TabControlShortcutHintDebugSettings.yKey) private var controlShortcutHintYOffset = TabControlShortcutHintDebugSettings.defaultY
     @AppStorage(TabControlShortcutHintDebugSettings.alwaysShowKey) private var alwaysShowShortcutHints = TabControlShortcutHintDebugSettings.defaultAlwaysShow
@@ -409,16 +422,22 @@ struct TabItemView: View {
                                 fontSize: appearance.tabTitleFontSize,
                                 textColor: titleTextNSColor,
                                 height: titleLineHeight,
-                                onTextChange: { inlineRenameDraftTitle = $0 },
+                                showsNativeText: inlineRenameShowsNativeText,
+                                onTextChange: {
+                                    inlineRenameDraftTitle = $0
+                                    inlineRenameShowsNativeText = true
+                                },
                                 onCommit: { title in
                                     let initialTitle = inlineRenameInitialTitle ?? tab.title
                                     inlineRenameInitialTitle = nil
                                     inlineRenameDraftTitle = nil
+                                    inlineRenameShowsNativeText = false
                                     onInlineRenameCommit(title, initialTitle)
                                 },
                                 onCancel: {
                                     inlineRenameInitialTitle = nil
                                     inlineRenameDraftTitle = nil
+                                    inlineRenameShowsNativeText = false
                                     onInlineRenameCancel()
                                 }
                             )
@@ -427,10 +446,12 @@ struct TabItemView: View {
                         .onAppear {
                             inlineRenameInitialTitle = tab.title
                             inlineRenameDraftTitle = tab.title
+                            inlineRenameShowsNativeText = false
                         }
                         .onDisappear {
                             inlineRenameInitialTitle = nil
                             inlineRenameDraftTitle = nil
+                            inlineRenameShowsNativeText = false
                         }
                         .layoutPriority(1)
                 } else {
@@ -588,6 +609,7 @@ struct TabItemView: View {
             .font(.system(size: appearance.tabTitleFontSize))
             .lineLimit(1)
             .foregroundStyle(titleTextColor)
+            .opacity(isInlineRenaming && inlineRenameShowsNativeText ? 0 : 1)
             .saturation(saturation)
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -200,6 +200,12 @@ public final class BonsplitController {
         delegate?.splitTabBar(self, didRequestTabContextAction: action, for: tab, inPane: pane)
     }
 
+    /// Request the delegate to commit a tab title from inline editing.
+    public func requestInlineTabRename(_ title: String, for tabId: TabID, inPane pane: PaneID) {
+        guard let tab = tab(tabId) else { return }
+        delegate?.splitTabBar(self, didCommitInlineRename: title, for: tab, inPane: pane)
+    }
+
     /// Request the delegate to move a tab to a host-provided destination.
     public func requestTabMove(toDestination destinationId: String, for tabId: TabID, inPane pane: PaneID) {
         guard let tab = tab(tabId) else { return }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -203,7 +203,13 @@ public final class BonsplitController {
     /// Request the delegate to commit a tab title from inline editing.
     public func requestInlineTabRename(_ title: String, for tabId: TabID, inPane pane: PaneID) {
         guard let tab = tab(tabId) else { return }
-        delegate?.splitTabBar(self, didCommitInlineRename: title, for: tab, inPane: pane)
+        requestInlineTabRename(title, initialTitle: tab.title, for: tabId, inPane: pane)
+    }
+
+    /// Request the delegate to commit a tab title from inline editing.
+    public func requestInlineTabRename(_ title: String, initialTitle: String, for tabId: TabID, inPane pane: PaneID) {
+        guard let tab = tab(tabId) else { return }
+        delegate?.splitTabBar(self, didCommitInlineRename: title, initialTitle: initialTitle, for: tab, inPane: pane)
     }
 
     /// Request the delegate to move a tab to a host-provided destination.

--- a/Sources/Bonsplit/Public/BonsplitDelegate.swift
+++ b/Sources/Bonsplit/Public/BonsplitDelegate.swift
@@ -62,6 +62,9 @@ public protocol BonsplitDelegate: AnyObject {
     /// Called when the user triggers an action from a tab's context menu.
     func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID)
 
+    /// Called when the user commits an inline tab rename.
+    func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, for tab: Tab, inPane pane: PaneID)
+
     /// Called when the user chooses a host-provided destination from the tab move submenu.
     func splitTabBar(_ controller: BonsplitController, didRequestTabMoveToDestination destinationId: String, for tab: Tab, inPane pane: PaneID)
 
@@ -91,6 +94,7 @@ public extension BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID) {}
+    func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, for tab: Tab, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestTabMoveToDestination destinationId: String, for tab: Tab, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {}
     func splitTabBar(_ controller: BonsplitController, shouldNotifyDuringDrag: Bool) -> Bool { false }

--- a/Sources/Bonsplit/Public/BonsplitDelegate.swift
+++ b/Sources/Bonsplit/Public/BonsplitDelegate.swift
@@ -65,6 +65,9 @@ public protocol BonsplitDelegate: AnyObject {
     /// Called when the user commits an inline tab rename.
     func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, for tab: Tab, inPane pane: PaneID)
 
+    /// Called when the user commits an inline tab rename, including the title that opened in the editor.
+    func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, initialTitle: String, for tab: Tab, inPane pane: PaneID)
+
     /// Called when the user chooses a host-provided destination from the tab move submenu.
     func splitTabBar(_ controller: BonsplitController, didRequestTabMoveToDestination destinationId: String, for tab: Tab, inPane pane: PaneID)
 
@@ -95,6 +98,9 @@ public extension BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Tab, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, for tab: Tab, inPane pane: PaneID) {}
+    func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, initialTitle: String, for tab: Tab, inPane pane: PaneID) {
+        splitTabBar(controller, didCommitInlineRename: title, for: tab, inPane: pane)
+    }
     func splitTabBar(_ controller: BonsplitController, didRequestTabMoveToDestination destinationId: String, for tab: Tab, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {}
     func splitTabBar(_ controller: BonsplitController, shouldNotifyDuringDrag: Bool) -> Bool { false }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -81,6 +81,7 @@ final class BonsplitTests: XCTestCase {
         var tabId: TabID?
         var paneId: PaneID?
         var moveDestinationId: String?
+        var inlineRenameTitle: String?
 
         func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Bonsplit.Tab, inPane pane: PaneID) {
             self.action = action
@@ -92,6 +93,12 @@ final class BonsplitTests: XCTestCase {
             self.moveDestinationId = destinationId
             self.tabId = tab.id
             self.paneId = pane
+        }
+
+        func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, for tab: Bonsplit.Tab, inPane pane: PaneID) {
+            inlineRenameTitle = title
+            tabId = tab.id
+            paneId = pane
         }
     }
 
@@ -1355,6 +1362,21 @@ final class BonsplitTests: XCTestCase {
         controller.requestTabMove(toDestination: "workspace:abc", for: tabId, inPane: pane)
 
         XCTAssertEqual(spy.moveDestinationId, "workspace:abc")
+        XCTAssertEqual(spy.tabId, tabId)
+        XCTAssertEqual(spy.paneId, pane)
+    }
+
+    @MainActor
+    func testRequestInlineTabRenameForwardsToDelegate() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Test", kind: "terminal")!
+        let spy = TabContextActionDelegateSpy()
+        controller.delegate = spy
+
+        controller.requestInlineTabRename("Inline Title", for: tabId, inPane: pane)
+
+        XCTAssertEqual(spy.inlineRenameTitle, "Inline Title")
         XCTAssertEqual(spy.tabId, tabId)
         XCTAssertEqual(spy.paneId, pane)
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -82,6 +82,7 @@ final class BonsplitTests: XCTestCase {
         var paneId: PaneID?
         var moveDestinationId: String?
         var inlineRenameTitle: String?
+        var inlineRenameInitialTitle: String?
 
         func splitTabBar(_ controller: BonsplitController, didRequestTabContextAction action: TabContextAction, for tab: Bonsplit.Tab, inPane pane: PaneID) {
             self.action = action
@@ -97,6 +98,13 @@ final class BonsplitTests: XCTestCase {
 
         func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, for tab: Bonsplit.Tab, inPane pane: PaneID) {
             inlineRenameTitle = title
+            tabId = tab.id
+            paneId = pane
+        }
+
+        func splitTabBar(_ controller: BonsplitController, didCommitInlineRename title: String, initialTitle: String, for tab: Bonsplit.Tab, inPane pane: PaneID) {
+            inlineRenameTitle = title
+            inlineRenameInitialTitle = initialTitle
             tabId = tab.id
             paneId = pane
         }
@@ -1377,6 +1385,23 @@ final class BonsplitTests: XCTestCase {
         controller.requestInlineTabRename("Inline Title", for: tabId, inPane: pane)
 
         XCTAssertEqual(spy.inlineRenameTitle, "Inline Title")
+        XCTAssertEqual(spy.inlineRenameInitialTitle, "Test")
+        XCTAssertEqual(spy.tabId, tabId)
+        XCTAssertEqual(spy.paneId, pane)
+    }
+
+    @MainActor
+    func testRequestInlineTabRenameForwardsInitialTitleToDelegate() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Live Title", kind: "terminal")!
+        let spy = TabContextActionDelegateSpy()
+        controller.delegate = spy
+
+        controller.requestInlineTabRename("Initial Title", initialTitle: "Initial Title", for: tabId, inPane: pane)
+
+        XCTAssertEqual(spy.inlineRenameTitle, "Initial Title")
+        XCTAssertEqual(spy.inlineRenameInitialTitle, "Initial Title")
         XCTAssertEqual(spy.tabId, tabId)
         XCTAssertEqual(spy.paneId, pane)
     }


### PR DESCRIPTION
## Summary
- keep inline tab rename geometry stable while editing
- render AppKit editor glyphs transparent so SwiftUI text stays fixed
- select the full title on entry, with highlight and caret matching the visible text

## Parent PR
https://github.com/manaflow-ai/cmux/pull/4341

## Tests
- swift test --package-path vendor/bonsplit
- hosted cmux E2E in parent PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782010526&installation_id=133855650&pr_number=129&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F129&signature=b483f6fb5b754b62503a6504a63dbdaca445013b572390f6c063bb38383c9f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds inline tab rename on double‑click with selection highlight and caret matching the visible title. Keeps tab geometry and the title’s baseline stable before, during, and after editing, and keeps text visible at handoff.

- **New Features**
  - Double‑click a tab to rename inline; overlays `InlineTabRenameField` so geometry doesn’t shift and focuses the tab/pane first.
  - Selection highlight and caret match the SwiftUI title; AppKit editor glyphs are initially transparent, the text rect aligns to the font with a fixed line height, the full title is selected on entry, the baseline stays fixed before/after edit, and the label stays visible at handoff to avoid flicker.
  - New API: `BonsplitController.requestInlineTabRename(_:,for:inPane:)` and `requestInlineTabRename(_:,initialTitle:for:inPane:)`; delegate: `splitTabBar(_:didCommitInlineRename:for:inPane:)` and `splitTabBar(_:didCommitInlineRename:initialTitle:for:inPane:)`.
  - Tracks `isInlineRenaming` per tab and clears if the tab is removed; Return commits, Escape cancels, clicking outside commits; accessibility isolates the rename field.

- **Migration**
  - Optional: implement either `splitTabBar(_:didCommitInlineRename:for:inPane:)` or `splitTabBar(_:didCommitInlineRename:initialTitle:for:inPane:)` to persist title changes. No changes needed if you don’t handle renames.

<sup>Written for commit ae19e45b152f58a7a96c709ff0efb7643d51d079. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/129?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline tab renaming: double-click a tab title to edit in-place; Enter to commit, Escape to cancel, or click outside to dismiss. Focus and selection behavior improved during editing.
* **Bug Fixes**
  * Improved context-menu/right-click behavior and hit-testing reliability when interacting with tabs.
* **Chores**
  * Rename commit notifications now include both the committed title and the original initial title.
* **Tests**
  * Added tests covering inline-rename delegation and initial-title propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->