### PR TITLE
Add openAsChatView tab context action for terminal tabs

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -872,8 +872,21 @@ enum TabContextMenuBuilder {
             )
         }
 
-        if state.canForkConversation {
+        if state.isTerminal || state.canForkConversation {
             menu.addItem(.separator())
+        }
+
+        if state.isTerminal {
+            addAction(
+                title: localized("tabContext.openAsChatView", defaultValue: "Open as Chat View"),
+                action: .openAsChatView,
+                state: state,
+                target: target,
+                to: menu
+            )
+        }
+
+        if state.canForkConversation {
             addAction(
                 title: localized("tabContext.forkConversation", defaultValue: "Fork Conversation"),
                 action: .forkConversation,

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -21,6 +21,7 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case markAsRead
     case markAsUnread
     case toggleZoom
+    case openAsChatView
     case forkConversation
     case forkConversationRight
     case forkConversationLeft

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "tabContext.pinTab" = "Pin Tab";
 "tabContext.markTabAsRead" = "Mark Tab as Read";
 "tabContext.markTabAsUnread" = "Mark Tab as Unread";
+"tabContext.openAsChatView" = "Open as Chat View";
 "tabContext.forkConversation" = "Fork Conversation";
 "tabContext.forkConversationTo" = "Fork Conversation To";
 "tabContext.forkConversation.right" = "Right Split";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -21,6 +21,7 @@
 "tabContext.pinTab" = "タブをピン留め";
 "tabContext.markTabAsRead" = "タブを既読にする";
 "tabContext.markTabAsUnread" = "タブを未読にする";
+"tabContext.openAsChatView" = "チャットビューで開く";
 "tabContext.forkConversation" = "会話をフォーク";
 "tabContext.forkConversationTo" = "会話のフォーク先";
 "tabContext.forkConversation.right" = "右分割";


### PR DESCRIPTION
Adds an "Open as Chat View" item to the tab context menu, shown only for terminal tabs (`state.isTerminal`), mirroring the forkConversation gating pattern. The action flows through the existing `requestTabContextAction` → `splitTabBar(_:didRequestTabContextAction:for:inPane:)` delegate path, so the host app decides what opening a chat view means.

New `TabContextAction.openAsChatView` case, menu construction in `TabContextMenuBuilder.makeMenu`, and localized titles (en + ja) via the existing `Bundle.module` strings tables.

Consumed by cmux in https://github.com/manaflow-ai/cmux/pull/5576 follow-up (open agent chat as a tab in the pane instead of a separate window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783667412&installation_id=133855650&pr_number=144&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F144&signature=9f84df58fb3e7ea3b4b54ed52e8c44d11507861090ce624266663182e899af7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an “Open as Chat View” option to terminal tab context menus. It sends a new `openAsChatView` action through the existing delegate so host apps decide how to open the chat view.

- **New Features**
  - New `TabContextAction.openAsChatView`.
  - Show “Open as Chat View” only when `state.isTerminal`.
  - Uses `requestTabContextAction` → `splitTabBar(_:didRequestTabContextAction:for:inPane:)`.
  - Added `tabContext.openAsChatView` strings in en and ja.

<sup>Written for commit ea86dfea2ad5bac5ed60205bb08e98f09db549ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open as Chat View" option to the context menu for terminal tabs, making it available alongside other existing menu options.
  * Context menu interface enhanced with improved visual separators for better organization and menu readability.
  * New menu option fully localized with language translations provided for English and Japanese users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->