### PR TITLE
Add Fork Conversation action to tab context menu

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -884,6 +884,7 @@ struct TabContextMenuState {
     let canMoveToNewWorkspace: Bool
     let canMoveToLeftPane: Bool
     let canMoveToRightPane: Bool
+    let canForkConversation: Bool
     let isZoomed: Bool
     let hasSplits: Bool
     let shortcuts: [TabContextAction: KeyboardShortcut]
@@ -1386,6 +1387,7 @@ struct TabBarView: View {
             canMoveToNewWorkspace: controller.allTabIds.count > 1,
             canMoveToLeftPane: controller.adjacentPane(to: pane.id, direction: .left) != nil,
             canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
+            canForkConversation: controller.tabContextForkConversationAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false,
             isZoomed: splitViewController.zoomedPaneId == pane.id,
             hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
             shortcuts: controller.contextMenuShortcuts

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -832,6 +832,17 @@ enum TabContextMenuBuilder {
             )
         }
 
+        if state.canForkConversation {
+            menu.addItem(.separator())
+            addAction(
+                title: localized("tabContext.forkConversation", defaultValue: "Fork Conversation"),
+                action: .forkConversation,
+                state: state,
+                target: target,
+                to: menu
+            )
+        }
+
         menu.addItem(.separator())
 
         addAction(

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -77,6 +77,11 @@ public final class BonsplitController {
     /// Host-provided destinations for the tab context menu's Move Tab submenu.
     @ObservationIgnored public var tabContextMoveDestinationsProvider: ((TabID, PaneID) -> [TabContextMoveDestination])?
 
+    /// Host-provided synchronous check that decides whether the tab context menu should
+    /// surface a "Fork Conversation" action for the tab (e.g. an active forkable agent
+    /// session). Return `true` to enable the item, `false` (or omit the provider) to hide it.
+    @ObservationIgnored public var tabContextForkConversationAvailabilityProvider: ((TabID, PaneID) -> Bool)?
+
     /// Called when the user explicitly requests to close a tab from the tab strip UI.
     /// Internal host-driven closes should not use this hook.
     @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID, _ source: TabCloseRequestSource) -> Void)?

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -20,6 +20,7 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case markAsRead
     case markAsUnread
     case toggleZoom
+    case forkConversation
 }
 
 public struct TabContextMoveDestination: Identifiable, Equatable, Sendable {

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -18,3 +18,4 @@
 "tabContext.pinTab" = "Pin Tab";
 "tabContext.markTabAsRead" = "Mark Tab as Read";
 "tabContext.markTabAsUnread" = "Mark Tab as Unread";
+"tabContext.forkConversation" = "Fork Conversation";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -18,3 +18,4 @@
 "tabContext.pinTab" = "タブをピン留め";
 "tabContext.markTabAsRead" = "タブを既読にする";
 "tabContext.markTabAsUnread" = "タブを未読にする";
+"tabContext.forkConversation" = "会話をフォーク";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1558,6 +1558,7 @@ final class BonsplitTests: XCTestCase {
             canMoveToNewWorkspace: true,
             canMoveToLeftPane: false,
             canMoveToRightPane: true,
+            canForkConversation: false,
             isZoomed: false,
             hasSplits: true,
             shortcuts: [:]


### PR DESCRIPTION
## Summary
- New `.forkConversation` case in `TabContextAction`
- New host-provided `tabContextForkConversationAvailabilityProvider` on `BonsplitController`
- Menu item added to `TabContextMenuBuilder` (shown only when the provider returns true)
- English + Japanese strings, test fixture updated for the new `canForkConversation` field

Used by cmux (see manaflow-ai/cmux companion PR) to surface a Fork Conversation entry when a tab is running an active forkable Claude or Codex session.

## Test plan
- [x] `swift build --build-tests` clean
- [ ] Visual: right-click a terminal tab whose host returns `true` for the provider, confirm "Fork Conversation" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Fork Conversation” action to the tab context menu, shown only when the host says it’s available. This lets apps surface forking for tabs running an active, forkable agent session.

- **New Features**
  - Added `TabContextAction.forkConversation`.
  - Added `BonsplitController.tabContextForkConversationAvailabilityProvider` to control visibility.
  - Menu item appears only when the provider returns true.
  - Added English and Japanese strings.

- **Migration**
  - If you switch exhaustively on `TabContextAction`, add a `.forkConversation` case (or a default).
  - Implement the new provider to enable the item for tabs with forkable sessions.

<sup>Written for commit 082bf6602d3e8fb2761d2eef199aa7e3f85fabdb. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/135?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782499956&installation_id=133855650&pr_number=135&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F135&signature=6b64b6ac4f3605f4e129facb8858bef49510182381b667641ef55f98c0bf2544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Fork Conversation" action to the tab context menu, allowing users to fork conversations directly from the interface without additional navigation. The feature is fully localized in English and Japanese. Host applications can selectively enable this action on a per-conversation basis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->