### PR TITLE
Add configurable pane divider thickness

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarMetrics.swift
@@ -40,6 +40,20 @@ enum TabBarMetrics {
     static let minimumPaneHeight: CGFloat = 100
     static let dividerThickness: CGFloat = 1
 
+    /// Lower bound for a host-configured divider thickness. Zero keeps the
+    /// divider hit-testable while letting hosts hide the painted bar.
+    static let minimumDividerThickness: CGFloat = 0
+    /// Upper bound for a host-configured divider thickness. Guards against
+    /// runaway values that would swallow pane content.
+    static let maximumDividerThickness: CGFloat = 12
+
+    /// Clamp a host-supplied divider thickness into a usable range, falling
+    /// back to the hairline default for non-finite input.
+    static func resolvedDividerThickness(_ value: CGFloat) -> CGFloat {
+        guard value.isFinite else { return dividerThickness }
+        return min(max(value, minimumDividerThickness), maximumDividerThickness)
+    }
+
     // MARK: - Animations
 
     static let selectionDuration: Double = 0.15

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -356,8 +356,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.layer?.backgroundColor = NSColor.clear.cgColor
         splitView.layer?.isOpaque = false
         (splitView as? ThemedSplitView)?.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
-        (splitView as? ThemedSplitView)?.customDividerThickness =
-            TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
+        let resolvedThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
+        let dividerThicknessChanged = (splitView as? ThemedSplitView)?.customDividerThickness != resolvedThickness
+        (splitView as? ThemedSplitView)?.customDividerThickness = resolvedThickness
 
         // Update orientation if changed
         splitView.isVertical = splitState.orientation == .horizontal
@@ -401,6 +402,14 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // Then sync if the position changed externally
         let currentPosition = splitState.dividerPosition
         context.coordinator.syncPosition(currentPosition, in: splitView)
+
+        // A pure divider-thickness change doesn't move the model divider
+        // position, so `syncPosition` early-returns and AppKit keeps the cached
+        // pane frames — leaving the painted divider at its old width. Force a
+        // re-divide so the new thickness changes the gap immediately.
+        if dividerThicknessChanged {
+            context.coordinator.reapplyDividerForThicknessChange(in: splitView)
+        }
     }
 
     // MARK: - Helpers
@@ -656,6 +665,23 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             if layout {
                 splitView.layoutSubtreeIfNeeded()
             }
+        }
+
+        /// Re-divide the split using the model's current fractional position so a
+        /// runtime change to `dividerThickness` takes effect immediately.
+        ///
+        /// `setPosition(_:ofDividerAt:)` recomputes both arranged-subview frames
+        /// against the split view's current `dividerThickness`; recomputing from
+        /// the stored fraction preserves the user's split ratio while widening
+        /// (or narrowing) the gap to match the new thickness.
+        func reapplyDividerForThicknessChange(in splitView: NSSplitView) {
+            guard splitView.arrangedSubviews.count >= 2 else { return }
+            let available = splitAvailableSize(in: splitView)
+            guard available > 0 else { return }
+            let bounds = normalizedDividerBounds(in: splitView)
+            let normalized = max(bounds.lowerBound, min(bounds.upperBound, splitState.dividerPosition))
+            setPositionSafely(available * normalized, in: splitView, layout: true)
+            lastAppliedPosition = normalized
         }
 
         func syncPosition(_ statePosition: CGFloat, in splitView: NSSplitView) {

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -6,8 +6,36 @@ private var splitContainerProgrammaticSyncDepth = 0
 private class ThemedSplitView: NSSplitView {
     var customDividerColor: NSColor?
 
+    /// Host-configured divider thickness in points. When `nil` the split view
+    /// uses AppKit's default thickness for its `dividerStyle`.
+    var customDividerThickness: CGFloat? {
+        didSet {
+            guard oldValue != customDividerThickness else { return }
+            // Thickness participates in pane layout, so re-run AppKit's divider
+            // bookkeeping and repaint when the host changes it on config reload.
+            needsLayout = true
+            needsDisplay = true
+        }
+    }
+
     override var dividerColor: NSColor {
         customDividerColor ?? super.dividerColor
+    }
+
+    override var dividerThickness: CGFloat {
+        customDividerThickness ?? super.dividerThickness
+    }
+
+    // Paint the full reserved divider rect with the resolved color so a
+    // thicker-than-hairline divider renders as a solid bar. AppKit's `.thin`
+    // style otherwise draws a 1pt line regardless of the reserved thickness.
+    override func drawDivider(in rect: NSRect) {
+        guard let customDividerColor else {
+            super.drawDivider(in: rect)
+            return
+        }
+        customDividerColor.setFill()
+        rect.fill()
     }
 
     override var isOpaque: Bool { false }
@@ -122,6 +150,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         let splitView = ThemedSplitView()
 #endif
         splitView.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
+        splitView.customDividerThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
         splitView.isVertical = splitState.orientation == .horizontal
         splitView.dividerStyle = .thin
         splitView.delegate = context.coordinator
@@ -327,6 +356,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.layer?.backgroundColor = NSColor.clear.cgColor
         splitView.layer?.isOpaque = false
         (splitView as? ThemedSplitView)?.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
+        (splitView as? ThemedSplitView)?.customDividerThickness =
+            TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
 
         // Update orientation if changed
         splitView.isVertical = splitState.orientation == .horizontal

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -406,9 +406,13 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // A pure divider-thickness change doesn't move the model divider
         // position, so `syncPosition` early-returns and AppKit keeps the cached
         // pane frames — leaving the painted divider at its old width. Force a
-        // re-divide so the new thickness changes the gap immediately.
+        // re-divide so the new thickness changes the gap. Deferred to the next
+        // runloop turn (mirroring `applyInitialDividerPosition`) so it runs
+        // after this layout pass settles real, non-zero bounds.
         if dividerThicknessChanged {
-            context.coordinator.reapplyDividerForThicknessChange(in: splitView)
+            DispatchQueue.main.async {
+                context.coordinator.reapplyDividerForThicknessChange(in: splitView)
+            }
         }
     }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -476,6 +476,13 @@ extension BonsplitConfiguration {
         /// Minimum height of a pane
         public var minimumPaneHeight: CGFloat
 
+        /// Thickness, in points, of the divider drawn between split panes.
+        ///
+        /// Defaults to `1` to match the historical hairline divider. Hosts can
+        /// raise this to make the separator between adjacent panes easier to see.
+        /// Values are clamped to a sane range when applied to the split view.
+        public var dividerThickness: CGFloat
+
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
 
@@ -552,6 +559,7 @@ extension BonsplitConfiguration {
             tabSpacing: CGFloat = 0,
             minimumPaneWidth: CGFloat = 100,
             minimumPaneHeight: CGFloat = 100,
+            dividerThickness: CGFloat = 1,
             showSplitButtons: Bool = true,
             splitButtons: [SplitActionButton] = SplitActionButton.defaults,
             splitButtonsOnHover: Bool = false,
@@ -571,6 +579,7 @@ extension BonsplitConfiguration {
             self.tabSpacing = tabSpacing
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
+            self.dividerThickness = dividerThickness
             self.showSplitButtons = showSplitButtons
             self.splitButtons = Self.uniqueSplitButtons(splitButtons)
             self.splitButtonsOnHover = splitButtonsOnHover

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -975,6 +975,22 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(appearance.splitButtons, [duplicateRunTests, .splitRight])
     }
 
+    func testAppearanceDefaultsToHairlineDividerThickness() {
+        XCTAssertEqual(BonsplitConfiguration.Appearance().dividerThickness, 1)
+    }
+
+    func testAppearanceCarriesConfiguredDividerThickness() {
+        let appearance = BonsplitConfiguration.Appearance(dividerThickness: 3)
+        XCTAssertEqual(appearance.dividerThickness, 3)
+    }
+
+    func testResolvedDividerThicknessClampsToRange() {
+        XCTAssertEqual(TabBarMetrics.resolvedDividerThickness(2), 2)
+        XCTAssertEqual(TabBarMetrics.resolvedDividerThickness(-5), TabBarMetrics.minimumDividerThickness)
+        XCTAssertEqual(TabBarMetrics.resolvedDividerThickness(999), TabBarMetrics.maximumDividerThickness)
+        XCTAssertEqual(TabBarMetrics.resolvedDividerThickness(.nan), TabBarMetrics.dividerThickness)
+    }
+
     @MainActor
     func testControllerRequestsCustomAction() {
         let controller = BonsplitController()


### PR DESCRIPTION
Adds `dividerThickness` to `BonsplitConfiguration.Appearance` (default 1pt hairline, backward compatible). A custom `NSSplitView` override applies the thickness and paints the full divider rect so a thicker-than-hairline divider renders as a solid bar; values are clamped to a sane range.

Consumed by cmux for the configurable pane separator feature (manaflow-ai/cmux#5030, issue manaflow-ai/cmux#5006).

Tests: `Appearance.dividerThickness` default + carry-through, and `TabBarMetrics.resolvedDividerThickness` clamping.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782777143&installation_id=133855650&pr_number=139&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F139&signature=e8d4fafa61a9ad3820ceb9485f477cfc95c1746172b3bc8fd5b943449cbadc3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the pane divider thickness configurable with live updates to improve visibility and control. Supports the configurable pane separator requested in issue 5006 in `cmux`.

- **New Features**
  - Added `appearance.dividerThickness` (points), default 1; backward compatible.
  - Applied via an `NSSplitView` override that uses the thickness for layout and paints the full divider rect as a solid bar.
  - Clamped to 0–12 with `TabBarMetrics.resolvedDividerThickness`; non-finite values fall back to the default.
  - Tests cover default, carry-through, and clamping.

- **Bug Fixes**
  - Runtime changes to `dividerThickness` now force a re-divide (deferred to the next runloop) so the gap updates immediately while preserving the current split ratio.

<sup>Written for commit 7c1d833a2a5b80690021bab4c8bcfce1f8ad1a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customize divider thickness between split panes via Appearance (default: 1pt); host-supplied values are clamped to usable bounds and non-finite inputs fall back to the hairline default.

* **Bug Fixes**
  * Changing the divider thickness now updates layout and rendering immediately so the divider gap reflects the new thickness without other adjustments.

* **Tests**
  * Added tests for default value, boundary clamping, and non-finite input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->