### PR TITLE
Add `didReorderTabsInPane` delegate for within-pane tab reorder

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2349,9 +2349,17 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 return
             }
 
+            let orderBeforeReorder = pane.tabs.map { $0.id }
             withTransaction(Transaction(animation: nil)) {
                 pane.moveTab(from: currentSourceIndex, to: targetIndex)
                 bonsplitController.focusPane(pane.id)
+            }
+            if pane.tabs.map({ $0.id }) != orderBeforeReorder {
+                bonsplitController.delegate?.splitTabBar(
+                    bonsplitController,
+                    didReorderTabsInPane: pane.id,
+                    orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
+                )
             }
         }
 
@@ -3400,6 +3408,11 @@ struct TabDropDelegate: DropDelegate {
                         return
                     }
                     pane.moveTab(from: sourceIndex, to: targetIndex)
+                    bonsplitController.delegate?.splitTabBar(
+                        bonsplitController,
+                        didReorderTabsInPane: pane.id,
+                        orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
+                    )
                 } else {
                     _ = bonsplitController.moveTab(
                         TabID(id: draggedTab.id),

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3407,12 +3407,18 @@ struct TabDropDelegate: DropDelegate {
                     if targetIndex == sourceIndex || targetIndex == sourceIndex + 1 {
                         return
                     }
+                    // Guard the delegate on an actual order change (mirrors the manual-drag
+                    // path): if moveTab is a no-op, firing didReorderTabsInPane would push a
+                    // spurious reorder to consumers (e.g. a redundant tmux swap-window).
+                    let orderBeforeReorder = pane.tabs.map { $0.id }
                     pane.moveTab(from: sourceIndex, to: targetIndex)
-                    bonsplitController.delegate?.splitTabBar(
-                        bonsplitController,
-                        didReorderTabsInPane: pane.id,
-                        orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
-                    )
+                    if pane.tabs.map({ $0.id }) != orderBeforeReorder {
+                        bonsplitController.delegate?.splitTabBar(
+                            bonsplitController,
+                            didReorderTabsInPane: pane.id,
+                            orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
+                        )
+                    }
                 } else {
                     _ = bonsplitController.moveTab(
                         TabID(id: draggedTab.id),

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3399,6 +3399,11 @@ struct TabDropDelegate: DropDelegate {
 
         // Execute synchronously when possible so the dragged tab disappears immediately.
         let applyMove = {
+            // Pre-move order, captured inside the transaction below; the delegate is
+            // fired AFTER the transaction (mirroring the manual-drag path) and only when
+            // the order actually changed, so a no-op move never pushes a spurious
+            // reorder to consumers (e.g. a redundant tmux swap-window).
+            var orderBeforeReorder: [UUID]?
             // Ensure the move itself doesn't animate.
             withTransaction(Transaction(animation: nil)) {
                 if sourcePaneId == pane.id {
@@ -3407,18 +3412,8 @@ struct TabDropDelegate: DropDelegate {
                     if targetIndex == sourceIndex || targetIndex == sourceIndex + 1 {
                         return
                     }
-                    // Guard the delegate on an actual order change (mirrors the manual-drag
-                    // path): if moveTab is a no-op, firing didReorderTabsInPane would push a
-                    // spurious reorder to consumers (e.g. a redundant tmux swap-window).
-                    let orderBeforeReorder = pane.tabs.map { $0.id }
+                    orderBeforeReorder = pane.tabs.map { $0.id }
                     pane.moveTab(from: sourceIndex, to: targetIndex)
-                    if pane.tabs.map({ $0.id }) != orderBeforeReorder {
-                        bonsplitController.delegate?.splitTabBar(
-                            bonsplitController,
-                            didReorderTabsInPane: pane.id,
-                            orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
-                        )
-                    }
                 } else {
                     _ = bonsplitController.moveTab(
                         TabID(id: draggedTab.id),
@@ -3426,6 +3421,16 @@ struct TabDropDelegate: DropDelegate {
                         atIndex: targetIndex
                     )
                 }
+            }
+            // Outside the transaction, matching the manual-drag path's delegate timing.
+            if sourcePaneId == pane.id,
+               let orderBeforeReorder,
+               pane.tabs.map({ $0.id }) != orderBeforeReorder {
+                bonsplitController.delegate?.splitTabBar(
+                    bonsplitController,
+                    didReorderTabsInPane: pane.id,
+                    orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
+                )
             }
         }
 

--- a/Sources/Bonsplit/Public/BonsplitDelegate.swift
+++ b/Sources/Bonsplit/Public/BonsplitDelegate.swift
@@ -27,6 +27,10 @@ public protocol BonsplitDelegate: AnyObject {
     /// Called when a tab is moved between panes.
     func splitTabBar(_ controller: BonsplitController, didMoveTab tab: Tab, fromPane source: PaneID, toPane destination: PaneID)
 
+    /// Called after the user reorders tabs within a single pane (drag-reorder).
+    /// `orderedTabIds` is the new full order of that pane's tabs.
+    func splitTabBar(_ controller: BonsplitController, didReorderTabsInPane pane: PaneID, orderedTabIds: [TabID])
+
     // MARK: - Split Lifecycle (Veto Operations)
 
     /// Called when a split is about to be created.
@@ -83,6 +87,7 @@ public extension BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, didCloseTab tabId: TabID, fromPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didSelectTab tab: Tab, inPane pane: PaneID) {}
     func splitTabBar(_ controller: BonsplitController, didMoveTab tab: Tab, fromPane source: PaneID, toPane destination: PaneID) {}
+    func splitTabBar(_ controller: BonsplitController, didReorderTabsInPane pane: PaneID, orderedTabIds: [TabID]) {}
     func splitTabBar(_ controller: BonsplitController, shouldSplitPane pane: PaneID, orientation: SplitOrientation) -> Bool { true }
     func splitTabBar(_ controller: BonsplitController, shouldClosePane pane: PaneID) -> Bool { true }
     func splitTabBar(_ controller: BonsplitController, didSplitPane originalPane: PaneID, newPane: PaneID, orientation: SplitOrientation) {}


### PR DESCRIPTION
> [!NOTE]
> **Required by manaflow-ai/cmux#5553** (the remote tmux `-CC` mirror). That PR's
> `vendor/bonsplit` submodule points at this delegate and cannot build until this
> PR is merged. Please merge this first.

**What**
Adds one optional `BonsplitDelegate` method, fired after the user drag-reorders tabs *within* a single pane:
```swift
func splitTabBar(_ controller: BonsplitController,
                 didReorderTabsInPane pane: PaneID, orderedTabIds: [TabID])
```
Bonsplit already notified on *cross*-pane moves (`didMoveTab…fromPane…toPane`) but had no callback for a within-pane reorder. This fires it on both reorder paths (manual-drag tracking + the SwiftUI drop delegate), passing the pane's new full tab order.

**Why**
Consumers that mirror external state to tab order need to know when tabs are reordered within a pane, not only moved across panes. (cmux's remote-tmux mirror uses it to propagate window reordering to tmux `swap-window`.)

**Compatibility** — non-breaking: a default no-op is added in the protocol extension, so existing conformers are unaffected.

**Scope** — 18 lines, 2 files (`TabBarView.swift`, `BonsplitDelegate.swift`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783378637&installation_id=133855650&pr_number=143&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F143&signature=c9c5a55d7241715e412e579a1866feeeb3d1ff5dd4b2da3b5a2eb8254ff95392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional `BonsplitDelegate` callback `splitTabBar(_:didReorderTabsInPane:orderedTabIds:)` to report within‑pane tab reorders, complementing the cross‑pane move callback. Fires for manual drag and SwiftUI drop only when the order changes, and now fires after the transaction to match manual‑drag timing; non‑breaking via a default no‑op.

<sup>Written for commit c209a0db3cffd02a9117a17ee5a5854e79a6137c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new callback so host apps can be notified when tabs are are reordered within a single pane, enabling external synchronization or analytics.

* **Bug Fixes**
  * Reorder notifications are now only emitted when the tab order actually changes, avoiding redundant events and preventing unnecessary focus/animation side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
