### PR TITLE
Honor disabled tab close affordances

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1287,6 +1287,7 @@ struct TabBarView: View {
             allowsShortcutHints: isFocused && splitViewController.tabShortcutHintsEnabled,
             showsControlShortcutHint: showsControlShortcutHints,
             shortcutModifierSymbol: controlKeyMonitor.shortcutModifierSymbol,
+            allowsClose: controller.configuration.allowCloseTabs,
             contextMenuState: contextMenuState,
             moveDestinationsProvider: {
                 controller.tabContextMoveDestinationsProvider?(TabID(id: tab.id), pane.id) ?? []
@@ -1303,14 +1304,14 @@ struct TabBarView: View {
                     controller.focusPane(pane.id)
                 }
             },
-            onClose: {
+            onClose: { source in
                 guard !tab.isPinned else { return }
                 // Close should be instant (no fade-out/removal animation).
 #if DEBUG
                 dlog("tab.close pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5)) title=\"\(tab.title)\"")
 #endif
                 withTransaction(Transaction(animation: nil)) {
-                    controller.onTabCloseRequest?(TabID(id: tab.id), pane.id)
+                    controller.onTabCloseRequest?(TabID(id: tab.id), pane.id, source)
                     _ = controller.closeTab(TabID(id: tab.id), inPane: pane.id)
                 }
             },
@@ -1360,17 +1361,19 @@ struct TabBarView: View {
     }
 
     private func contextMenuState(for tab: TabItem, at index: Int) -> TabContextMenuState {
+        let allowsCloseTabs = controller.configuration.allowCloseTabs
         let leftTabs = pane.tabs.prefix(index)
-        let canCloseToLeft = leftTabs.contains(where: { !$0.isPinned })
+        let canCloseToLeft = allowsCloseTabs && leftTabs.contains(where: { !$0.isPinned })
         let canCloseToRight: Bool
         if (index + 1) < pane.tabs.count {
-            canCloseToRight = pane.tabs.suffix(from: index + 1).contains(where: { !$0.isPinned })
+            canCloseToRight = allowsCloseTabs && pane.tabs.suffix(from: index + 1).contains(where: { !$0.isPinned })
         } else {
             canCloseToRight = false
         }
-        let canCloseOthers = pane.tabs.enumerated().contains { itemIndex, item in
-            itemIndex != index && !item.isPinned
-        }
+        let canCloseOthers = allowsCloseTabs
+            && pane.tabs.enumerated().contains { itemIndex, item in
+                itemIndex != index && !item.isPinned
+            }
         return TabContextMenuState(
             isPinned: tab.isPinned,
             isUnread: tab.showsNotificationBadge,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -70,10 +70,11 @@ struct TabItemView: View {
     let allowsShortcutHints: Bool
     let showsControlShortcutHint: Bool
     let shortcutModifierSymbol: String
+    let allowsClose: Bool
     let contextMenuState: TabContextMenuState
     let moveDestinationsProvider: () -> [TabContextMoveDestination]
     let onSelect: () -> Void
-    let onClose: () -> Void
+    let onClose: (TabCloseRequestSource) -> Void
     let onZoomToggle: () -> Void
     let onContextAction: (TabContextAction) -> Void
     let onMoveDestination: (String) -> Void
@@ -207,8 +208,8 @@ struct TabItemView: View {
         // Middle click to close (macOS convention).
         // Uses an AppKit event monitor so it doesn't interfere with left click selection or drag/reorder.
         .background(MiddleClickMonitorView(onMiddleClick: {
-            guard !tab.isPinned else { return }
-            onClose()
+            guard allowsClose, !tab.isPinned else { return }
+            onClose(.middleClick)
         }))
         .background(TabContextMenuPresenter(
             snapshot: TabContextMenuSnapshot(
@@ -436,10 +437,10 @@ struct TabItemView: View {
                         .frame(width: accessorySlotSize, height: accessorySlotSize)
                         .saturation(saturation)
                 }
-            } else if isSelected || isHovered || isCloseHovered {
+            } else if allowsClose && (isSelected || isHovered || isCloseHovered) {
                 // Close button (always visible on active tab, shown on hover for others)
                 Button {
-                    onClose()
+                    onClose(.closeButton)
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: TabBarMetrics.closeIconSize, weight: .semibold))

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -79,7 +79,7 @@ public final class BonsplitController {
 
     /// Called when the user explicitly requests to close a tab from the tab strip UI.
     /// Internal host-driven closes should not use this hook.
-    @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID) -> Void)?
+    @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID, _ source: TabCloseRequestSource) -> Void)?
 
     /// Called when the user explicitly requests to toggle zoom from tab chrome.
     /// When set, the host owns the full toggle and should return whether it succeeded.

--- a/Sources/Bonsplit/Public/Types/TabCloseRequestSource.swift
+++ b/Sources/Bonsplit/Public/Types/TabCloseRequestSource.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Describes the user gesture that requested a tab-strip close.
+public enum TabCloseRequestSource: Sendable, Equatable {
+    case closeButton
+    case middleClick
+}


### PR DESCRIPTION
## Summary
- honor allowCloseTabs by hiding the tab close button and disabling middle-click/context close affordances
- report whether a tab close request came from the close button or middle click so hosts can apply source-specific policy

## Verification
- Not run locally; cmux issue #4622 work runs validation in the parent PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782099308&installation_id=133855650&pr_number=133&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F133&signature=c8c8893106ac999c96164d514825205e95917fb522832418ced17be45431b39e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `allowCloseTabs` by hiding the X button and disabling middle-click/context close, and report the close request source so hosts can apply different rules per gesture.

- **New Features**
  - Tab strip now honors `allowCloseTabs`: hides the close button, ignores middle-click to close, and disables “Close Left/Right/Others” when closing is not allowed.
  - Added `TabCloseRequestSource` (`.closeButton`, `.middleClick`) and updated `onTabCloseRequest` to include a `source` parameter.

- **Migration**
  - Update any `onTabCloseRequest` handlers to accept the new `source` argument.
  - Ensure `allowCloseTabs` is true if you rely on middle-click tab closing.

<sup>Written for commit 2930de407b86b7755feefb88e9fee720e283c56c. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/133?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

