### PR TITLE
Preserve split entry divider ratio

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -240,8 +240,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             context.coordinator.initialDividerApplyAttempts = 0
 
             if animationOrigin != nil {
-                let targetPosition = availableSize * 0.5
-                splitState.dividerPosition = 0.5
+                let targetDividerPosition = min(max(splitState.dividerPosition, 0.1), 0.9)
+                let targetPosition = availableSize * targetDividerPosition
+                splitState.dividerPosition = targetDividerPosition
 
                 if shouldAnimate {
                     // Position at edge while new pane is hidden
@@ -268,9 +269,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                             duration: duration
                         ) {
                             context.coordinator.isAnimating = false
-                            // Re-assert exact 0.5 ratio to prevent pixel-rounding drift
-                            splitState.dividerPosition = 0.5
-                            context.coordinator.lastAppliedPosition = 0.5
+                            // Re-assert the target ratio to prevent pixel-rounding drift.
+                            splitState.dividerPosition = targetDividerPosition
+                            context.coordinator.lastAppliedPosition = targetDividerPosition
 #if DEBUG
                             dlog(
                                 "split.entry.complete split=\(splitDebugToken) orientation=\(orientationToken) " +
@@ -282,6 +283,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 } else {
                     // No animation - just set the position immediately
                     context.coordinator.setPositionSafely(targetPosition, in: splitView, layout: false)
+                    context.coordinator.lastAppliedPosition = targetDividerPosition
 #if DEBUG
                     dlog(
                         "split.entry.noAnimation split=\(splitDebugToken) orientation=\(orientationToken) " +


### PR DESCRIPTION
## Summary
- Merge the cmux.json split-ratio fix into current bonsplit main.
- Preserve the configured splitState divider ratio during initial split entry layout instead of hardcoding 0.5.

## Context
Needed by manaflow-ai/cmux#3980 after main advanced the bonsplit submodule pointer.

## Testing
- Not run locally; parent cmux CI covers the regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782099169&installation_id=133855650&pr_number=132&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F132&signature=91c53d070af2632bad69529fb9aac6ba48a6ab46a1a823d3de8df104080a8aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the saved split divider ratio during initial split entry instead of forcing 0.5, so the split matches user/configured preferences (needed by manaflow-ai/cmux#3980). Clamps the ratio to 0.1–0.9, applies the correct target position, and re-asserts the ratio after animation to avoid rounding drift.

<sup>Written for commit 627251ff0961f2f5d6e226bbc6911dbe74294396. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/132?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed split container view to properly initialize with the configured divider position instead of always defaulting to a centered split on entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->