### PR TITLE
Fix slow scrolled tab strip interactions

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -216,6 +216,13 @@ private struct SplitButtonLaneWidthReader: View {
     }
 }
 
+struct TabBarScrollAffordances: Equatable {
+    var left: Bool
+    var right: Bool
+
+    static let none = TabBarScrollAffordances(left: false, right: false)
+}
+
 @MainActor
 private final class TabBarScrollViewBridge: ObservableObject {
     private struct ScrollMetrics {
@@ -247,6 +254,10 @@ private final class TabBarScrollViewBridge: ObservableObject {
         )
     }
 
+    func currentScrollOffset() -> CGFloat {
+        currentMetrics()?.offset ?? 0
+    }
+
     func shouldPreferLeadingTarget(
         selectedTabId: UUID?,
         fallbackContentWidth: CGFloat,
@@ -264,6 +275,15 @@ private final class TabBarScrollViewBridge: ObservableObject {
         return TabBarStyling.shouldKeepLeadingAligned(
             contentWidth: fallbackContentWidth,
             containerWidth: fallbackContainerWidth
+        )
+    }
+
+    func shouldForceResetToLeading() -> Bool {
+        guard let metrics = currentMetrics(), metrics.viewportWidth > 0 else { return false }
+        return TabBarStyling.shouldForceResetToLeading(
+            scrollOffset: metrics.offset,
+            contentWidth: metrics.documentWidth,
+            containerWidth: metrics.viewportWidth
         )
     }
 
@@ -364,12 +384,26 @@ enum TabBarStyling {
         scrollOffset: CGFloat,
         contentWidth: CGFloat,
         viewportWidth: CGFloat
-    ) -> (left: Bool, right: Bool) {
+    ) -> TabBarScrollAffordances {
         let overflowThreshold: CGFloat = 1
         let maxOffset = max(0, contentWidth - viewportWidth)
-        return (
+        return TabBarScrollAffordances(
             left: scrollOffset > overflowThreshold,
             right: scrollOffset < maxOffset - overflowThreshold
+        )
+    }
+
+    static func tabScrollAffordances(
+        scrollOffset: CGFloat,
+        contentWidth: CGFloat,
+        containerWidth: CGFloat,
+        trailingDropZoneWidth: CGFloat = 30
+    ) -> TabBarScrollAffordances {
+        let tabsWidth = max(0, contentWidth - trailingDropZoneWidth)
+        guard tabsWidth > containerWidth + 4 else { return .none }
+        return TabBarScrollAffordances(
+            left: scrollOffset > 1,
+            right: scrollOffset < tabsWidth - containerWidth
         )
     }
 
@@ -914,11 +948,11 @@ struct TabBarView: View {
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
-    @State private var scrollOffset: CGFloat = 0
+    @State private var tabScrollAffordances: TabBarScrollAffordances = .none
     @State private var contentWidth: CGFloat = 0
     @State private var tabContentWidthExcludingSplitButtonLane: CGFloat?
     @State private var containerWidth: CGFloat = 0
-    @State private var tabFramesInBar: [UUID: CGRect] = [:]
+    @State private var tabFramesInContent: [UUID: CGRect] = [:]
     @State private var measuredSplitButtonLaneWidth: CGFloat = 0
     @State private var splitButtonScrollOffset: CGFloat = 0
     @State private var splitButtonContentWidth: CGFloat = 0
@@ -927,14 +961,11 @@ struct TabBarView: View {
     @StateObject private var scrollViewBridge = TabBarScrollViewBridge()
 
     private var canScrollLeft: Bool {
-        scrollOffset > 1
+        tabScrollAffordances.left
     }
 
     private var canScrollRight: Bool {
-        // contentWidth includes the 30pt drop zone after tabs.
-        let tabsWidth = contentWidth - 30
-        guard tabsWidth > containerWidth + 4 else { return false }
-        return scrollOffset < tabsWidth - containerWidth
+        tabScrollAffordances.right
     }
 
     /// Whether this tab bar should show full saturation (focused or drag source)
@@ -1005,10 +1036,10 @@ struct TabBarView: View {
         tabBarLayout.trailingTabContentInset
     }
 
-    private var selectedTabFrameInBar: CGRect? {
+    private var selectedTabFrameInContent: CGRect? {
         TabBarStyling.selectedTabFrame(
             selectedTabId: pane.selectedTabId,
-            tabFrames: tabFramesInBar
+            tabFrames: tabFramesInContent
         )
     }
 
@@ -1020,7 +1051,11 @@ struct TabBarView: View {
         "split-button-scroll-\(pane.id.id.uuidString)"
     }
 
-    private var splitButtonScrollAffordances: (left: Bool, right: Bool) {
+    private var tabContentCoordinateSpaceName: String {
+        "tab-content-\(pane.id.id.uuidString)"
+    }
+
+    private var splitButtonScrollAffordances: TabBarScrollAffordances {
         TabBarStyling.splitButtonScrollAffordances(
             scrollOffset: splitButtonScrollOffset,
             contentWidth: splitButtonContentWidth,
@@ -1060,11 +1095,7 @@ struct TabBarView: View {
         }
 
         if target == .leading,
-           TabBarStyling.shouldForceResetToLeading(
-                scrollOffset: scrollOffset,
-                contentWidth: contentWidth,
-                containerWidth: containerWidth
-           ) {
+           scrollViewBridge.shouldForceResetToLeading() {
             scrollViewBridge.resetToLeadingEdgeIfNeeded(reason: "scrollToPreferredTarget")
         } else if target == .leading {
             scrollViewBridge.enforceLeadingEdgeIfContentFits(reason: "scrollToPreferredTarget")
@@ -1102,6 +1133,11 @@ struct TabBarView: View {
                         .padding(.horizontal, TabBarMetrics.barPadding)
                         .padding(.trailing, trailingTabContentInset)
                         .frame(height: tabBarHeight, alignment: .top)
+                        .coordinateSpace(name: tabContentCoordinateSpaceName)
+                        .overlay(alignment: .bottomLeading) {
+                            tabBarBottomSeparator(totalWidth: contentWidth)
+                                .frame(width: contentWidth, height: tabBarHeight, alignment: .topLeading)
+                        }
                         .animation(nil, value: pane.tabs.map(\.id))
                         .background(
                             GeometryReader { contentGeo in
@@ -1175,20 +1211,21 @@ struct TabBarView: View {
         .frame(height: tabBarHeight)
         .coordinateSpace(name: "tabBar")
         .background(tabBarSurface)
-        .overlay(maskedSelectedTabIndicatorChrome)
         .overlay(alignment: .trailing) {
             splitButtonBackdropChrome
                 .opacity(shouldShowSplitButtons ? 1 : 0)
                 .allowsHitTesting(false)
                 .tabBarButtonAnimationsDisabled()
         }
-        .overlay(maskedTabBarBottomSeparatorChrome)
         .overlay {
             TabBarDragZoneView(
                 hitRegion: .trailingEmptyChrome(
-                    tabFrames: Array(tabFramesInBar.values),
+                    tabFrames: Array(tabFramesInContent.values),
                     reservedTrailingWidth: shouldRenderSplitButtons ? splitButtonsBackdropWidth : 0
                 ),
+                scrollOffsetProvider: {
+                    scrollViewBridge.currentScrollOffset()
+                },
                 isMinimalMode: isMinimalMode,
                 isFocusedPane: isFocused,
                 onSingleClick: focusPaneFromTabBarChrome
@@ -1208,7 +1245,10 @@ struct TabBarView: View {
         }
         .background(TabBarDragAndHoverView(
             isMinimalMode: isMinimalMode,
-            tabFrames: Array(tabFramesInBar.values),
+            tabFrames: Array(tabFramesInContent.values),
+            scrollOffsetProvider: {
+                scrollViewBridge.currentScrollOffset()
+            },
             onDoubleClick: {
                 performNewTerminalSplitButtonAction()
             },
@@ -1222,7 +1262,10 @@ struct TabBarView: View {
                 pane: pane,
                 bonsplitController: controller,
                 splitViewController: splitViewController,
-                tabFrames: tabFramesInBar,
+                tabFrames: tabFramesInContent,
+                scrollOffsetProvider: {
+                    scrollViewBridge.currentScrollOffset()
+                },
                 dropTargetIndex: $dropTargetIndex,
                 dropLifecycle: $dropLifecycle
             )
@@ -1251,8 +1294,9 @@ struct TabBarView: View {
             controlKeyMonitor.start()
         }
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
+            guard tabFramesInContent != frames else { return }
             withTransaction(Transaction(animation: nil)) {
-                tabFramesInBar = frames
+                tabFramesInContent = frames
             }
         }
         .onPreferenceChange(SplitButtonLaneWidthPreferenceKey.self) { width in
@@ -1333,7 +1377,7 @@ struct TabBarView: View {
         )
         .background(
             GeometryReader { geometry in
-                let frame = geometry.frame(in: .named("tabBar"))
+                let frame = geometry.frame(in: .named(tabContentCoordinateSpaceName))
                 Color.clear
                     .preference(
                         key: TabFramePreferenceKey.self,
@@ -1601,7 +1645,7 @@ struct TabBarView: View {
     private func splitButtonFallbackSeparator(snapshot: TabBarChromeSnapshot, totalWidth: CGFloat) -> some View {
         let geometry = snapshot.actionLaneGeometry
         let selectedGap = tabBarLayout.selectedSeparatorGap(
-            selectedTabFrame: selectedTabFrameInBar,
+            selectedTabFrame: selectedTabFrameInContent,
             totalWidth: totalWidth
         )
         if let maskFrame = geometry.fallbackSeparatorMaskFrame(
@@ -1718,9 +1762,26 @@ struct TabBarView: View {
     }
 
     private func updateTabScrollContent(frame: CGRect) {
-        scrollOffset = -frame.minX
-        contentWidth = frame.width
-        tabContentWidthExcludingSplitButtonLane = max(0, frame.width - tabBarLayout.trailingTabContentInset)
+        let nextContentWidth = frame.width
+        let nextTabContentWidthExcludingSplitButtonLane = max(0, nextContentWidth - tabBarLayout.trailingTabContentInset)
+        let nextAffordances = TabBarStyling.tabScrollAffordances(
+            scrollOffset: max(0, -frame.minX),
+            contentWidth: nextContentWidth,
+            containerWidth: containerWidth
+        )
+
+        withTransaction(Transaction(animation: nil)) {
+            if abs(contentWidth - nextContentWidth) > 0.5 {
+                contentWidth = nextContentWidth
+            }
+            if tabContentWidthExcludingSplitButtonLane == nil ||
+                abs((tabContentWidthExcludingSplitButtonLane ?? 0) - nextTabContentWidthExcludingSplitButtonLane) > 0.5 {
+                tabContentWidthExcludingSplitButtonLane = nextTabContentWidthExcludingSplitButtonLane
+            }
+            if tabScrollAffordances != nextAffordances {
+                tabScrollAffordances = nextAffordances
+            }
+        }
     }
 
     @ViewBuilder
@@ -1905,44 +1966,13 @@ struct TabBarView: View {
     }
 
     @ViewBuilder
-    private var maskedSelectedTabIndicatorChrome: some View {
-        GeometryReader { geometry in
-            selectedTabIndicator(totalWidth: geometry.size.width)
-                .frame(width: geometry.size.width, height: tabBarHeight, alignment: .topLeading)
-                .mask(combinedMask)
-        }
-        .allowsHitTesting(false)
-    }
-
-    @ViewBuilder
-    private var maskedTabBarBottomSeparatorChrome: some View {
-        GeometryReader { geometry in
-            tabBarBottomSeparator(totalWidth: geometry.size.width)
-        }
-        .allowsHitTesting(false)
-    }
-
-    @ViewBuilder
-    private func selectedTabIndicator(totalWidth: CGFloat) -> some View {
-        if let frame = selectedIndicatorFrame(totalWidth: totalWidth) {
-            Rectangle()
-                .fill(TabBarColors.activeIndicator(saturation: tabBarSaturation))
-                .frame(width: frame.width, height: TabBarMetrics.activeIndicatorHeight)
-                .offset(x: frame.minX)
-                .transaction { transaction in
-                    transaction.animation = nil
-                }
-        }
-    }
-
-    @ViewBuilder
     private func tabBarBottomSeparator(totalWidth: CGFloat) -> some View {
         VStack(spacing: 0) {
             Spacer(minLength: 0)
             HStack(spacing: 0) {
                 let separator = TabBarColors.separator(for: appearance)
                 let gapRange = tabBarLayout.selectedSeparatorGap(
-                    selectedTabFrame: selectedTabFrameInBar,
+                    selectedTabFrame: selectedTabFrameInContent,
                     totalWidth: totalWidth
                 )
                 let segments = TabBarStyling.separatorSegments(
@@ -1958,13 +1988,6 @@ struct TabBarView: View {
                     .frame(width: segments.right, height: 1)
             }
         }
-    }
-
-    private func selectedIndicatorFrame(totalWidth: CGFloat) -> CGRect? {
-        tabBarLayout.selectedIndicatorFrame(
-            selectedTabFrame: selectedTabFrameInBar,
-            totalWidth: totalWidth
-        )
     }
 }
 
@@ -2184,6 +2207,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
     let bonsplitController: BonsplitController
     let splitViewController: SplitViewController
     let tabFrames: [UUID: CGRect]
+    let scrollOffsetProvider: () -> CGFloat
     @Binding var dropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
 
@@ -2202,6 +2226,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
         view.bonsplitController = bonsplitController
         view.splitViewController = splitViewController
         view.tabFrames = tabFrames
+        view.scrollOffsetProvider = scrollOffsetProvider
         view.onDropStateChanged = { targetIndex, lifecycle in
             dropTargetIndex = targetIndex
             dropLifecycle = lifecycle
@@ -2213,6 +2238,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
         weak var bonsplitController: BonsplitController?
         weak var splitViewController: SplitViewController?
         var tabFrames: [UUID: CGRect] = [:]
+        var scrollOffsetProvider: (() -> CGFloat)?
         var onDropStateChanged: ((Int?, TabDropLifecycle) -> Void)?
 
         private var localMouseMonitor: Any?
@@ -2292,7 +2318,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                   let pane,
                   let splitViewController,
                   splitViewController.isInteractive,
-                  let source = tab(at: point, in: pane) else {
+                  let source = tab(at: contentPoint(for: point), in: pane) else {
                 clearManualDrag()
                 return
             }
@@ -2404,20 +2430,25 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 return nil
             }
 
+            let contentPoint = contentPoint(for: point)
             var lastFrame: CGRect?
             for (index, tab) in pane.tabs.enumerated() {
                 guard let frame = tabFrames[tab.id] else { continue }
                 lastFrame = frame
-                if point.x < frame.midX {
+                if contentPoint.x < frame.midX {
                     return index
                 }
             }
 
             if let lastFrame,
-               point.x <= lastFrame.maxX + Self.trailingDropSlop {
+               contentPoint.x <= lastFrame.maxX + Self.trailingDropSlop {
                 return pane.tabs.count
             }
             return nil
+        }
+
+        private func contentPoint(for point: NSPoint) -> NSPoint {
+            NSPoint(x: point.x + max(0, scrollOffsetProvider?() ?? 0), y: point.y)
         }
 
         private func shouldSuppressIndicator(sourceTabId: UUID, targetIndex: Int) -> Bool {
@@ -2445,6 +2476,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
 private struct TabBarDragAndHoverView: NSViewRepresentable {
     let isMinimalMode: Bool
     let tabFrames: [CGRect]
+    let scrollOffsetProvider: () -> CGFloat
     let onDoubleClick: () -> Bool
     let onHoverChanged: (Bool) -> Void
 
@@ -2452,6 +2484,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         let view = TabBarBackgroundNSView()
         view.isMinimalMode = isMinimalMode
         view.tabFrames = tabFrames
+        view.scrollOffsetProvider = scrollOffsetProvider
         view.onDoubleClick = onDoubleClick
         view.onHoverChanged = onHoverChanged
         return view
@@ -2460,6 +2493,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
     func updateNSView(_ nsView: TabBarBackgroundNSView, context: Context) {
         nsView.isMinimalMode = isMinimalMode
         nsView.tabFrames = tabFrames
+        nsView.scrollOffsetProvider = scrollOffsetProvider
         nsView.onDoubleClick = onDoubleClick
         nsView.onHoverChanged = onHoverChanged
     }
@@ -2467,8 +2501,10 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
     final class TabBarBackgroundNSView: NSView, BonsplitTabItemHitRegionProviding {
         var isMinimalMode = false
         nonisolated(unsafe) var tabFrames: [CGRect] = []
+        nonisolated(unsafe) var scrollOffsetProvider: (() -> CGFloat)?
         var onDoubleClick: (() -> Bool)?
         var onHoverChanged: ((Bool) -> Void)?
+        nonisolated(unsafe) private var hitBounds: NSRect = .zero
         private var hoverTrackingArea: NSTrackingArea?
         private var windowDidBecomeKeyObserver: NSObjectProtocol?
         private var windowDidResignKeyObserver: NSObjectProtocol?
@@ -2486,6 +2522,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            syncHitBounds()
             BonsplitTabBarHitRegionRegistry.unregister(self)
             BonsplitTabItemHitRegionRegistry.unregister(self)
             removeWindowObservers()
@@ -2510,11 +2547,27 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             }
         }
 
+        override func layout() {
+            super.layout()
+            syncHitBounds()
+        }
+
+        override func setFrameSize(_ newSize: NSSize) {
+            super.setFrameSize(newSize)
+            syncHitBounds()
+        }
+
+        override func setBoundsSize(_ newSize: NSSize) {
+            super.setBoundsSize(newSize)
+            syncHitBounds()
+        }
+
         nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
-            BonsplitTabItemHitTesting.containsTabLaneHit(
-                localPoint: localPoint,
+            let scrollOffset = max(0, scrollOffsetProvider?() ?? 0)
+            return BonsplitTabItemHitTesting.containsTabLaneHit(
+                localPoint: NSPoint(x: localPoint.x + scrollOffset, y: localPoint.y),
                 tabFrames: tabFrames,
-                bounds: bounds
+                bounds: hitBounds.offsetBy(dx: scrollOffset, dy: 0)
             )
         }
 
@@ -2631,6 +2684,14 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             onHoverChanged?(newValue)
         }
 
+        nonisolated private func contentPoint(for point: NSPoint) -> NSPoint {
+            NSPoint(x: point.x + max(0, scrollOffsetProvider?() ?? 0), y: point.y)
+        }
+
+        private func syncHitBounds() {
+            hitBounds = bounds
+        }
+
         private func installWindowObservers() {
             guard let window else { return }
             windowDidBecomeKeyObserver = NotificationCenter.default.addObserver(
@@ -2669,6 +2730,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
     }
 
     var hitRegion: HitRegion = .entireBounds
+    var scrollOffsetProvider: () -> CGFloat = { 0 }
     let isMinimalMode: Bool
     let isFocusedPane: Bool
     let onSingleClick: () -> Bool
@@ -2677,6 +2739,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
     func makeNSView(context: Context) -> DragNSView {
         let view = DragNSView()
         view.hitRegion = hitRegion
+        view.scrollOffsetProvider = scrollOffsetProvider
         view.isMinimalMode = isMinimalMode
         view.isFocusedPane = isFocusedPane
         view.onSingleClick = onSingleClick
@@ -2688,6 +2751,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
     func updateNSView(_ nsView: DragNSView, context: Context) {
         nsView.hitRegion = hitRegion
+        nsView.scrollOffsetProvider = scrollOffsetProvider
         nsView.isMinimalMode = isMinimalMode
         nsView.isFocusedPane = isFocusedPane
         nsView.onSingleClick = onSingleClick
@@ -2698,6 +2762,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
         var hitRegion = HitRegion.entireBounds {
             didSet { invalidateWindowDragCursorRects() }
         }
+        var scrollOffsetProvider: (() -> CGFloat)?
         var hitTestEventTypeOverride: NSEvent.EventType?
         var isMinimalMode = false {
             didSet { invalidateWindowDragCursorRects() }
@@ -2820,12 +2885,13 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 guard isMouseDownOrDragCandidate else { return false }
                 let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
                 guard point.x < trailingLimit else { return false }
+                let contentPoint = contentPoint(for: point)
                 let paddedFrames = tabFrames.map {
                     $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
                 }
-                guard !paddedFrames.contains(where: { $0.contains(point) }) else { return false }
+                guard !paddedFrames.contains(where: { $0.contains(contentPoint) }) else { return false }
                 let startX = paddedFrames.map(\.maxX).max() ?? bounds.minX
-                return point.x >= startX
+                return contentPoint.x >= startX
             }
         }
 
@@ -2839,10 +2905,12 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
                 guard trailingLimit > bounds.minX else { return [] }
 
+                let scrollOffset = max(0, scrollOffsetProvider?() ?? 0)
                 let paddedFrames = tabFrames.map {
                     $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
                 }
-                let startX = max(bounds.minX, paddedFrames.map(\.maxX).max() ?? bounds.minX)
+                let contentStartX = paddedFrames.map(\.maxX).max() ?? bounds.minX
+                let startX = max(bounds.minX, contentStartX - scrollOffset)
                 guard trailingLimit > startX else { return [] }
 
                 return [
@@ -2868,6 +2936,10 @@ struct TabBarDragZoneView: NSViewRepresentable {
             default:
                 return false
             }
+        }
+
+        private func contentPoint(for point: NSPoint) -> NSPoint {
+            NSPoint(x: point.x + max(0, scrollOffsetProvider?() ?? 0), y: point.y)
         }
 
         override func mouseDragged(with event: NSEvent) {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -216,6 +216,19 @@ struct TabItemView: View {
             maxHeight: tabHeight
         )
         .background(tabBackground.saturation(saturation))
+        .overlay(alignment: .topLeading) {
+            if isSelected {
+                Rectangle()
+                    .fill(TabBarColors.activeIndicator(saturation: saturation))
+                    .frame(height: TabBarMetrics.activeIndicatorHeight)
+                    .padding(.trailing, TabBarMetrics.activeIndicatorTrailingInset)
+                    .transaction { transaction in
+                        transaction.animation = nil
+                        transaction.disablesAnimations = true
+                    }
+            }
+        }
+        .animation(nil, value: isSelected)
         .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
         .contentShape(Rectangle().inset(by: -BonsplitTabItemHitTesting.horizontalSlop))
         // Middle click to close (macOS convention).

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3162,6 +3162,42 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarTrailingEmptyChromeUsesScrolledContentCoordinates() throws {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        view.hitRegion = .trailingEmptyChrome(
+            tabFrames: [CGRect(x: 410, y: 0, width: 90, height: 30)],
+            reservedTrailingWidth: 48
+        )
+        view.scrollOffsetProvider = { 400 }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        contentView.addSubview(view)
+        window.makeKeyAndOrderFront(nil)
+        view.hitTestEventTypeOverride = .leftMouseDown
+
+        XCTAssertNil(
+            view.hitTest(NSPoint(x: 40, y: 15)),
+            "The empty chrome catcher must not cover a visible tab after horizontal scrolling"
+        )
+        XCTAssertIdentical(
+            view.hitTest(NSPoint(x: 140, y: 15)),
+            view,
+            "Empty chrome after the visible scrolled tab should still capture clicks"
+        )
+    }
+
+    @MainActor
     func testTabBarTrailingEmptyChromeDefersToRegisteredTabItemWhenFrameCacheIsEmpty() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         view.hitRegion = .trailingEmptyChrome(tabFrames: [], reservedTrailingWidth: 48)
@@ -3216,6 +3252,23 @@ final class BonsplitTests: XCTestCase {
             view.windowDragCursorRectsForCurrentState(),
             [NSRect(x: 110, y: 0, width: 162, height: 30)],
             "Minimal mode should show the open-hand cursor only in empty chrome after the tab frames and before action buttons"
+        )
+    }
+
+    @MainActor
+    func testTabBarDragZoneCursorUsesScrolledContentCoordinates() {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
+        view.hitRegion = .trailingEmptyChrome(
+            tabFrames: [CGRect(x: 410, y: 0, width: 90, height: 30)],
+            reservedTrailingWidth: 48
+        )
+        view.scrollOffsetProvider = { 400 }
+        view.isMinimalMode = true
+
+        XCTAssertEqual(
+            view.windowDragCursorRectsForCurrentState(),
+            [NSRect(x: 110, y: 0, width: 162, height: 30)],
+            "Minimal-mode cursor rects should be derived from content-space tab frames translated into the visible viewport"
         )
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -642,6 +642,65 @@ final class BonsplitTests: XCTestCase {
         XCTAssertFalse(affordances.right)
     }
 
+    func testTabScrollAffordancesIgnoreTrailingDropZone() {
+        var affordances = TabBarStyling.tabScrollAffordances(
+            scrollOffset: 0,
+            contentWidth: 330,
+            containerWidth: 160
+        )
+        XCTAssertFalse(affordances.left)
+        XCTAssertTrue(affordances.right)
+
+        affordances = TabBarStyling.tabScrollAffordances(
+            scrollOffset: 70,
+            contentWidth: 330,
+            containerWidth: 160
+        )
+        XCTAssertTrue(affordances.left)
+        XCTAssertTrue(affordances.right)
+
+        affordances = TabBarStyling.tabScrollAffordances(
+            scrollOffset: 140,
+            contentWidth: 330,
+            containerWidth: 160
+        )
+        XCTAssertTrue(affordances.left)
+        XCTAssertFalse(affordances.right)
+
+        affordances = TabBarStyling.tabScrollAffordances(
+            scrollOffset: 0,
+            contentWidth: 190,
+            containerWidth: 160
+        )
+        XCTAssertFalse(affordances.left)
+        XCTAssertFalse(affordances.right)
+    }
+
+    func testTabLaneHitTestingUsesScrolledContentBounds() {
+        let scrollOffset: CGFloat = 420
+        let viewportBounds = CGRect(x: 0, y: 0, width: 220, height: 30)
+        let visibleContentBounds = viewportBounds.offsetBy(dx: scrollOffset, dy: 0)
+        let visibleTabFrame = CGRect(x: 500, y: 0, width: 80, height: 30)
+        let visiblePoint = NSPoint(x: 540, y: 14)
+
+        XCTAssertTrue(
+            BonsplitTabItemHitTesting.containsTabLaneHit(
+                localPoint: visiblePoint,
+                tabFrames: [visibleTabFrame],
+                bounds: visibleContentBounds
+            ),
+            "Scrolled tab hit testing should compare content-space tab frames against content-space visible bounds"
+        )
+        XCTAssertFalse(
+            BonsplitTabItemHitTesting.containsTabLaneHit(
+                localPoint: visiblePoint,
+                tabFrames: [visibleTabFrame],
+                bounds: viewportBounds
+            ),
+            "Using viewport bounds with content-space tab frames drops visible scrolled tabs outside the hit lane"
+        )
+    }
+
     func testTabBarLayoutDoesNotHardClipSelectedChromeAtSplitButtonLane() {
         let layout = TabBarLayout(
             tabBarHeight: 28,


### PR DESCRIPTION
Summary
- Keep tab bar geometry in scroll-content coordinates so scroll offset changes do not invalidate every tab frame.
- Translate drag, hover, hit-test, reorder, and cursor points through the current NSScrollView offset.
- Add regression coverage for scrolled trailing chrome and hit regions.

Validation
- swift test --filter BonsplitTests/testTabBarTrailingEmptyChromeUsesScrolledContentCoordinates
- swift test --filter BonsplitTests/testTabBarDragZoneCursorUsesScrolledContentCoordinates
- swift test

Downstream cmux PR: https://github.com/manaflow-ai/cmux/pull/6053

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967180&installation_id=133855650&pr_number=147&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F147&signature=dafbb9b19ee4c68d0d76a08ee205deb4a53ff63e3473c559cb2865757b0b707b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sluggish tab strip interactions while scrolled by keeping tab geometry in content-space and translating interactions by the current scroll offset. Addresses the tab strip scroll performance issue and fixes scrolled hit regions.

- **Bug Fixes**
  - Keep tab frames in content-space to avoid per-scroll frame invalidation.
  - Translate drag, hover, hit-test, reorder, and cursor math by the scroll offset for accurate behavior while scrolled.
  - Add TabBarScrollAffordances and ignore the trailing drop zone when computing left/right scroll affordances.
  - Move the selected tab indicator and bottom separator into content-space; fix trailing empty chrome hit region and minimal-mode cursor rects; add regression tests.

<sup>Written for commit 674339b5d3b980d771c20f86bd710a56677641b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse interaction accuracy and hit-testing for horizontally scrolled tabs.
  * Fixed drag-and-drop and manual tab reordering when content is scrolled.
  * Corrected cursor behavior and drag-zone detection in scrolled tab bar areas.

* **Style**
  * Added visual indicator to highlight the currently selected tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->