### PR TITLE
Move tab loading spinner to Core Animation

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import QuartzCore
 
 enum TabControlShortcutHintAnimation {
     static let visibility: Animation = .easeOut(duration: 0.12)
@@ -94,15 +95,16 @@ struct TabItemView: View {
             // Icon + title block uses the standard spacing, but keep the close affordance tight.
             HStack(spacing: TabBarMetrics.contentSpacing) {
                 let iconSlotSize = TabBarMetrics.iconSize
-                let iconTint = isSelected
-                    ? TabBarColors.activeText(for: appearance)
-                    : TabBarColors.inactiveText(for: appearance)
+                let iconTintColor = isSelected
+                    ? TabBarColors.nsColorActiveText(for: appearance)
+                    : TabBarColors.nsColorInactiveText(for: appearance)
+                let iconTint = Color(nsColor: iconTintColor)
                 let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { NSImage(data: $0) }
 
                 Group {
                     if tab.isLoading {
                         // Slightly smaller than the icon slot so it reads cleaner at tab scale.
-                        TabLoadingSpinner(size: iconSlotSize * 0.86, color: iconTint)
+                        TabLoadingSpinner(size: iconSlotSize * 0.86, color: iconTintColor)
                     } else if let image = faviconImage {
                         FaviconIconView(image: image)
                             .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
@@ -465,30 +467,162 @@ struct TabItemView: View {
     }
 }
 
-private struct TabLoadingSpinner: View {
+private struct TabLoadingSpinner: NSViewRepresentable {
     let size: CGFloat
-    let color: Color
+    let color: NSColor
 
-    var body: some View {
-        TimelineView(.animation) { context in
-            let t = context.date.timeIntervalSinceReferenceDate
-            // 0.9s per revolution feels a bit snappier at tab-icon scale.
-            let angle = (t.truncatingRemainder(dividingBy: 0.9) / 0.9) * 360.0
+    func makeNSView(context: Context) -> TabLoadingSpinnerLayerView {
+        let view = TabLoadingSpinnerLayerView(frame: NSRect(x: 0, y: 0, width: size, height: size))
+        view.configure(size: size, color: color)
+        return view
+    }
 
-            ZStack {
-                Circle()
-                    .stroke(color.opacity(0.20), lineWidth: ringWidth)
-                Circle()
-                    .trim(from: 0.0, to: 0.28)
-                    .stroke(color, style: StrokeStyle(lineWidth: ringWidth, lineCap: .round))
-                    .rotationEffect(.degrees(angle))
-            }
-            .frame(width: size, height: size)
+    func updateNSView(_ nsView: TabLoadingSpinnerLayerView, context: Context) {
+        nsView.configure(size: size, color: color)
+    }
+}
+
+final class TabLoadingSpinnerLayerView: NSView {
+    static let rotationAnimationKey = "tabLoadingSpinnerRotation"
+    static let rotationDuration: CFTimeInterval = 0.9
+    private static let arcStrokeEnd: CGFloat = 0.28
+
+    private let trackLayer = CAShapeLayer()
+    private let arcContainerLayer = CALayer()
+    private let arcLayer = CAShapeLayer()
+    private var spinnerSize: CGFloat = 0
+    private var spinnerColor: NSColor = .labelColor
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        setupLayers()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: spinnerSize, height: spinnerSize)
+    }
+
+    func configure(size: CGFloat, color: NSColor) {
+        let resolvedSize = max(1, size)
+        let sizeChanged = abs(spinnerSize - resolvedSize) > 0.001
+        spinnerSize = resolvedSize
+        spinnerColor = color
+
+        updateColors()
+        updateGeometry()
+
+        if sizeChanged {
+            invalidateIntrinsicContentSize()
+        }
+        if window != nil {
+            startAnimating()
         }
     }
 
-    private var ringWidth: CGFloat {
-        max(1.6, size * 0.14)
+    override func layout() {
+        super.layout()
+        updateGeometry()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            stopAnimating()
+        } else {
+            startAnimating()
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateColors()
+    }
+
+    private func setupLayers() {
+        guard let layer else { return }
+        layer.masksToBounds = false
+
+        trackLayer.fillColor = nil
+        arcLayer.fillColor = nil
+        arcLayer.strokeStart = 0
+        arcLayer.strokeEnd = Self.arcStrokeEnd
+        arcLayer.lineCap = .round
+
+        arcContainerLayer.addSublayer(arcLayer)
+        layer.addSublayer(trackLayer)
+        layer.addSublayer(arcContainerLayer)
+    }
+
+    private func updateGeometry() {
+        let diameter = max(1, min(spinnerSize, bounds.width, bounds.height))
+        let frame = CGRect(
+            x: (bounds.width - diameter) * 0.5,
+            y: (bounds.height - diameter) * 0.5,
+            width: diameter,
+            height: diameter
+        )
+        let lineWidth = max(1.6, spinnerSize * 0.14)
+        let pathRect = CGRect(origin: .zero, size: frame.size).insetBy(dx: lineWidth * 0.5, dy: lineWidth * 0.5)
+        let path = CGPath(ellipseIn: pathRect, transform: nil)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        trackLayer.frame = frame
+        trackLayer.lineWidth = lineWidth
+        trackLayer.path = path
+        arcContainerLayer.frame = frame
+        arcLayer.frame = CGRect(origin: .zero, size: frame.size)
+        arcLayer.lineWidth = lineWidth
+        arcLayer.path = path
+        CATransaction.commit()
+    }
+
+    private func updateColors() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        trackLayer.strokeColor = resolvedCGColor(spinnerColor, alphaMultiplier: 0.20)
+        arcLayer.strokeColor = resolvedCGColor(spinnerColor, alphaMultiplier: 1.0)
+        CATransaction.commit()
+    }
+
+    private func resolvedCGColor(_ color: NSColor, alphaMultiplier: CGFloat) -> CGColor {
+        let resolved = color.usingColorSpace(NSColorSpace.sRGB) ?? color
+        let alpha = resolved.alphaComponent * alphaMultiplier
+        return resolved.withAlphaComponent(alpha).cgColor
+    }
+
+    private func startAnimating() {
+        guard arcContainerLayer.animation(forKey: Self.rotationAnimationKey) == nil else { return }
+        let animation = CABasicAnimation(keyPath: "transform.rotation.z")
+        animation.fromValue = 0
+        animation.toValue = CGFloat.pi * 2
+        animation.duration = Self.rotationDuration
+        animation.repeatCount = .infinity
+        animation.timingFunction = CAMediaTimingFunction(name: .linear)
+        animation.isRemovedOnCompletion = false
+        arcContainerLayer.add(animation, forKey: Self.rotationAnimationKey)
+    }
+
+    private func stopAnimating() {
+        arcContainerLayer.removeAnimation(forKey: Self.rotationAnimationKey)
+    }
+
+    var activeRotationAnimationForTesting: CAAnimation? {
+        arcContainerLayer.animation(forKey: Self.rotationAnimationKey)
+    }
+
+    var arcStrokeEndForTesting: CGFloat {
+        arcLayer.strokeEnd
+    }
+
+    var ringWidthForTesting: CGFloat {
+        arcLayer.lineWidth
     }
 }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Bonsplit
 import AppKit
+import QuartzCore
 import SwiftUI
 
 final class BonsplitTests: XCTestCase {
@@ -1820,6 +1821,54 @@ final class BonsplitTests: XCTestCase {
         let existing = NSImage(size: NSSize(width: 16, height: 16))
         let resolved = TabItemStyling.resolvedFaviconImage(existing: existing, incomingData: nil)
         XCTAssertNil(resolved)
+    }
+
+    @MainActor
+    func testLoadingSpinnerUsesCoreAnimationRotationLayer() throws {
+        let spinner = TabLoadingSpinnerLayerView(frame: NSRect(x: 4, y: 4, width: 12, height: 12))
+        spinner.configure(size: 12, color: .labelColor)
+
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 20, height: 20))
+        let window = NSWindow(
+            contentRect: contentView.bounds,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = contentView
+        contentView.addSubview(spinner)
+        contentView.layoutSubtreeIfNeeded()
+        spinner.layoutSubtreeIfNeeded()
+
+        let animation = try XCTUnwrap(
+            spinner.activeRotationAnimationForTesting as? CABasicAnimation
+        )
+        XCTAssertEqual(animation.keyPath, "transform.rotation.z")
+        XCTAssertEqual(animation.duration, TabLoadingSpinnerLayerView.rotationDuration, accuracy: 0.001)
+        XCTAssertEqual(animation.repeatCount, .infinity)
+        XCTAssertFalse(animation.isRemovedOnCompletion)
+        XCTAssertEqual(spinner.arcStrokeEndForTesting, 0.28, accuracy: 0.001)
+        XCTAssertEqual(spinner.ringWidthForTesting, max(1.6, 12 * 0.14), accuracy: 0.001)
+    }
+
+    @MainActor
+    func testLoadingSpinnerStopsCoreAnimationWhenRemovedFromWindow() throws {
+        let spinner = TabLoadingSpinnerLayerView(frame: NSRect(x: 4, y: 4, width: 12, height: 12))
+        spinner.configure(size: 12, color: .labelColor)
+
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 20, height: 20))
+        let window = NSWindow(
+            contentRect: contentView.bounds,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = contentView
+        contentView.addSubview(spinner)
+        XCTAssertNotNil(spinner.activeRotationAnimationForTesting)
+
+        spinner.removeFromSuperview()
+        XCTAssertNil(spinner.activeRotationAnimationForTesting)
     }
 
     func testTabControlShortcutHintPolicyMatchesConfiguredModifiers() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1840,15 +1840,17 @@ final class BonsplitTests: XCTestCase {
         contentView.layoutSubtreeIfNeeded()
         spinner.layoutSubtreeIfNeeded()
 
-        let animation = try XCTUnwrap(
-            spinner.activeRotationAnimationForTesting as? CABasicAnimation
-        )
-        XCTAssertEqual(animation.keyPath, "transform.rotation.z")
-        XCTAssertEqual(animation.duration, TabLoadingSpinnerLayerView.rotationDuration, accuracy: 0.001)
-        XCTAssertEqual(animation.repeatCount, .infinity)
-        XCTAssertFalse(animation.isRemovedOnCompletion)
-        XCTAssertEqual(spinner.arcStrokeEndForTesting, 0.28, accuracy: 0.001)
-        XCTAssertEqual(spinner.ringWidthForTesting, max(1.6, 12 * 0.14), accuracy: 0.001)
+        try withExtendedLifetime(window) {
+            let animation = try XCTUnwrap(
+                spinner.activeRotationAnimationForTesting as? CABasicAnimation
+            )
+            XCTAssertEqual(animation.keyPath, "transform.rotation.z")
+            XCTAssertEqual(animation.duration, TabLoadingSpinnerLayerView.rotationDuration, accuracy: 0.001)
+            XCTAssertEqual(animation.repeatCount, .infinity)
+            XCTAssertFalse(animation.isRemovedOnCompletion)
+            XCTAssertEqual(spinner.arcStrokeEndForTesting, 0.28, accuracy: 0.001)
+            XCTAssertEqual(spinner.ringWidthForTesting, max(1.6, 12 * 0.14), accuracy: 0.001)
+        }
     }
 
     @MainActor
@@ -1865,10 +1867,13 @@ final class BonsplitTests: XCTestCase {
         )
         window.contentView = contentView
         contentView.addSubview(spinner)
-        XCTAssertNotNil(spinner.activeRotationAnimationForTesting)
 
-        spinner.removeFromSuperview()
-        XCTAssertNil(spinner.activeRotationAnimationForTesting)
+        withExtendedLifetime(window) {
+            XCTAssertNotNil(spinner.activeRotationAnimationForTesting)
+
+            spinner.removeFromSuperview()
+            XCTAssertNil(spinner.activeRotationAnimationForTesting)
+        }
     }
 
     func testTabControlShortcutHintPolicyMatchesConfiguredModifiers() {


### PR DESCRIPTION
## Summary
- Replace the SwiftUI TimelineView tab loading spinner with a Core Animation-backed layer view.
- Add tests for installing and stopping the compositor rotation animation.

## Testing
- swift test --package-path vendor/bonsplit

## Task
- Browser loading indicator should keep animating when the app main thread lags.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782091323&installation_id=133855650&pr_number=130&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F130&signature=52f36fb6ff00c73ef16dfd5beee3e0a33f64ca78fa8e7e719ffed4f5bd7f3468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the tab loading spinner from SwiftUI to Core Animation so it keeps animating smoothly even when the main thread lags. This meets the requirement that the browser loading indicator stays active under main-thread load.

- **Refactors**
  - Replaced `TimelineView` spinner with a Core Animation–backed `TabLoadingSpinnerLayerView` via `NSViewRepresentable` (0.9s linear rotation).
  - Switched icon tinting to `NSColor` to feed layer `CGColor`; updated track/arc drawing and ring width scaling.
  - Stabilized and expanded tests to verify rotation animation setup, ring width and stroke end, and lifecycle (starts in a window, stops when removed).

<sup>Written for commit 72f775bcb25eb256800c98b1b30fd2e973b03b7e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/130?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab loading spinner to properly update appearance and animations during layout transitions and window state changes.

* **Tests**
  * Added comprehensive test coverage for tab loading spinner animation behavior and lifecycle management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->