### PR TITLE
Add fork conversation destinations to context menu

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -885,6 +885,7 @@ struct TabContextMenuState {
     let canMoveToLeftPane: Bool
     let canMoveToRightPane: Bool
     let canForkConversation: Bool
+    let forkConversationDefaultAction: TabContextAction
     let isZoomed: Bool
     let hasSplits: Bool
     let shortcuts: [TabContextAction: KeyboardShortcut]
@@ -1388,6 +1389,7 @@ struct TabBarView: View {
             canMoveToLeftPane: controller.adjacentPane(to: pane.id, direction: .left) != nil,
             canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
             canForkConversation: controller.tabContextForkConversationAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false,
+            forkConversationDefaultAction: controller.tabContextForkConversationDefaultActionProvider?(TabID(id: tab.id), pane.id) ?? .defaultForkConversationDestination,
             isZoomed: splitViewController.zoomedPaneId == pane.id,
             hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
             shortcuts: controller.contextMenuShortcuts

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -841,6 +841,7 @@ enum TabContextMenuBuilder {
                 target: target,
                 to: menu
             )
+            menu.addItem(forkConversationSubmenuItem(state: state, target: target))
         }
 
         menu.addItem(.separator())
@@ -972,6 +973,76 @@ enum TabContextMenuBuilder {
         return item
     }
 
+    private static func forkConversationSubmenuItem(
+        state: TabContextMenuState,
+        target: TabContextMenuActionTarget
+    ) -> NSMenuItem {
+        let item = NSMenuItem(
+            title: localized("tabContext.forkConversationTo", defaultValue: "Fork Conversation To"),
+            action: nil,
+            keyEquivalent: ""
+        )
+        let submenu = NSMenu()
+        submenu.autoenablesItems = false
+        let defaultAction = state.forkConversationDefaultAction.isForkConversationDestination
+            ? state.forkConversationDefaultAction
+            : .defaultForkConversationDestination
+
+        addAction(
+            title: localized("tabContext.forkConversation.right", defaultValue: "Right Split"),
+            action: .forkConversationRight,
+            state: state,
+            target: target,
+            to: submenu,
+            stateValue: defaultAction == .forkConversationRight ? .on : .off
+        )
+        addAction(
+            title: localized("tabContext.forkConversation.left", defaultValue: "Left Split"),
+            action: .forkConversationLeft,
+            state: state,
+            target: target,
+            to: submenu,
+            stateValue: defaultAction == .forkConversationLeft ? .on : .off
+        )
+        addAction(
+            title: localized("tabContext.forkConversation.top", defaultValue: "Top Split"),
+            action: .forkConversationTop,
+            state: state,
+            target: target,
+            to: submenu,
+            stateValue: defaultAction == .forkConversationTop ? .on : .off
+        )
+        addAction(
+            title: localized("tabContext.forkConversation.bottom", defaultValue: "Bottom Split"),
+            action: .forkConversationBottom,
+            state: state,
+            target: target,
+            to: submenu,
+            stateValue: defaultAction == .forkConversationBottom ? .on : .off
+        )
+        submenu.addItem(.separator())
+        addAction(
+            title: localized("tabContext.forkConversation.newTab", defaultValue: "New Tab"),
+            action: .forkConversationNewTab,
+            state: state,
+            target: target,
+            to: submenu,
+            stateValue: defaultAction == .forkConversationNewTab ? .on : .off
+        )
+        addAction(
+            title: localized("tabContext.forkConversation.newWorkspace", defaultValue: "New Workspace"),
+            action: .forkConversationNewWorkspace,
+            state: state,
+            target: target,
+            to: submenu,
+            stateValue: defaultAction == .forkConversationNewWorkspace ? .on : .off
+        )
+
+        item.submenu = submenu
+        item.isEnabled = true
+        return item
+    }
+
     @discardableResult
     private static func addAction(
         title: String,
@@ -979,7 +1050,8 @@ enum TabContextMenuBuilder {
         enabled: Bool = true,
         state: TabContextMenuState,
         target: TabContextMenuActionTarget,
-        to menu: NSMenu
+        to menu: NSMenu,
+        stateValue: NSControl.StateValue = .off
     ) -> NSMenuItem {
         let item = NSMenuItem(
             title: title,
@@ -989,6 +1061,7 @@ enum TabContextMenuBuilder {
         item.target = target
         item.representedObject = action.rawValue
         item.isEnabled = enabled
+        item.state = stateValue
         if let shortcut = state.shortcuts[action] {
             applyShortcut(shortcut, to: item)
         }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -82,6 +82,11 @@ public final class BonsplitController {
     /// session). Return `true` to enable the item, `false` (or omit the provider) to hide it.
     @ObservationIgnored public var tabContextForkConversationAvailabilityProvider: ((TabID, PaneID) -> Bool)?
 
+    /// Host-provided default destination for the tab context menu's primary "Fork
+    /// Conversation" action. Return a destination-specific fork action; invalid values
+    /// fall back to `.forkConversationRight`.
+    @ObservationIgnored public var tabContextForkConversationDefaultActionProvider: ((TabID, PaneID) -> TabContextAction)?
+
     /// Called when the user explicitly requests to close a tab from the tab strip UI.
     /// Internal host-driven closes should not use this hook.
     @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID, _ source: TabCloseRequestSource) -> Void)?

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -21,6 +21,28 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case markAsUnread
     case toggleZoom
     case forkConversation
+    case forkConversationRight
+    case forkConversationLeft
+    case forkConversationTop
+    case forkConversationBottom
+    case forkConversationNewTab
+    case forkConversationNewWorkspace
+
+    public static let defaultForkConversationDestination: TabContextAction = .forkConversationRight
+
+    public var isForkConversationDestination: Bool {
+        switch self {
+        case .forkConversationRight,
+             .forkConversationLeft,
+             .forkConversationTop,
+             .forkConversationBottom,
+             .forkConversationNewTab,
+             .forkConversationNewWorkspace:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 public struct TabContextMoveDestination: Identifiable, Equatable, Sendable {

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -19,3 +19,10 @@
 "tabContext.markTabAsRead" = "Mark Tab as Read";
 "tabContext.markTabAsUnread" = "Mark Tab as Unread";
 "tabContext.forkConversation" = "Fork Conversation";
+"tabContext.forkConversationTo" = "Fork Conversation To";
+"tabContext.forkConversation.right" = "Right Split";
+"tabContext.forkConversation.left" = "Left Split";
+"tabContext.forkConversation.top" = "Top Split";
+"tabContext.forkConversation.bottom" = "Bottom Split";
+"tabContext.forkConversation.newTab" = "New Tab";
+"tabContext.forkConversation.newWorkspace" = "New Workspace";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -19,3 +19,10 @@
 "tabContext.markTabAsRead" = "タブを既読にする";
 "tabContext.markTabAsUnread" = "タブを未読にする";
 "tabContext.forkConversation" = "会話をフォーク";
+"tabContext.forkConversationTo" = "会話のフォーク先";
+"tabContext.forkConversation.right" = "右分割";
+"tabContext.forkConversation.left" = "左分割";
+"tabContext.forkConversation.top" = "上分割";
+"tabContext.forkConversation.bottom" = "下分割";
+"tabContext.forkConversation.newTab" = "新規タブ";
+"tabContext.forkConversation.newWorkspace" = "新規ワークスペース";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1559,6 +1559,7 @@ final class BonsplitTests: XCTestCase {
             canMoveToLeftPane: false,
             canMoveToRightPane: true,
             canForkConversation: false,
+            forkConversationDefaultAction: .forkConversationRight,
             isZoomed: false,
             hasSplits: true,
             shortcuts: [:]
@@ -1591,6 +1592,53 @@ final class BonsplitTests: XCTestCase {
         let workspaceItem = try XCTUnwrap(moveItem?.submenu?.items.dropFirst().first)
         target.performMoveDestination(workspaceItem)
         XCTAssertEqual(selectedDestinationId, "workspace:abc")
+    }
+
+    @MainActor
+    func testTabContextMenuBuilderCreatesForkConversationSubmenu() throws {
+        let target = TabContextMenuActionTarget()
+        var selectedAction: TabContextAction?
+        target.onContextAction = { selectedAction = $0 }
+        let state = TabContextMenuState(
+            isPinned: false,
+            isUnread: false,
+            isBrowser: false,
+            isTerminal: true,
+            hasCustomTitle: false,
+            canCloseToLeft: true,
+            canCloseToRight: true,
+            canCloseOthers: true,
+            canMoveToNewWorkspace: false,
+            canMoveToLeftPane: false,
+            canMoveToRightPane: false,
+            canForkConversation: true,
+            forkConversationDefaultAction: .forkConversationLeft,
+            isZoomed: false,
+            hasSplits: false,
+            shortcuts: [:]
+        )
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: state,
+            moveDestinationsProvider: { [] }
+        )
+
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation" })
+        target.performContextAction(forkItem)
+        XCTAssertEqual(selectedAction, .forkConversation)
+
+        let forkSubmenuItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation To" })
+        let destinationItems = try XCTUnwrap(forkSubmenuItem.submenu?.items.filter { !$0.isSeparatorItem })
+        XCTAssertEqual(
+            destinationItems.map(\.title),
+            ["Right Split", "Left Split", "Top Split", "Bottom Split", "New Tab", "New Workspace"]
+        )
+        XCTAssertEqual(destinationItems.map(\.state), [.off, .on, .off, .off, .off, .off])
+
+        let newTabItem = try XCTUnwrap(destinationItems.first { $0.title == "New Tab" })
+        target.performContextAction(newTabItem)
+        XCTAssertEqual(selectedAction, .forkConversationNewTab)
     }
 
     @MainActor


### PR DESCRIPTION
Adds explicit fork-conversation context menu destinations so cmux can expose a primary default action plus a destination submenu.\n\nValidation:\n- swift test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782638673&installation_id=133855650&pr_number=138&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F138&signature=9abb66d2f7a28615ecad315dc64bbd6dccb02890b8df0cfc0e3b1230015c54f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds destination-specific “Fork Conversation” options to the tab context menu with a submenu and a host-configurable default destination. Improves discoverability and speed by exposing both a primary action and quick destination choices.

- **New Features**
  - New “Fork Conversation To” submenu with: Right, Left, Top, Bottom, New Tab, New Workspace.
  - Default destination is indicated via a checkmark; hosts can set it via `tabContextForkConversationDefaultActionProvider`.
  - Added `TabContextAction` cases for each destination, plus `isForkConversationDestination` and `defaultForkConversationDestination`.
  - `TabContextMenuState` now carries `forkConversationDefaultAction`.
  - Added localized strings for `en` and `ja`.
  - Tests cover submenu creation, default selection, and action dispatch.

<sup>Written for commit a69e28333a0bc2b30f0ad7f333d2e38bfaddf326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/138?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fork Conversation feature now displays as an expandable submenu showing multiple destination options: split right/left/top/bottom, new tab, and new workspace.
  * Added localization support for fork conversation submenu in English and Japanese languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/bonsplit/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->