### PR TITLE
Scale tab icons with tab title font size

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1760,15 +1760,23 @@ struct TabBarView: View {
         }
     }
 
+    /// Scale factor of the configured tab title font relative to the default,
+    /// so the trailing split / new-tab control icons grow and shrink together
+    /// with the tab title text instead of staying pinned at their default size.
+    private var controlIconFontScale: CGFloat {
+        max(0.1, appearance.tabTitleFontSize / TabBarMetrics.titleFontSize)
+    }
+
     @ViewBuilder
     private func splitActionButtonIcon(_ icon: BonsplitConfiguration.SplitActionButton.Icon) -> some View {
+        let scale = controlIconFontScale
         switch icon {
         case .systemImage(let name):
             Image(systemName: name)
-                .font(.system(size: 12))
-        case .emoji(let value, let scale):
+                .font(.system(size: 12 * scale))
+        case .emoji(let value, let emojiScale):
             Text(value)
-                .font(.system(size: emojiIconFontSize(scale: scale)))
+                .font(.system(size: emojiIconFontSize(scale: emojiScale) * scale))
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
         case .imageData(let data):
@@ -1778,10 +1786,10 @@ struct TabBarView: View {
                     .resizable()
                     .interpolation(.high)
                     .scaledToFit()
-                    .frame(width: 14, height: 14)
+                    .frame(width: 14 * scale, height: 14 * scale)
             } else {
                 Image(systemName: "questionmark.circle")
-                    .font(.system(size: 12))
+                    .font(.system(size: 12 * scale))
             }
         }
     }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -95,8 +95,8 @@ struct TabItemView: View {
     var body: some View {
         HStack(spacing: 0) {
             // Icon + title block uses the standard spacing, but keep the close affordance tight.
-            HStack(spacing: TabBarMetrics.contentSpacing) {
-                let iconSlotSize = TabBarMetrics.iconSize
+            HStack(spacing: scaledContentSpacing) {
+                let iconSlotSize = scaledIconSize
                 let iconTintColor = isSelected
                     ? TabBarColors.nsColorActiveText(for: appearance)
                     : TabBarColors.nsColorInactiveText(for: appearance)
@@ -253,13 +253,37 @@ struct TabItemView: View {
         .safeHelp(tab.title)
     }
 
+    /// Scale factor of the configured tab title font relative to the default.
+    ///
+    /// Icons and close/pin affordances are multiplied by this so they grow and
+    /// shrink together with the tab title font size instead of staying pinned to
+    /// the default-size constants.
+    private var fontScale: CGFloat {
+        max(0.1, appearance.tabTitleFontSize / TabBarMetrics.titleFontSize)
+    }
+
+    /// Leading-icon slot size, scaled to the configured tab title font.
+    private var scaledIconSize: CGFloat {
+        TabBarMetrics.iconSize * fontScale
+    }
+
+    /// Close / pin glyph size, scaled to the configured tab title font.
+    private var scaledCloseIconSize: CGFloat {
+        TabBarMetrics.closeIconSize * fontScale
+    }
+
+    /// Spacing between the leading icon and the title, scaled to the font.
+    private var scaledContentSpacing: CGFloat {
+        TabBarMetrics.contentSpacing * fontScale
+    }
+
     private func glyphSize(for iconName: String) -> CGFloat {
         // `terminal.fill` reads visually heavier than most symbols at the same point size.
-        // Hardcode sizes to avoid cross-glyph layout shifts.
+        // Keep the base sizes hardcoded to avoid cross-glyph layout shifts, then scale to the font.
         if iconName == "terminal.fill" || iconName == "terminal" || iconName == "globe" {
-            return max(10, TabBarMetrics.iconSize - 2.5)
+            return max(10, TabBarMetrics.iconSize - 2.5) * fontScale
         }
-        return TabBarMetrics.iconSize
+        return scaledIconSize
     }
 
     private var shortcutHintLabel: String? {
@@ -448,7 +472,7 @@ struct TabItemView: View {
             if tab.isPinned {
                 if isSelected || isHovered || isCloseHovered || (!tab.isDirty && !tab.showsNotificationBadge) {
                     Image(systemName: "pin.fill")
-                        .font(.system(size: TabBarMetrics.closeIconSize, weight: .semibold))
+                        .font(.system(size: scaledCloseIconSize, weight: .semibold))
                         .foregroundStyle(TabBarColors.inactiveText(for: appearance))
                         .frame(width: accessorySlotSize, height: accessorySlotSize)
                         .saturation(saturation)
@@ -459,7 +483,7 @@ struct TabItemView: View {
                     onClose(.closeButton)
                 } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: TabBarMetrics.closeIconSize, weight: .semibold))
+                        .font(.system(size: scaledCloseIconSize, weight: .semibold))
                         .foregroundStyle(
                             isCloseHovered
                                 ? TabBarColors.activeText(for: appearance)


### PR DESCRIPTION
The bonsplit tab **title** scales with `appearance.tabTitleFontSize`, but the leading tab icon (terminal/globe), close `x`, and pin glyphs were pinned to fixed `TabBarMetrics` constants — so when a consumer raises the tab-bar font size the text grew while the icons stayed small.

This adds a `fontScale = tabTitleFontSize / TabBarMetrics.titleFontSize` factor and scales the leading icon slot + glyph, the close/pin glyph, and the icon→title spacing by it. Right-side accessory icons (mute/zoom) already scaled via `accessoryFontSize`.

Used by cmux's `surface-tab-bar-font-size` setting (manaflow-ai/cmux#4798).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782863122&installation_id=133855650&pr_number=140&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F140&signature=fa9b5e9088cb2976402a2fe1ca0ef476463d849194dc362cedb0914e288f490b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale all tab bar icons and controls with the tab title font size so icons and text stay visually balanced. Works with cmux's `surface-tab-bar-font-size`.

- **New Features**
  - Added `fontScale = appearance.tabTitleFontSize / TabBarMetrics.titleFontSize`.
  - Scaled the leading icon slot and glyph, close/pin glyphs, and icon-to-title spacing by `fontScale`.
  - Scaled trailing control icons (split/new-terminal/new-browser) by the same factor; per-tab accessory icons still scale via `accessoryFontSize`.

<sup>Written for commit 2dce53a160a541679858fa3cfb7b462905843ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tab item icons, close/pin glyphs, and spacing now scale with the configured tab title font size for consistent layout.
  * Split-button and control icons now scale alongside tab titles (emoji sizing preserved and adjusted), improving visual consistency across font configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->