### PR TITLE
fix: apply tab bar leading inset to zoomed pane

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1073,8 +1073,12 @@ struct TabBarView: View {
 
 
     var body: some View {
+        // A zoomed pane is the only visible pane, so it owns the reserved
+        // leading strip (traffic lights) even when it is not first in the tree.
+        let leadingInsetPaneId = splitViewController.zoomedPaneId
+            ?? splitViewController.rootNode.allPaneIds.first
         HStack(spacing: 0) {
-            if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
+            if appearance.tabBarLeadingInset > 0 && leadingInsetPaneId == pane.id {
                 TabBarDragZoneView(
                     isMinimalMode: isMinimalMode,
                     isFocusedPane: isFocused,


### PR DESCRIPTION
## Summary

In cmux minimal mode the tab bar reserves a leading strip (`appearance.tabBarLeadingInset`, 80pt) so tabs don't slide under the macOS traffic lights. `TabBarView` only rendered that strip for the **first pane in the split tree**, so zooming any other pane (cmd+shift+enter after a cmd+D split) made the zoomed pane's tab bar render underneath the traffic lights.

## Screenshot

Before
<img width="2032" height="1167" alt="Screenshot 2026-06-10 at 3 08 45 PM" src="https://github.com/user-attachments/assets/78966547-ce48-45f9-aa47-e9a37466eb29" />

After
<img width="2032" height="1167" alt="Screenshot 2026-06-10 at 3 09 05 PM" src="https://github.com/user-attachments/assets/ff0f3410-6ffb-4a85-9074-43d9b5040307" />


## Fix

When a zoom is active, the zoomed pane is the only visible pane, so it now owns the reserved strip (`splitViewController.zoomedPaneId ?? rootNode.allPaneIds.first`). Behavior is unchanged when unzoomed or when the zoomed pane is already the first pane.

## Repro / verification

1. In cmux, switch to minimal presentation mode (sidebar collapsed).
2. Cmd+D to split, focus the second pane.
3. Cmd+Shift+Enter to zoom it.
4. Before: tabs render under the traffic lights. After: the zoomed pane's tab bar starts to the right of the traffic lights, and un-zooming restores the strip to the first pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783676126&installation_id=133855650&pr_number=145&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F145&signature=e5b7937fff1a6886459610caf4f9cf372c253671c28f12aa18e00c12ca37b522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the minimal-mode tab bar so the zoomed pane owns the leading traffic-lights inset, preventing tabs from rendering under the macOS window controls. When unzoomed, the first pane keeps the inset; behavior is unchanged.

<sup>Written for commit 46c1d89baca243b593e9ec9718a67fa75b502e18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the tab bar's reserved leading inset to correctly determine which pane it belongs to. When a pane is zoomed, it now properly associates with the zoomed pane instead of always defaulting to the first pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->