### PR TITLE
feat(tabbar): collapse split buttons into an overflow menu

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -959,7 +959,7 @@ struct TabBarView: View {
             tabBarHeight: appearance.tabBarHeight,
             availableWidth: containerWidth,
             tabContentWidthExcludingSplitButtonLane: tabContentWidthExcludingSplitButtonLane,
-            splitButtonCount: visibleSplitButtons.count,
+            splitButtonCount: effectiveSplitButtonCount,
             splitButtonLaneVisible: shouldShowSplitButtons,
             reservesSplitButtonLane: showSplitButtons && !isMinimalMode,
             measuredSplitButtonLaneWidth: measuredSplitButtonLaneWidth
@@ -979,6 +979,15 @@ struct TabBarView: View {
     private var visibleSplitButtons: [BonsplitConfiguration.SplitActionButton] {
         guard showSplitButtons else { return [] }
         return appearance.splitButtons
+    }
+
+    /// Effective button count for reserving the trailing action lane. When the
+    /// buttons are collapsed into the "⋯" overflow menu, only that single menu
+    /// button occupies the lane, so reserve width for one — not all of them.
+    private var effectiveSplitButtonCount: Int {
+        let count = visibleSplitButtons.count
+        guard count > 0 else { return 0 }
+        return appearance.collapseSplitButtonsIntoMenu ? 1 : count
     }
 
     private var shouldRenderSplitButtons: Bool {
@@ -1727,22 +1736,73 @@ struct TabBarView: View {
     private var splitButtonRow: some View {
         let tooltips = controller.configuration.appearance.splitButtonTooltips
         let buttons = visibleSplitButtons
-        HStack(spacing: TabBarStyling.splitButtonsSpacing) {
-            ForEach(buttons.indices, id: \.self) { index in
-                let button = buttons[index]
-                Button {
-                    performSplitActionButton(button)
-                } label: {
-                    splitActionButtonIcon(button.icon)
+        Group {
+            if controller.configuration.appearance.collapseSplitButtonsIntoMenu, !buttons.isEmpty {
+                splitButtonOverflowMenu(buttons: buttons, tooltips: tooltips)
+            } else {
+                HStack(spacing: TabBarStyling.splitButtonsSpacing) {
+                    ForEach(buttons.indices, id: \.self) { index in
+                        let button = buttons[index]
+                        Button {
+                            performSplitActionButton(button)
+                        } label: {
+                            splitActionButtonIcon(button.icon)
+                        }
+                        .buttonStyle(SplitActionButtonStyle(appearance: appearance, layout: tabBarLayout))
+                        .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
+                        .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
+                    }
                 }
-                .buttonStyle(SplitActionButtonStyle(appearance: appearance, layout: tabBarLayout))
-                .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
-                .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
             }
         }
         .padding(.leading, TabBarStyling.splitButtonsLeadingPadding)
         .padding(.trailing, TabBarStyling.splitButtonsTrailingPadding)
         .frame(height: tabBarHeight, alignment: .center)
+    }
+
+    /// Single "⋯" button that expands the split actions into a menu. Reuses the
+    /// exact same `performSplitActionButton` dispatch as the inline row, so
+    /// every action (including custom ones like New Note) behaves identically.
+    @ViewBuilder
+    private func splitButtonOverflowMenu(
+        buttons: [BonsplitConfiguration.SplitActionButton],
+        tooltips: BonsplitConfiguration.SplitButtonTooltips
+    ) -> some View {
+        Menu {
+            ForEach(buttons.indices, id: \.self) { index in
+                let button = buttons[index]
+                Button {
+                    performSplitActionButton(button)
+                } label: {
+                    splitActionButtonMenuLabel(button, tooltips: tooltips)
+                }
+                .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 12))
+        }
+        .menuStyle(.button)
+        .menuIndicator(.hidden)
+        .buttonStyle(SplitActionButtonStyle(appearance: appearance, layout: tabBarLayout))
+        .fixedSize()
+        .accessibilityIdentifier("paneTabBarControl.overflowMenu")
+    }
+
+    @ViewBuilder
+    private func splitActionButtonMenuLabel(
+        _ button: BonsplitConfiguration.SplitActionButton,
+        tooltips: BonsplitConfiguration.SplitButtonTooltips
+    ) -> some View {
+        let title = splitActionButtonTooltip(button, tooltips: tooltips)
+        switch button.icon {
+        case .systemImage(let name):
+            Label(title, systemImage: name)
+        case .emoji(let value, _):
+            Text("\(value)  \(title)")
+        case .imageData:
+            Text(title)
+        }
     }
 
     private func splitActionButtonAccessibilityIdentifier(_ button: BonsplitConfiguration.SplitActionButton) -> String {

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -490,6 +490,11 @@ extension BonsplitConfiguration {
         /// When true, split buttons are only visible on hover
         public var splitButtonsOnHover: Bool
 
+        /// When true, the tab bar's right-side action buttons collapse into a
+        /// single overflow ("⋯") menu instead of rendering as a row of icons.
+        /// Menu item labels come from each button's `tooltip`.
+        public var collapseSplitButtonsIntoMenu: Bool
+
         /// Optional explicit backdrop style for the tab bar's right-side action buttons.
         /// When unset, Bonsplit uses the host app's debug override if one is configured.
         public var splitButtonBackdropStyle: SplitButtonBackdropStyle?
@@ -555,6 +560,7 @@ extension BonsplitConfiguration {
             showSplitButtons: Bool = true,
             splitButtons: [SplitActionButton] = SplitActionButton.defaults,
             splitButtonsOnHover: Bool = false,
+            collapseSplitButtonsIntoMenu: Bool = false,
             splitButtonBackdropStyle: SplitButtonBackdropStyle? = nil,
             splitButtonBackdropEffect: SplitButtonBackdropEffect? = nil,
             tabBarLeadingInset: CGFloat = 0,
@@ -574,6 +580,7 @@ extension BonsplitConfiguration {
             self.showSplitButtons = showSplitButtons
             self.splitButtons = Self.uniqueSplitButtons(splitButtons)
             self.splitButtonsOnHover = splitButtonsOnHover
+            self.collapseSplitButtonsIntoMenu = collapseSplitButtonsIntoMenu
             self.splitButtonBackdropStyle = splitButtonBackdropStyle
             self.splitButtonBackdropEffect = splitButtonBackdropEffect
             self.tabBarLeadingInset = tabBarLeadingInset


### PR DESCRIPTION
Adds `Appearance.collapseSplitButtonsIntoMenu`; when set, the tab bar's right-side action buttons render as a single ellipsis (`⋯`) menu (labels from each button's tooltip) instead of a row, with the action lane sized for one button. Reuses `performSplitActionButton` dispatch. Pinned by cmux PR #4332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782947886&installation_id=133855650&pr_number=142&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F142&signature=8ff6fab4aaf0f2bb0b2e773714de3e6a7731e93cb7d698013a0a9262fbae1cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an option to collapse the tab bar’s right-side action buttons into a single "⋯" overflow menu. Reserves space for one button and aligns with the overflow-menu requirement in Linear 4331.

- **New Features**
  - Introduces `Appearance.collapseSplitButtonsIntoMenu` (default false).
  - Renders a single "⋯" `Menu` with labels from each button’s tooltip and reuses `performSplitActionButton`.
  - Adds accessibility identifier `paneTabBarControl.overflowMenu`.

- **Migration**
  - Opt-in: set `appearance.collapseSplitButtonsIntoMenu = true` to enable.

<sup>Written for commit 5be7109e9fead43ea7bb8ec1dfaa04b1452bf18c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to collapse split action buttons in the tab bar into a single overflow menu button. When enabled, individual split action buttons are hidden and consolidated into a "⋯" menu, with each action's tooltip displayed as a menu item label, providing improved interface compactness and better space utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->