### PR TITLE
Add opt-in fill tab-width mode to the tab strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Bonsplit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `BonsplitConfiguration.Appearance.tabWidthMode` (`TabWidthMode`) to control tab sizing.
+  - `.fixed` (default) keeps the historical fixed-width + horizontal-scroll layout unchanged.
+  - `.fill` stretches tabs to fill the pane's available tab-bar width, distributing the
+    space equally; a single tab spans the full width. Tabs fall back to fixed sizing and
+    scroll when they would overflow at their natural width.
+
 ## [1.1.1] - 2025-01-29
 
 ### Fixed

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -977,6 +977,20 @@ struct TabBarView: View {
         controller.configuration.appearance
     }
 
+    /// Whether tabs should stretch to fill the pane's available tab-bar width.
+    private var fillsTabsToWidth: Bool {
+        appearance.tabWidthMode == .fill
+    }
+
+    /// Minimum width to impose on the (already trailing-inset-padded) tab row when
+    /// filling, so the horizontal `ScrollView` hands the row the full viewport and
+    /// SwiftUI distributes the slack across the flexible tabs. `nil` in fixed mode
+    /// (and before the container width is known) leaves the historical layout intact.
+    private var fillRowMinWidth: CGFloat? {
+        guard fillsTabsToWidth, containerWidth > 0 else { return nil }
+        return containerWidth
+    }
+
     private var tabBarHeight: CGFloat {
         tabBarLayout.barHeight
     }
@@ -1099,6 +1113,45 @@ struct TabBarView: View {
     }
 
 
+    /// The horizontally-scrolling tab row hosted inside the tab strip's `ScrollView`.
+    ///
+    /// Extracted from `body` so the SwiftUI type-checker can resolve the surrounding
+    /// view tree in reasonable time. In fill mode `tabRowFillMinWidth` forces the row
+    /// to the viewport width so the flexible tabs distribute the slack.
+    @ViewBuilder
+    private var tabScrollContent: some View {
+        HStack(spacing: TabBarMetrics.tabSpacing) {
+            Color.clear
+                .frame(width: 0, height: tabBarHeight)
+                .id(leadingScrollAnchorId)
+
+            ForEach(Array(pane.tabs.enumerated()), id: \.element.id) { index, tab in
+                tabItem(for: tab, at: index)
+                    .id(tab.id)
+            }
+
+            // Unified drop zone after the last tab.
+            dropZoneAfterTabs
+        }
+        .padding(.horizontal, TabBarMetrics.barPadding)
+        .padding(.trailing, trailingTabContentInset)
+        .tabRowFillMinWidth(fillRowMinWidth)
+        .frame(height: tabBarHeight, alignment: .top)
+        .animation(nil, value: pane.tabs.map(\.id))
+        .background(
+            GeometryReader { contentGeo in
+                Color.clear
+                    .onChange(of: contentGeo.frame(in: .named("tabScroll"))) { _, newFrame in
+                        updateTabScrollContent(frame: newFrame)
+                    }
+                    .onAppear {
+                        let frame = contentGeo.frame(in: .named("tabScroll"))
+                        updateTabScrollContent(frame: frame)
+                    }
+            }
+        )
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
@@ -1113,35 +1166,7 @@ struct TabBarView: View {
             GeometryReader { containerGeo in
                 ScrollViewReader { proxy in
                     ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: TabBarMetrics.tabSpacing) {
-                            Color.clear
-                                .frame(width: 0, height: tabBarHeight)
-                                .id(leadingScrollAnchorId)
-
-                            ForEach(Array(pane.tabs.enumerated()), id: \.element.id) { index, tab in
-                                tabItem(for: tab, at: index)
-                                    .id(tab.id)
-                            }
-
-                            // Unified drop zone after the last tab.
-                            dropZoneAfterTabs
-                        }
-                        .padding(.horizontal, TabBarMetrics.barPadding)
-                        .padding(.trailing, trailingTabContentInset)
-                        .frame(height: tabBarHeight, alignment: .top)
-                        .animation(nil, value: pane.tabs.map(\.id))
-                        .background(
-                            GeometryReader { contentGeo in
-                                Color.clear
-                                    .onChange(of: contentGeo.frame(in: .named("tabScroll"))) { _, newFrame in
-                                        updateTabScrollContent(frame: newFrame)
-                                    }
-                                    .onAppear {
-                                        let frame = contentGeo.frame(in: .named("tabScroll"))
-                                        updateTabScrollContent(frame: frame)
-                                    }
-                            }
-                        )
+                        tabScrollContent
                     }
                     .background(
                         TabBarScrollViewResolver { scrollView in
@@ -1309,6 +1334,7 @@ struct TabBarView: View {
             isSelected: pane.selectedTabId == tab.id,
             showsZoomIndicator: showsZoomIndicator,
             appearance: appearance,
+            fillsWidth: fillsTabsToWidth,
             saturation: tabBarSaturation,
             trailingSeparatorBottomInset: isImmediatelyBeforeSelected
                 ? TabBarMetrics.selectedTabLeftSeparatorBottomInset

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -16,6 +16,21 @@ extension View {
             transaction.animation = nil
         }
     }
+
+    /// Imposes a minimum width on the tab row only when `minWidth` is non-nil.
+    ///
+    /// Used by the tab strip's fill mode to force the horizontal `ScrollView` to hand
+    /// the row the full viewport width so SwiftUI can distribute slack across flexible
+    /// tabs. Passing `nil` returns the view untouched, preserving the fixed-width layout
+    /// byte-for-byte.
+    @ViewBuilder
+    func tabRowFillMinWidth(_ minWidth: CGFloat?) -> some View {
+        if let minWidth {
+            frame(minWidth: minWidth, alignment: .leading)
+        } else {
+            self
+        }
+    }
 }
 
 private enum TabControlShortcutHintDebugSettings {
@@ -64,6 +79,9 @@ struct TabItemView: View {
     let isSelected: Bool
     let showsZoomIndicator: Bool
     let appearance: BonsplitConfiguration.Appearance
+    /// When true, the tab drops its fixed maximum width and grows to fill the slack
+    /// the enclosing tab strip distributes (see ``BonsplitConfiguration/Appearance/tabWidthMode``).
+    let fillsWidth: Bool
     let saturation: Double
     let trailingSeparatorBottomInset: CGFloat
     let controlShortcutDigit: Int?
@@ -211,7 +229,9 @@ struct TabItemView: View {
         .padding(.horizontal, TabBarMetrics.tabHorizontalPadding)
         .frame(
             minWidth: tabWidthRange.lowerBound,
-            maxWidth: tabWidthRange.upperBound,
+            // In fill mode the tab becomes flexible so the tab strip can distribute
+            // slack equally across tabs; the fixed upper bound only applies otherwise.
+            maxWidth: fillsWidth ? .infinity : tabWidthRange.upperBound,
             minHeight: tabHeight,
             maxHeight: tabHeight
         )

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -482,6 +482,23 @@ extension BonsplitConfiguration {
             }
         }
 
+        /// Controls how surface tabs are sized within a pane's tab bar.
+        public enum TabWidthMode: Sendable, Equatable, Codable {
+            /// Tabs use a fixed width clamped to `tabMinWidth...tabMaxWidth` and the
+            /// tab strip scrolls horizontally once the tabs overflow the pane. This is
+            /// the default and preserves Bonsplit's historical layout exactly.
+            case fixed
+
+            /// Tabs stretch to fill the pane's available tab-bar width, distributing the
+            /// space equally between them.
+            ///
+            /// A single tab spans the full available width; multiple tabs share it
+            /// evenly. When the tabs would overflow the pane at their natural width,
+            /// the strip falls back to ``fixed`` sizing and scrolls, so this mode never
+            /// shrinks tabs below their natural width.
+            case fill
+        }
+
         // MARK: - Tab Bar
 
         /// Height of the tab bar
@@ -500,6 +517,10 @@ extension BonsplitConfiguration {
 
         /// Spacing between tabs
         public var tabSpacing: CGFloat
+
+        /// Controls whether tabs use a fixed width and scroll, or stretch to fill the
+        /// pane's available tab-bar width. Defaults to ``TabWidthMode/fixed``.
+        public var tabWidthMode: TabWidthMode
 
         // MARK: - Split View
 
@@ -590,6 +611,7 @@ extension BonsplitConfiguration {
             tabMaxWidth: CGFloat = 220,
             tabTitleFontSize: CGFloat = 11,
             tabSpacing: CGFloat = 0,
+            tabWidthMode: TabWidthMode = .fixed,
             minimumPaneWidth: CGFloat = 100,
             minimumPaneHeight: CGFloat = 100,
             dividerThickness: CGFloat = 1,
@@ -610,6 +632,7 @@ extension BonsplitConfiguration {
             self.tabMaxWidth = tabMaxWidth
             self.tabTitleFontSize = tabTitleFontSize
             self.tabSpacing = tabSpacing
+            self.tabWidthMode = tabWidthMode
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.dividerThickness = dividerThickness

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -4383,4 +4383,27 @@ final class BonsplitTests: XCTestCase {
         }
         return event
     }
+
+    // MARK: - Tab Width Mode
+
+    /// The tab strip must default to fixed-width sizing so existing layouts are
+    /// unchanged; fill is strictly opt-in.
+    func testTabWidthModeDefaultsToFixed() {
+        XCTAssertEqual(BonsplitConfiguration.Appearance().tabWidthMode, .fixed)
+        XCTAssertEqual(BonsplitConfiguration.Appearance.default.tabWidthMode, .fixed)
+        XCTAssertEqual(BonsplitConfiguration.Appearance.compact.tabWidthMode, .fixed)
+        XCTAssertEqual(BonsplitConfiguration.Appearance.spacious.tabWidthMode, .fixed)
+        XCTAssertEqual(BonsplitConfiguration.default.appearance.tabWidthMode, .fixed)
+    }
+
+    /// Opting into fill is preserved on the configuration and is distinct from fixed.
+    func testTabWidthModeFillIsSettableAndDistinct() {
+        var appearance = BonsplitConfiguration.Appearance()
+        appearance.tabWidthMode = .fill
+        XCTAssertEqual(appearance.tabWidthMode, .fill)
+        XCTAssertNotEqual(BonsplitConfiguration.Appearance.TabWidthMode.fill, .fixed)
+
+        let configured = BonsplitConfiguration.Appearance(tabWidthMode: .fill)
+        XCTAssertEqual(configured.tabWidthMode, .fill)
+    }
 }


### PR DESCRIPTION
## Summary

Adds an **opt-in** tab-width mode so surface tabs can stretch to fill their pane's available tab-bar width instead of using a fixed width. The current fixed-width behavior remains the **default** — this is strictly opt-in.

New public API: `BonsplitConfiguration.Appearance.tabWidthMode: TabWidthMode`

- `.fixed` (default) — historical fixed-width (`tabMinWidth...tabMaxWidth`) + horizontal-scroll layout, unchanged byte-for-byte.
- `.fill` — tabs stretch to fill the pane's available tab-bar width, distributing the slack equally. A single tab spans the full width; multiple tabs share it evenly. When tabs would overflow at their natural width, the strip falls back to fixed sizing and **scrolls** (fill never shrinks tabs below their natural width).

## Implementation

The fixed width is enforced by a per-tab `.frame(maxWidth:)` inside a horizontal `ScrollView` whose `HStack` sizes to content, so naively setting `maxWidth: .infinity` would not fill the viewport. Instead:

- In `.fill`, each `TabItemView` becomes flexible (`maxWidth: .infinity`, min unchanged).
- The tab row is given a minimum width equal to the measured viewport (`tabRowFillMinWidth`) so the horizontal `ScrollView` hands it the full width; SwiftUI then distributes the slack equally across the flexible tabs. When natural content exceeds the viewport, the row grows past it and scrolls as before.
- The drop zone and all overflow/scroll machinery are untouched.
- Extracted the scroll content into `tabScrollContent` to keep `TabBarView.body` within the SwiftUI type-checker's budget.

## Tests

- `testTabWidthModeDefaultsToFixed` — asserts the opt-in default (every preset stays `.fixed`).
- `testTabWidthModeFillIsSettableAndDistinct` — fill is settable and distinct.

## Related

Consumed by cmux issue manaflow-ai/cmux#5091 (cmux PR linked below once opened), which exposes this via the `surface-tabs-fill-pane-width` Ghostty config key + a Settings toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782908915&installation_id=133855650&pr_number=141&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F141&signature=de8f7fbf7364a8f97b3d35658d90613ed1137f6f41637615b8a11d42de28ff10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in tab-width mode so tabs can stretch to fill a pane’s tab bar. Fixed-width with horizontal scroll remains the default, and overflow behavior is unchanged.

- **New Features**
  - New API: `BonsplitConfiguration.Appearance.tabWidthMode` (`TabWidthMode`) with `.fixed` (default) and `.fill`.
  - `.fill` makes each tab flexible (`maxWidth: .infinity`) and stretches to share available width; it falls back to fixed + scroll when natural width would overflow.

- **Refactors**
  - Extracted tab row into `tabScrollContent` for clarity.
  - Added `tabRowFillMinWidth(_:)` to give the row the viewport width in fill mode.

<sup>Written for commit e71a27bc7e39cd023be96d245f0c73369887cddf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable tab width mode option (`fixed` default, or `fill` to stretch tabs across the tab bar with a fallback to fixed + scrolling when sizing would overflow).
* **Bug Fixes**
  * Improved tab strip layout by updating tab row rendering to support the new width behavior consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->