### PR TITLE
Fix tab indicator animation drift

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1915,6 +1915,9 @@ struct TabBarView: View {
                 .fill(TabBarColors.activeIndicator(saturation: tabBarSaturation))
                 .frame(width: frame.width, height: TabBarMetrics.activeIndicatorHeight)
                 .offset(x: frame.minX)
+                .transaction { transaction in
+                    transaction.animation = nil
+                }
         }
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3300,6 +3300,7 @@ final class BonsplitTests: XCTestCase {
             }
         ) { hostingView in
             guard let scrollView = firstDescendant(ofType: NSScrollView.self, in: hostingView) else {
+                XCTFail("Expected tab bar scroll view for manual scroll regression")
                 return nil
             }
             scrollView.contentView.scroll(to: NSPoint(x: 96, y: 0))

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2260,6 +2260,30 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testActiveTabIndicatorTracksSelectedTabAfterHorizontalScroll() {
+        let size = NSSize(width: 160, height: TabBarMetrics.barHeight)
+        let range = renderedSelectedIndicatorRangeAfterManualScroll(size: size)
+        XCTAssertNil(
+            range,
+            "Selected indicator should scroll with its tab and leave the visible lane when the selected tab is manually scrolled out of view."
+        )
+    }
+
+    @MainActor
+    func testActiveTabIndicatorIgnoresAnimatedSelectionTransactions() {
+        guard let range = renderedIndicatorRangeAfterAnimatedSelectionChange() else {
+            XCTFail("Expected rendered selected indicator after selection change")
+            return
+        }
+
+        XCTAssertGreaterThan(
+            range.lowerBound,
+            TabBarMetrics.tabMinWidth - 4,
+            "Selected indicator should jump to the new selected tab instead of animating from the previous tab frame."
+        )
+    }
+
+    @MainActor
     func testSplitButtonLaneDoesNotExposeSelectedTabIndicator() {
         guard let saturation = renderedSplitButtonLaneTopSaturation() else {
             XCTFail("Expected rendered split button lane colors")
@@ -3263,6 +3287,62 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    private func renderedSelectedIndicatorRangeAfterManualScroll(size: NSSize) -> ClosedRange<CGFloat>? {
+        renderedTabBarValue(
+            isFocused: true,
+            size: size,
+            configurePane: { pane in
+                let tabs = (0..<8).map { index in
+                    TabItem(title: "Tab \(index)", icon: nil)
+                }
+                pane.tabs = tabs
+                pane.selectedTabId = tabs.first?.id
+            }
+        ) { hostingView in
+            guard let scrollView = firstDescendant(ofType: NSScrollView.self, in: hostingView) else {
+                return nil
+            }
+            scrollView.contentView.scroll(to: NSPoint(x: 96, y: 0))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            hostingView.layoutSubtreeIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            hostingView.layoutSubtreeIfNeeded()
+
+            let sampleRect = NSRect(x: 0, y: 0, width: size.width, height: 4)
+            return highSaturationRange(in: hostingView, sampleRect: sampleRect)
+        }
+    }
+
+    @MainActor
+    private func renderedIndicatorRangeAfterAnimatedSelectionChange() -> ClosedRange<CGFloat>? {
+        let first = TabItem(title: "First", icon: nil)
+        let second = TabItem(title: "Second", icon: nil)
+        let size = NSSize(width: 160, height: TabBarMetrics.barHeight)
+        var renderedPane: PaneState?
+
+        return renderedTabBarValue(
+            isFocused: true,
+            size: size,
+            configurePane: { pane in
+                renderedPane = pane
+                pane.tabs = [first, second]
+                pane.selectedTabId = first.id
+            }
+        ) { hostingView in
+            guard let renderedPane else { return nil }
+            withAnimation(.linear(duration: 10)) {
+                renderedPane.selectedTabId = second.id
+            }
+            hostingView.layoutSubtreeIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            hostingView.layoutSubtreeIfNeeded()
+
+            let sampleRect = NSRect(x: 0, y: 0, width: size.width, height: 4)
+            return highSaturationRange(in: hostingView, sampleRect: sampleRect)
+        }
+    }
+
+    @MainActor
     private func renderedSplitButtonLaneTopSaturation() -> CGFloat? {
         let buttonCount = BonsplitConfiguration.SplitActionButton.defaults.count
         let size = NSSize(width: 240, height: 28)
@@ -4017,6 +4097,51 @@ final class BonsplitTests: XCTestCase {
             }
         }
         return CGFloat(activeColumnCount) / scaleX
+    }
+
+    @MainActor
+    private func highSaturationRange(in view: NSView, sampleRect: NSRect) -> ClosedRange<CGFloat>? {
+        let integralBounds = view.bounds.integral
+        guard let bitmap = view.bitmapImageRepForCachingDisplay(in: integralBounds) else { return nil }
+        bitmap.size = integralBounds.size
+        view.cacheDisplay(in: integralBounds, to: bitmap)
+
+        let scaleX = CGFloat(bitmap.pixelsWide) / max(1, integralBounds.width)
+        let scaleY = CGFloat(bitmap.pixelsHigh) / max(1, integralBounds.height)
+        let minX = max(0, Int(floor(sampleRect.minX * scaleX)))
+        let maxX = min(bitmap.pixelsWide, Int(ceil(sampleRect.maxX * scaleX)))
+        let minY = max(0, Int(floor(sampleRect.minY * scaleY)))
+        let maxY = min(bitmap.pixelsHigh, Int(ceil(sampleRect.maxY * scaleY)))
+        var firstActiveX: Int?
+        var lastActiveX: Int?
+
+        for x in minX..<maxX {
+            var hasIndicatorPixel = false
+            for y in minY..<maxY {
+                guard let color = bitmap.colorAt(x: x, y: y),
+                      let rgb = color.usingColorSpace(.sRGB),
+                      rgb.alphaComponent > 0.05 else { continue }
+                let alpha = min(max(rgb.alphaComponent, 0), 1)
+                let red = rgb.redComponent * alpha
+                let green = rgb.greenComponent * alpha
+                let blue = rgb.blueComponent * alpha
+                let high = max(red, green, blue)
+                guard high > 0.01 else { continue }
+                let low = min(red, green, blue)
+                if (high - low) / high > 0.4 {
+                    hasIndicatorPixel = true
+                    break
+                }
+            }
+            guard hasIndicatorPixel else { continue }
+            if firstActiveX == nil {
+                firstActiveX = x
+            }
+            lastActiveX = x
+        }
+
+        guard let firstActiveX, let lastActiveX else { return nil }
+        return (CGFloat(firstActiveX) / scaleX)...(CGFloat(lastActiveX + 1) / scaleX)
     }
 
     @MainActor


### PR DESCRIPTION
Summary
- Adds Bonsplit rendering tests for the active tab indicator under horizontal scroll and inherited animated selection transactions.
- Makes the selected tab indicator opt out of inherited SwiftUI animations so it snaps to the selected tab frame.
- Hardens the manual-scroll test so missing scroll-view setup fails instead of looking like the expected offscreen indicator result.

Validation
- Red failure before fix: `testActiveTabIndicatorIgnoresAnimatedSelectionTransactions` failed with indicator lowerBound `11.0`, expected `>44.0`.
- Green pass: `swift test --package-path vendor/bonsplit --filter BonsplitTests.testActiveTabIndicator` passed on the cmux cloud Mac.

Parent PR
- Required by https://github.com/manaflow-ai/cmux/pull/4873 so the cmux submodule pointer is reachable from Bonsplit `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782477089&installation_id=133855650&pr_number=134&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F134&signature=a9ea76e637b654ba7d3366bd34804059380b6fafa830bb2e9af5b19a68a7349a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the active tab indicator drifting between tabs. The indicator now ignores inherited animations and snaps to the selected tab, and it scrolls out with its tab during horizontal scroll.

- **Bug Fixes**
  - Disabled animations for the selected indicator in `TabBarView` using a local transaction to prevent drift during animated selection changes.
  - Added rendering tests for horizontal scroll and animated selection; manual-scroll test now fails if the scroll view isn’t set up.

<sup>Written for commit 0699ba0610bdea38809d0fc12dfe555b37be0c67. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/134?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab indicator animation behavior to ensure smooth state updates without unwanted animation effects.

* **Tests**
  * Added test cases validating tab indicator visibility during scrolling and immediate selection behavior during animated transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->