### PR TITLE
Resolve spinner colors with view appearance

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -597,7 +597,10 @@ final class TabLoadingSpinnerLayerView: NSView {
     }
 
     private func resolvedCGColor(_ color: NSColor, alphaMultiplier: CGFloat) -> CGColor {
-        let resolved = color.usingColorSpace(NSColorSpace.sRGB) ?? color
+        var resolved = color
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(NSColorSpace.sRGB) ?? color
+        }
         let alpha = resolved.alphaComponent * alphaMultiplier
         return resolved.withAlphaComponent(alpha).cgColor
     }
@@ -628,6 +631,10 @@ final class TabLoadingSpinnerLayerView: NSView {
 
     var ringWidthForTesting: CGFloat {
         arcLayer.lineWidth
+    }
+
+    var arcStrokeColorForTesting: CGColor? {
+        arcLayer.strokeColor
     }
 }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1862,6 +1862,37 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testLoadingSpinnerResolvesDynamicColorWithEffectiveAppearance() throws {
+        let previousAppearance = NSApplication.shared.appearance
+        NSApplication.shared.appearance = NSAppearance(named: .aqua)
+        defer { NSApplication.shared.appearance = previousAppearance }
+
+        let spinner = TabLoadingSpinnerLayerView(frame: NSRect(x: 4, y: 4, width: 12, height: 12))
+        spinner.configure(size: 12, color: .labelColor)
+
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 20, height: 20))
+        let window = NSWindow(
+            contentRect: contentView.bounds,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.contentView = contentView
+        contentView.addSubview(spinner)
+        contentView.layoutSubtreeIfNeeded()
+        spinner.layoutSubtreeIfNeeded()
+
+        try withExtendedLifetime(window) {
+            let cgColor = try XCTUnwrap(spinner.arcStrokeColorForTesting)
+            let color = try XCTUnwrap(NSColor(cgColor: cgColor)?.usingColorSpace(.sRGB))
+            XCTAssertGreaterThan(color.redComponent, 0.9)
+            XCTAssertGreaterThan(color.greenComponent, 0.9)
+            XCTAssertGreaterThan(color.blueComponent, 0.9)
+        }
+    }
+
+    @MainActor
     func testLoadingSpinnerStopsCoreAnimationWhenRemovedFromWindow() throws {
         let spinner = TabLoadingSpinnerLayerView(frame: NSRect(x: 4, y: 4, width: 12, height: 12))
         spinner.configure(size: 12, color: .labelColor)


### PR DESCRIPTION
## Summary
- resolve Core Animation spinner semantic colors using the hosting view's effective appearance
- add a regression test for a dark window hosted while the app drawing appearance is light

## Testing
- swift test --filter testLoadingSpinner
- swift test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782095267&installation_id=133855650&pr_number=131&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F131&signature=8aef7767d12f034cf09eb11a00db0068eac0647faa9cc14a36f34c3cdf6b5071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the loading spinner so it resolves semantic colors using the hosting view’s effective appearance. This ensures the spinner matches dark/light mode, even when a dark window is shown in a light-mode app.

- **Bug Fixes**
  - Resolve dynamic `NSColor` in `TabLoadingSpinnerLayerView` using `effectiveAppearance.performAsCurrentDrawingAppearance`.
  - Add regression test for a dark window under a light app appearance; expose `arcStrokeColorForTesting` for assertions.

<sup>Written for commit 55e4fcedb724264e5687c960d412cbea68da0e0c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/131?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading spinner color rendering to properly respect the current system appearance, ensuring correct display in both light and dark modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->