### PR TITLE
Preserve empty panes when closing restore tabs

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -386,13 +386,13 @@ final class SplitViewController {
     }
 
     /// Close a tab in a specific pane
-    func closeTab(_ tabId: UUID, inPane paneId: PaneID) {
+    func closeTab(_ tabId: UUID, inPane paneId: PaneID, closeEmptyPane: Bool = true) {
         guard let pane = rootNode.findPane(paneId) else { return }
 
         pane.removeTab(tabId)
 
         // If pane is now empty and not the only pane, close it
-        if pane.tabs.isEmpty && rootNode.allPaneIds.count > 1 {
+        if closeEmptyPane, pane.tabs.isEmpty && rootNode.allPaneIds.count > 1 {
             closePane(paneId)
         }
     }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -267,7 +267,7 @@ public final class BonsplitController {
     @discardableResult
     public func closeTab(_ tabId: TabID) -> Bool {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return false }
-        return closeTab(tabId, with: tabIndex, in: pane)
+        return closeTab(tabId, with: tabIndex, in: pane, closeEmptyPane: true)
     }
     
     /// Close a tab by ID in a specific pane.
@@ -278,15 +278,25 @@ public final class BonsplitController {
               let tabIndex = pane.tabs.firstIndex(where: { $0.id == tabId.id }) else {
             return false
         }
-        
-        return closeTab(tabId, with: tabIndex, in: pane)
+
+        return closeTab(tabId, with: tabIndex, in: pane, closeEmptyPane: true)
     }
-    
+
+    /// Close a tab while preserving its pane if the close leaves the pane empty.
+    ///
+    /// This is useful for restore/migration flows that must remove temporary tabs
+    /// without changing the saved split tree shape.
+    @discardableResult
+    public func closeTabPreservingEmptyPane(_ tabId: TabID) -> Bool {
+        guard let (pane, tabIndex) = findTabInternal(tabId) else { return false }
+        return closeTab(tabId, with: tabIndex, in: pane, closeEmptyPane: false)
+    }
+
     /// Internal helper to close a tab given its index in a pane
     /// - Parameter tabId: The tab to close
     /// - Parameter tabIndex: The position of the tab within the pane
     /// - Parameter pane: The pane in which to close the tab
-    private func closeTab(_ tabId: TabID, with tabIndex: Int, in pane: PaneState) -> Bool {
+    private func closeTab(_ tabId: TabID, with tabIndex: Int, in pane: PaneState, closeEmptyPane: Bool) -> Bool {
         let tabItem = pane.tabs[tabIndex]
         let tab = Tab(from: tabItem)
         let paneId = pane.id
@@ -296,7 +306,7 @@ public final class BonsplitController {
             return false
         }
 
-        internalController.closeTab(tabId.id, inPane: pane.id)
+        internalController.closeTab(tabId.id, inPane: pane.id, closeEmptyPane: closeEmptyPane)
 
         // Notify delegate
         delegate?.splitTabBar(self, didCloseTab: tabId, fromPane: paneId)


### PR DESCRIPTION
## Summary

Adds a `closeTabPreservingEmptyPane` controller API so cmux restore/migration flows can remove temporary tabs without collapsing the saved split pane.

## Testing

Validated through cmux PR https://github.com/manaflow-ai/cmux/pull/4089 focused AWS unit coverage, including empty dock split restoration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782529278&installation_id=133855650&pr_number=136&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F136&signature=41817edeb37a39913d0b08168ffd3e39453e1a901dce695f1f695466c8c42bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves empty panes when closing temporary restore tabs so the saved split layout isn’t collapsed. Adds a public API to close a tab without removing its pane; default close behavior is unchanged.

- New Features
  - Added `closeTabPreservingEmptyPane(_:)` to `BonsplitController` to remove temp tabs while keeping the pane during restore/migration flows.
  - Extended close logic with a `closeEmptyPane` flag and plumbed it through to `SplitViewController.closeTab(_:inPane:closeEmptyPane:)`.

<sup>Written for commit 033083359400f2de98fca8666c20f37e2e708cb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/136?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tab closing option that preserves empty panes when removing tabs, providing more control over workspace layout management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->