### PR TITLE
Add per-tab remote indicator and Disconnect SSH tab context action

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -26,6 +26,7 @@ struct TabItem: Identifiable, Hashable, Codable {
     var isLoading: Bool
     var isAudioMuted: Bool
     var isPinned: Bool
+    var showsRemoteIndicator: Bool
 
     init(
         id: UUID = UUID(),
@@ -38,7 +39,8 @@ struct TabItem: Identifiable, Hashable, Codable {
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
         isAudioMuted: Bool = false,
-        isPinned: Bool = false
+        isPinned: Bool = false,
+        showsRemoteIndicator: Bool = false
     ) {
         self.id = id
         self.title = title
@@ -51,6 +53,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.isLoading = isLoading
         self.isAudioMuted = isAudioMuted
         self.isPinned = isPinned
+        self.showsRemoteIndicator = showsRemoteIndicator
     }
 
     func hash(into hasher: inout Hasher) {
@@ -73,6 +76,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         case isLoading
         case isAudioMuted
         case isPinned
+        case showsRemoteIndicator
     }
 
     init(from decoder: Decoder) throws {
@@ -88,6 +92,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.isLoading = try c.decodeIfPresent(Bool.self, forKey: .isLoading) ?? false
         self.isAudioMuted = try c.decodeIfPresent(Bool.self, forKey: .isAudioMuted) ?? false
         self.isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
+        self.showsRemoteIndicator = try c.decodeIfPresent(Bool.self, forKey: .showsRemoteIndicator) ?? false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -103,6 +108,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         try c.encode(isLoading, forKey: .isLoading)
         try c.encode(isAudioMuted, forKey: .isAudioMuted)
         try c.encode(isPinned, forKey: .isPinned)
+        try c.encode(showsRemoteIndicator, forKey: .showsRemoteIndicator)
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -890,6 +890,7 @@ struct TabContextMenuState {
     let isZoomed: Bool
     let hasSplits: Bool
     let shortcuts: [TabContextAction: KeyboardShortcut]
+    var canDisconnectRemote: Bool = false
 
     var canMarkAsUnread: Bool {
         !isUnread
@@ -1394,7 +1395,8 @@ struct TabBarView: View {
             forkConversationDefaultAction: controller.tabContextForkConversationDefaultActionProvider?(TabID(id: tab.id), pane.id) ?? .defaultForkConversationDestination,
             isZoomed: splitViewController.zoomedPaneId == pane.id,
             hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
-            shortcuts: controller.contextMenuShortcuts
+            shortcuts: controller.contextMenuShortcuts,
+            canDisconnectRemote: controller.tabContextDisconnectRemoteAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false
         )
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -157,6 +157,19 @@ struct TabItemView: View {
                     )
                     .saturation(saturation)
 
+                if tab.showsRemoteIndicator {
+                    Image(systemName: "network")
+                        .font(.system(size: accessoryFontSize, weight: .semibold))
+                        .foregroundStyle(
+                            (isSelected
+                                ? TabBarColors.activeText(for: appearance)
+                                : TabBarColors.inactiveText(for: appearance))
+                                .opacity(0.78)
+                        )
+                        .saturation(saturation)
+                        .accessibilityHidden(true)
+                }
+
                 if tab.isAudioMuted {
                     Image(systemName: "speaker.slash")
                         .font(.system(size: accessoryFontSize, weight: .semibold))
@@ -416,6 +429,9 @@ struct TabItemView: View {
         if tab.isDirty { parts.append("Modified") }
         if tab.isAudioMuted {
             parts.append(Bundle.module.localizedString(forKey: "tabContext.audioMutedAccessibility", value: "Muted", table: nil))
+        }
+        if tab.showsRemoteIndicator {
+            parts.append(Bundle.module.localizedString(forKey: "tabContext.remoteConnectedAccessibility", value: "Connected over SSH", table: nil))
         }
         if showsZoomIndicator { parts.append("Zoomed") }
         return parts.joined(separator: ", ")
@@ -922,6 +938,17 @@ enum TabContextMenuBuilder {
             addAction(
                 title: localized("tabContext.duplicateTab", defaultValue: "Duplicate Tab"),
                 action: .duplicate,
+                state: state,
+                target: target,
+                to: menu
+            )
+        }
+
+        if state.canDisconnectRemote {
+            menu.addItem(.separator())
+            addAction(
+                title: localized("tabContext.disconnectRemote", defaultValue: "Disconnect SSH"),
+                action: .disconnectRemote,
                 state: state,
                 target: target,
                 to: menu

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -87,6 +87,12 @@ public final class BonsplitController {
     /// fall back to `.forkConversationRight`.
     @ObservationIgnored public var tabContextForkConversationDefaultActionProvider: ((TabID, PaneID) -> TabContextAction)?
 
+    /// Host-provided synchronous check that decides whether the tab context menu should
+    /// surface a "Disconnect SSH" action for the tab (e.g. a terminal surface attached to
+    /// a host-managed remote connection). Return `true` to show the item, `false` (or omit
+    /// the provider) to hide it.
+    @ObservationIgnored public var tabContextDisconnectRemoteAvailabilityProvider: ((TabID, PaneID) -> Bool)?
+
     /// Called when the user explicitly requests to close a tab from the tab strip UI.
     /// Internal host-driven closes should not use this hook.
     @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID, _ source: TabCloseRequestSource) -> Void)?
@@ -135,6 +141,7 @@ public final class BonsplitController {
         isLoading: Bool = false,
         isAudioMuted: Bool = false,
         isPinned: Bool = false,
+        showsRemoteIndicator: Bool = false,
         inPane pane: PaneID? = nil
     ) -> TabID? {
         let tabId = TabID()
@@ -149,7 +156,8 @@ public final class BonsplitController {
             showsNotificationBadge: showsNotificationBadge,
             isLoading: isLoading,
             isAudioMuted: isAudioMuted,
-            isPinned: isPinned
+            isPinned: isPinned,
+            showsRemoteIndicator: showsRemoteIndicator
         )
         let targetPane = pane ?? focusedPaneId ?? PaneID(id: internalController.rootNode.allPaneIds.first!.id)
 
@@ -187,7 +195,8 @@ public final class BonsplitController {
             showsNotificationBadge: showsNotificationBadge,
             isLoading: isLoading,
             isAudioMuted: isAudioMuted,
-            isPinned: isPinned
+            isPinned: isPinned,
+            showsRemoteIndicator: showsRemoteIndicator
         )
         internalController.addTab(tabItem, toPane: PaneID(id: targetPane.id), atIndex: insertIndex)
 
@@ -244,7 +253,8 @@ public final class BonsplitController {
         showsNotificationBadge: Bool? = nil,
         isLoading: Bool? = nil,
         isAudioMuted: Bool? = nil,
-        isPinned: Bool? = nil
+        isPinned: Bool? = nil,
+        showsRemoteIndicator: Bool? = nil
     ) {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return }
 
@@ -277,6 +287,9 @@ public final class BonsplitController {
         }
         if let isPinned = isPinned {
             pane.tabs[tabIndex].isPinned = isPinned
+        }
+        if let showsRemoteIndicator = showsRemoteIndicator {
+            pane.tabs[tabIndex].showsRemoteIndicator = showsRemoteIndicator
         }
     }
 
@@ -442,7 +455,8 @@ public final class BonsplitController {
                 showsNotificationBadge: tab.showsNotificationBadge,
                 isLoading: tab.isLoading,
                 isAudioMuted: tab.isAudioMuted,
-                isPinned: tab.isPinned
+                isPinned: tab.isPinned,
+                showsRemoteIndicator: tab.showsRemoteIndicator
             )
         } else {
             internalTab = nil
@@ -507,7 +521,8 @@ public final class BonsplitController {
             showsNotificationBadge: tab.showsNotificationBadge,
             isLoading: tab.isLoading,
             isAudioMuted: tab.isAudioMuted,
-            isPinned: tab.isPinned
+            isPinned: tab.isPinned,
+            showsRemoteIndicator: tab.showsRemoteIndicator
         )
 
         // Perform split with insertion side.

--- a/Sources/Bonsplit/Public/Types/Tab.swift
+++ b/Sources/Bonsplit/Public/Types/Tab.swift
@@ -19,6 +19,8 @@ public struct Tab: Identifiable, Hashable, Sendable {
     public let isAudioMuted: Bool
     /// Whether the tab is pinned in its pane.
     public let isPinned: Bool
+    /// Whether the tab should show a remote-connection indicator (library consumer-defined meaning, e.g. SSH).
+    public let showsRemoteIndicator: Bool
 
     public init(
         id: TabID = TabID(),
@@ -31,7 +33,8 @@ public struct Tab: Identifiable, Hashable, Sendable {
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
         isAudioMuted: Bool = false,
-        isPinned: Bool = false
+        isPinned: Bool = false,
+        showsRemoteIndicator: Bool = false
     ) {
         self.id = id
         self.title = title
@@ -44,6 +47,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.isLoading = isLoading
         self.isAudioMuted = isAudioMuted
         self.isPinned = isPinned
+        self.showsRemoteIndicator = showsRemoteIndicator
     }
 
     internal init(from tabItem: TabItem) {
@@ -58,5 +62,6 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.isLoading = tabItem.isLoading
         self.isAudioMuted = tabItem.isAudioMuted
         self.isPinned = tabItem.isPinned
+        self.showsRemoteIndicator = tabItem.showsRemoteIndicator
     }
 }

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -21,6 +21,7 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case markAsRead
     case markAsUnread
     case toggleZoom
+    case disconnectRemote
     case forkConversation
     case forkConversationRight
     case forkConversationLeft

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -29,3 +29,5 @@
 "tabContext.forkConversation.bottom" = "Bottom Split";
 "tabContext.forkConversation.newTab" = "New Tab";
 "tabContext.forkConversation.newWorkspace" = "New Workspace";
+"tabContext.disconnectRemote" = "Disconnect SSH";
+"tabContext.remoteConnectedAccessibility" = "Connected over SSH";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -29,3 +29,5 @@
 "tabContext.forkConversation.bottom" = "下分割";
 "tabContext.forkConversation.newTab" = "新規タブ";
 "tabContext.forkConversation.newWorkspace" = "新規ワークスペース";
+"tabContext.disconnectRemote" = "SSH接続を解除";
+"tabContext.remoteConnectedAccessibility" = "SSH接続中";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1729,6 +1729,57 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabContextMenuShowsDisconnectRemoteOnlyWhenAvailable() throws {
+        let target = TabContextMenuActionTarget()
+        var selectedAction: TabContextAction?
+        target.onContextAction = { selectedAction = $0 }
+        func makeState(canDisconnectRemote: Bool) -> TabContextMenuState {
+            TabContextMenuState(
+                isPinned: false,
+                isUnread: false,
+                isBrowser: false,
+                isAudioMuted: false,
+                isTerminal: true,
+                hasCustomTitle: false,
+                canCloseToLeft: false,
+                canCloseToRight: false,
+                canCloseOthers: false,
+                canMoveToNewWorkspace: false,
+                canMoveToLeftPane: false,
+                canMoveToRightPane: false,
+                canForkConversation: false,
+                forkConversationDefaultAction: .forkConversationRight,
+                isZoomed: false,
+                hasSplits: false,
+                shortcuts: [:],
+                canDisconnectRemote: canDisconnectRemote
+            )
+        }
+
+        let withoutRemote = TabContextMenuBuilder.makeMenu(
+            snapshot: TabContextMenuSnapshot(
+                tabId: UUID(),
+                state: makeState(canDisconnectRemote: false),
+                moveDestinationsProvider: { [] }
+            ),
+            target: target
+        )
+        XCTAssertFalse(withoutRemote.items.contains { $0.title == "Disconnect SSH" })
+
+        let withRemote = TabContextMenuBuilder.makeMenu(
+            snapshot: TabContextMenuSnapshot(
+                tabId: UUID(),
+                state: makeState(canDisconnectRemote: true),
+                moveDestinationsProvider: { [] }
+            ),
+            target: target
+        )
+        let disconnectItem = try XCTUnwrap(withRemote.items.first { $0.title == "Disconnect SSH" })
+        target.performContextAction(disconnectItem)
+        XCTAssertEqual(selectedAction, .disconnectRemote)
+    }
+
+    @MainActor
     func testDoubleClickingEmptyTrailingTabBarSpaceRequestsNewTerminalTab() {
         let appearance = BonsplitConfiguration.Appearance()
         let configuration = BonsplitConfiguration(appearance: appearance)


### PR DESCRIPTION
Adds the bonsplit half of cmux pane-scoped SSH connections (cmux ssh --pane):

- `Tab`/`TabItem` gain `showsRemoteIndicator`, rendered as a small network glyph after the tab title with accessibility text (localized en/ja).
- `BonsplitController.updateTab`/`createTab`/`splitPane` carry the new field.
- New `TabContextAction.disconnectRemote` context menu item ("Disconnect SSH", localized en/ja), shown only when the host's `tabContextDisconnectRemoteAvailabilityProvider` returns true.

Includes unit tests for the indicator field plumbing and context action availability.

Consumed by the cmux PR for pane-scoped SSH connections (link added there).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783831810&installation_id=133855650&pr_number=146&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F146&signature=fa7c8203d49d04b826e0b3d6d9fa99ef9d0af5f555b0d6ac3992bc1def98fdfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-tab remote connection indicator and a “Disconnect SSH” context action to support pane-scoped SSH sessions. This clarifies which tabs are remote and gives users a quick way to disconnect when the host allows it.

- New Features
  - New showsRemoteIndicator on tabs; renders a small network glyph after the title with accessible text (en/ja).
  - `BonsplitController.createTab`, `updateTab`, and `splitPane` accept and propagate showsRemoteIndicator.
  - New TabContextAction.disconnectRemote; visibility controlled by host via tabContextDisconnectRemoteAvailabilityProvider.
  - Unit tests for indicator plumbing and context menu availability.

- Migration
  - Pass showsRemoteIndicator when creating or updating tabs that are connected remotely.
  - Provide tabContextDisconnectRemoteAvailabilityProvider and handle the .disconnectRemote action to enable the menu item.

<sup>Written for commit f3b3658ea0983c12dc61ba23467ad18ada7a2232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tabs can now display a remote SSH connection indicator icon when connected.
  * Tab context menu includes a new "Disconnect SSH" action when applicable.
  * Accessibility support added for remote connection status labels.
  * Japanese localization added for SSH-related menu items and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->