### PR TITLE
Add browser tab audio mute action for cmux #4910

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -24,6 +24,7 @@ struct TabItem: Identifiable, Hashable, Codable {
     var isDirty: Bool
     var showsNotificationBadge: Bool
     var isLoading: Bool
+    var isAudioMuted: Bool
     var isPinned: Bool
 
     init(
@@ -36,6 +37,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         isDirty: Bool = false,
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
+        isAudioMuted: Bool = false,
         isPinned: Bool = false
     ) {
         self.id = id
@@ -47,6 +49,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.isDirty = isDirty
         self.showsNotificationBadge = showsNotificationBadge
         self.isLoading = isLoading
+        self.isAudioMuted = isAudioMuted
         self.isPinned = isPinned
     }
 
@@ -68,6 +71,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         case isDirty
         case showsNotificationBadge
         case isLoading
+        case isAudioMuted
         case isPinned
     }
 
@@ -82,6 +86,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.isDirty = try c.decodeIfPresent(Bool.self, forKey: .isDirty) ?? false
         self.showsNotificationBadge = try c.decodeIfPresent(Bool.self, forKey: .showsNotificationBadge) ?? false
         self.isLoading = try c.decodeIfPresent(Bool.self, forKey: .isLoading) ?? false
+        self.isAudioMuted = try c.decodeIfPresent(Bool.self, forKey: .isAudioMuted) ?? false
         self.isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
     }
 
@@ -96,6 +101,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         try c.encode(isDirty, forKey: .isDirty)
         try c.encode(showsNotificationBadge, forKey: .showsNotificationBadge)
         try c.encode(isLoading, forKey: .isLoading)
+        try c.encode(isAudioMuted, forKey: .isAudioMuted)
         try c.encode(isPinned, forKey: .isPinned)
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -876,6 +876,7 @@ struct TabContextMenuState {
     let isPinned: Bool
     let isUnread: Bool
     let isBrowser: Bool
+    let isAudioMuted: Bool
     let isTerminal: Bool
     let hasCustomTitle: Bool
     let canCloseToLeft: Bool
@@ -1379,6 +1380,7 @@ struct TabBarView: View {
             isPinned: tab.isPinned,
             isUnread: tab.showsNotificationBadge,
             isBrowser: tab.kind == "browser",
+            isAudioMuted: tab.isAudioMuted,
             isTerminal: tab.kind == "terminal",
             hasCustomTitle: tab.hasCustomTitle,
             canCloseToLeft: canCloseToLeft,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -157,6 +157,19 @@ struct TabItemView: View {
                     )
                     .saturation(saturation)
 
+                if tab.isAudioMuted {
+                    Image(systemName: "speaker.slash")
+                        .font(.system(size: accessoryFontSize, weight: .semibold))
+                        .foregroundStyle(
+                            (isSelected
+                                ? TabBarColors.activeText(for: appearance)
+                                : TabBarColors.inactiveText(for: appearance))
+                                .opacity(0.78)
+                        )
+                        .saturation(saturation)
+                        .accessibilityHidden(true)
+                }
+
                 if showsZoomIndicator {
                     Button {
                         onZoomToggle()
@@ -377,6 +390,9 @@ struct TabItemView: View {
         if tab.isPinned { parts.append("Pinned") }
         if tab.showsNotificationBadge { parts.append("Unread") }
         if tab.isDirty { parts.append("Modified") }
+        if tab.isAudioMuted {
+            parts.append(Bundle.module.localizedString(forKey: "tabContext.audioMutedAccessibility", value: "Muted", table: nil))
+        }
         if showsZoomIndicator { parts.append("Zoomed") }
         return parts.joined(separator: ", ")
     }
@@ -862,6 +878,15 @@ enum TabContextMenuBuilder {
 
         if state.isBrowser {
             menu.addItem(.separator())
+            addAction(
+                title: state.isAudioMuted
+                    ? localized("tabContext.unmuteTab", defaultValue: "Unmute Tab")
+                    : localized("tabContext.muteTab", defaultValue: "Mute Tab"),
+                action: .toggleAudioMute,
+                state: state,
+                target: target,
+                to: menu
+            )
             addAction(
                 title: localized("tabContext.reloadTab", defaultValue: "Reload Tab"),
                 action: .reload,

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -114,6 +114,7 @@ public final class BonsplitController {
     ///   - isDirty: Whether the tab shows a dirty indicator
     ///   - showsNotificationBadge: Whether the tab shows an "unread/activity" badge
     ///   - isLoading: Whether the tab shows an activity/loading indicator (e.g. spinning icon)
+    ///   - isAudioMuted: Whether the tab shows browser audio as muted
     ///   - isPinned: Whether the tab should be treated as pinned
     ///   - pane: Optional pane to add the tab to (defaults to focused pane)
     /// - Returns: The TabID of the created tab, or nil if creation was vetoed by delegate
@@ -127,6 +128,7 @@ public final class BonsplitController {
         isDirty: Bool = false,
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
+        isAudioMuted: Bool = false,
         isPinned: Bool = false,
         inPane pane: PaneID? = nil
     ) -> TabID? {
@@ -141,6 +143,7 @@ public final class BonsplitController {
             isDirty: isDirty,
             showsNotificationBadge: showsNotificationBadge,
             isLoading: isLoading,
+            isAudioMuted: isAudioMuted,
             isPinned: isPinned
         )
         let targetPane = pane ?? focusedPaneId ?? PaneID(id: internalController.rootNode.allPaneIds.first!.id)
@@ -178,6 +181,7 @@ public final class BonsplitController {
             isDirty: isDirty,
             showsNotificationBadge: showsNotificationBadge,
             isLoading: isLoading,
+            isAudioMuted: isAudioMuted,
             isPinned: isPinned
         )
         internalController.addTab(tabItem, toPane: PaneID(id: targetPane.id), atIndex: insertIndex)
@@ -222,6 +226,7 @@ public final class BonsplitController {
     ///   - isDirty: New dirty state (pass nil to keep current)
     ///   - showsNotificationBadge: New badge state (pass nil to keep current)
     ///   - isLoading: New loading/busy state (pass nil to keep current)
+    ///   - isAudioMuted: New browser-audio mute state (pass nil to keep current)
     ///   - isPinned: New pinned state (pass nil to keep current)
     public func updateTab(
         _ tabId: TabID,
@@ -233,6 +238,7 @@ public final class BonsplitController {
         isDirty: Bool? = nil,
         showsNotificationBadge: Bool? = nil,
         isLoading: Bool? = nil,
+        isAudioMuted: Bool? = nil,
         isPinned: Bool? = nil
     ) {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return }
@@ -260,6 +266,9 @@ public final class BonsplitController {
         }
         if let isLoading = isLoading {
             pane.tabs[tabIndex].isLoading = isLoading
+        }
+        if let isAudioMuted = isAudioMuted {
+            pane.tabs[tabIndex].isAudioMuted = isAudioMuted
         }
         if let isPinned = isPinned {
             pane.tabs[tabIndex].isPinned = isPinned
@@ -427,6 +436,7 @@ public final class BonsplitController {
                 isDirty: tab.isDirty,
                 showsNotificationBadge: tab.showsNotificationBadge,
                 isLoading: tab.isLoading,
+                isAudioMuted: tab.isAudioMuted,
                 isPinned: tab.isPinned
             )
         } else {
@@ -491,6 +501,7 @@ public final class BonsplitController {
             isDirty: tab.isDirty,
             showsNotificationBadge: tab.showsNotificationBadge,
             isLoading: tab.isLoading,
+            isAudioMuted: tab.isAudioMuted,
             isPinned: tab.isPinned
         )
 

--- a/Sources/Bonsplit/Public/Types/Tab.swift
+++ b/Sources/Bonsplit/Public/Types/Tab.swift
@@ -15,6 +15,8 @@ public struct Tab: Identifiable, Hashable, Sendable {
     public let showsNotificationBadge: Bool
     /// Whether the tab should show an activity/loading indicator (e.g. spinning icon).
     public let isLoading: Bool
+    /// Whether the tab should show browser audio as muted.
+    public let isAudioMuted: Bool
     /// Whether the tab is pinned in its pane.
     public let isPinned: Bool
 
@@ -28,6 +30,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         isDirty: Bool = false,
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
+        isAudioMuted: Bool = false,
         isPinned: Bool = false
     ) {
         self.id = id
@@ -39,6 +42,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.isDirty = isDirty
         self.showsNotificationBadge = showsNotificationBadge
         self.isLoading = isLoading
+        self.isAudioMuted = isAudioMuted
         self.isPinned = isPinned
     }
 
@@ -52,6 +56,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.isDirty = tabItem.isDirty
         self.showsNotificationBadge = tabItem.showsNotificationBadge
         self.isLoading = tabItem.isLoading
+        self.isAudioMuted = tabItem.isAudioMuted
         self.isPinned = tabItem.isPinned
     }
 }

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -16,6 +16,7 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case newBrowserToRight
     case reload
     case duplicate
+    case toggleAudioMute
     case togglePin
     case markAsRead
     case markAsUnread

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -12,6 +12,9 @@
 "tabContext.newBrowserTabToRight" = "New Browser Tab to Right";
 "tabContext.reloadTab" = "Reload Tab";
 "tabContext.duplicateTab" = "Duplicate Tab";
+"tabContext.muteTab" = "Mute Tab";
+"tabContext.unmuteTab" = "Unmute Tab";
+"tabContext.audioMutedAccessibility" = "Muted";
 "tabContext.exitZoom" = "Exit Zoom";
 "tabContext.zoomPane" = "Zoom Pane";
 "tabContext.unpinTab" = "Unpin Tab";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -12,6 +12,9 @@
 "tabContext.newBrowserTabToRight" = "右側に新しいブラウザータブ";
 "tabContext.reloadTab" = "タブを再読み込み";
 "tabContext.duplicateTab" = "タブを複製";
+"tabContext.muteTab" = "タブをミュート";
+"tabContext.unmuteTab" = "タブのミュートを解除";
+"tabContext.audioMutedAccessibility" = "ミュート中";
 "tabContext.exitZoom" = "ズームを終了";
 "tabContext.zoomPane" = "ペインをズーム";
 "tabContext.unpinTab" = "タブのピン留めを解除";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1550,6 +1550,7 @@ final class BonsplitTests: XCTestCase {
             isPinned: false,
             isUnread: false,
             isBrowser: false,
+            isAudioMuted: false,
             isTerminal: true,
             hasCustomTitle: false,
             canCloseToLeft: true,
@@ -1591,6 +1592,73 @@ final class BonsplitTests: XCTestCase {
         let workspaceItem = try XCTUnwrap(moveItem?.submenu?.items.dropFirst().first)
         target.performMoveDestination(workspaceItem)
         XCTAssertEqual(selectedDestinationId, "workspace:abc")
+    }
+
+    @MainActor
+    func testBrowserTabContextMenuCreatesAudioMuteToggle() throws {
+        let target = TabContextMenuActionTarget()
+        var selectedAction: TabContextAction?
+        target.onContextAction = { selectedAction = $0 }
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: TabContextMenuState(
+                isPinned: false,
+                isUnread: false,
+                isBrowser: true,
+                isAudioMuted: false,
+                isTerminal: false,
+                hasCustomTitle: false,
+                canCloseToLeft: false,
+                canCloseToRight: false,
+                canCloseOthers: false,
+                canMoveToNewWorkspace: false,
+                canMoveToLeftPane: false,
+                canMoveToRightPane: false,
+                canForkConversation: false,
+                isZoomed: false,
+                hasSplits: false,
+                shortcuts: [:]
+            ),
+            moveDestinationsProvider: { [] }
+        )
+
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+        let muteItem = try XCTUnwrap(menu.items.first { $0.title == "Mute Tab" })
+        target.performContextAction(muteItem)
+
+        XCTAssertEqual(selectedAction, .toggleAudioMute)
+    }
+
+    @MainActor
+    func testBrowserTabContextMenuUsesUnmuteTitleWhenAudioMuted() throws {
+        let target = TabContextMenuActionTarget()
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: TabContextMenuState(
+                isPinned: false,
+                isUnread: false,
+                isBrowser: true,
+                isAudioMuted: true,
+                isTerminal: false,
+                hasCustomTitle: false,
+                canCloseToLeft: false,
+                canCloseToRight: false,
+                canCloseOthers: false,
+                canMoveToNewWorkspace: false,
+                canMoveToLeftPane: false,
+                canMoveToRightPane: false,
+                canForkConversation: false,
+                isZoomed: false,
+                hasSplits: false,
+                shortcuts: [:]
+            ),
+            moveDestinationsProvider: { [] }
+        )
+
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+
+        XCTAssertTrue(menu.items.contains { $0.title == "Unmute Tab" })
+        XCTAssertFalse(menu.items.contains { $0.title == "Mute Tab" })
     }
 
     @MainActor


### PR DESCRIPTION
Adds tab metadata and context-menu plumbing for browser audio mute state used by manaflow-ai/cmux#4910.\n\nThis keeps the cmux mute control on the pane tab context menu instead of the browser toolbar.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782593906&installation_id=133855650&pr_number=137&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F137&signature=f1f61d7b42049a397fe9d5c80dea5c817ecf0be1022cb05488616e465383f22e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Mute/Unmute action for browser tabs in the tab context menu and tracks each tab’s audio mute state. Keeps the control in the pane tab menu (not the browser toolbar) to support `manaflow-ai/cmux#4910`.

- **New Features**
  - Added `isAudioMuted` to tab models and public `Tab`; exposed in `BonsplitController.createTab` and `.updateTab`.
  - Added context menu item for browser tabs that toggles between “Mute Tab” and “Unmute Tab”; new `TabContextAction.toggleAudioMute`.
  - Shows a speaker-slash icon on muted tabs and an accessibility label.
  - Added localized strings (en, ja) and tests for the new menu behavior.

- **Migration**
  - Handle `toggleAudioMute` in your context action handler to toggle the browser’s audio state.
  - Set `isAudioMuted` when creating or updating tabs to keep the UI in sync.

<sup>Written for commit 9166c3639fabb80bca050d57d7cbf3fe66248c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tab audio mute: mute/unmute tabs from the tab context menu; muted tabs show a speaker‑slash icon and accessibility label.
* **Localization**
  * Added English and Japanese strings for mute/unmute actions and muted accessibility label.
* **Tests**
  * Updated context-menu tests to cover mute/unmute states and actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->