### PR TITLE
Merge five-button tab bar branch

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -325,7 +325,13 @@ private final class TabBarScrollViewBridge: ObservableObject {
 }
 
 enum TabBarStyling {
+    struct SplitActionSystemImage: Equatable {
+        let name: String
+        let rotationDegrees: Double
+    }
+
     static let maximumSplitButtonLaneWidthFraction: CGFloat = 0.25
+    static let minimumFullyVisibleSplitButtonCount = 5
     static let splitButtonScrollFadeWidth: CGFloat = 12
     static let splitActionButtonReservedWidth: CGFloat = 22
     static let splitButtonsSpacing: CGFloat = 4
@@ -342,6 +348,22 @@ enum TabBarStyling {
             + splitButtonsTrailingPadding
             + (CGFloat(buttonCount) * splitActionButtonReservedWidth)
             + (CGFloat(max(0, buttonCount - 1)) * splitButtonsSpacing)
+    }
+
+    static func minimumVisibleSplitButtonLaneWidth(buttonCount: Int) -> CGFloat {
+        splitButtonsBackdropWidth(
+            buttonCount: min(max(0, buttonCount), minimumFullyVisibleSplitButtonCount)
+        )
+    }
+
+    static func splitActionSystemImage(for name: String) -> SplitActionSystemImage {
+        if NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil {
+            return SplitActionSystemImage(name: name, rotationDegrees: 0)
+        }
+        if name == "ellipsis.vertical" {
+            return SplitActionSystemImage(name: "ellipsis", rotationDegrees: 90)
+        }
+        return SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0)
     }
 
     static func splitButtonBackdropSolidSurfaceWidth(
@@ -506,7 +528,11 @@ struct TabBarLayout: Equatable {
     var maximumSplitButtonLaneWidth: CGFloat {
         guard availableWidth > 0 else { return 0 }
         let fractionLimit = availableWidth * TabBarStyling.maximumSplitButtonLaneWidthFraction
-        return max(fractionLimit, trailingWhitespaceBeforeSplitButtonLane)
+        return max(
+            fractionLimit,
+            trailingWhitespaceBeforeSplitButtonLane,
+            TabBarStyling.minimumVisibleSplitButtonLaneWidth(buttonCount: splitButtonCount)
+        )
     }
 
     var trailingWhitespaceBeforeSplitButtonLane: CGFloat {
@@ -1764,8 +1790,10 @@ struct TabBarView: View {
     private func splitActionButtonIcon(_ icon: BonsplitConfiguration.SplitActionButton.Icon) -> some View {
         switch icon {
         case .systemImage(let name):
-            Image(systemName: name)
+            let image = TabBarStyling.splitActionSystemImage(for: name)
+            Image(systemName: image.name)
                 .font(.system(size: 12))
+                .rotationEffect(.degrees(image.rotationDegrees))
         case .emoji(let value, let scale):
             Text(value)
                 .font(.system(size: emojiIconFontSize(scale: scale)))

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1756,12 +1756,7 @@ struct TabBarView: View {
         HStack(spacing: TabBarStyling.splitButtonsSpacing) {
             ForEach(buttons.indices, id: \.self) { index in
                 let button = buttons[index]
-                Button {
-                    performSplitActionButton(button)
-                } label: {
-                    splitActionButtonIcon(button.icon)
-                }
-                .buttonStyle(SplitActionButtonStyle(appearance: appearance, layout: tabBarLayout))
+                splitActionButton(button, tooltips: tooltips)
                 .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
                 .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
             }
@@ -1769,6 +1764,35 @@ struct TabBarView: View {
         .padding(.leading, TabBarStyling.splitButtonsLeadingPadding)
         .padding(.trailing, TabBarStyling.splitButtonsTrailingPadding)
         .frame(height: tabBarHeight, alignment: .center)
+    }
+
+    @ViewBuilder
+    private func splitActionButton(
+        _ button: BonsplitConfiguration.SplitActionButton,
+        tooltips: BonsplitConfiguration.SplitButtonTooltips
+    ) -> some View {
+        if button.activatesOnMouseDown {
+            splitActionButtonIcon(button.icon)
+                .frame(height: tabBarLayout.splitActionButtonHeight)
+                .contentShape(Rectangle())
+                .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: false))
+                .tabBarButtonAnimationsDisabled()
+                .overlay(
+                    SplitActionMouseDownOverlay {
+                        performSplitActionButton(button)
+                    }
+                )
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(splitActionButtonTooltip(button, tooltips: tooltips))
+                .accessibilityAddTraits(.isButton)
+        } else {
+            Button {
+                performSplitActionButton(button)
+            } label: {
+                splitActionButtonIcon(button.icon)
+            }
+            .buttonStyle(SplitActionButtonStyle(appearance: appearance, layout: tabBarLayout))
+        }
     }
 
     private func splitActionButtonAccessibilityIdentifier(_ button: BonsplitConfiguration.SplitActionButton) -> String {
@@ -2082,6 +2106,32 @@ private struct SplitActionButtonStyle: ButtonStyle {
             .foregroundStyle(TabBarColors.splitActionIcon(for: appearance, isPressed: configuration.isPressed))
             .opacity(configuration.isPressed ? 0.72 : 1.0)
             .tabBarButtonAnimationsDisabled()
+    }
+}
+
+private struct SplitActionMouseDownOverlay: NSViewRepresentable {
+    let onMouseDown: () -> Void
+
+    func makeNSView(context: Context) -> SplitActionMouseDownNSView {
+        let view = SplitActionMouseDownNSView()
+        view.onMouseDown = onMouseDown
+        return view
+    }
+
+    func updateNSView(_ nsView: SplitActionMouseDownNSView, context: Context) {
+        nsView.onMouseDown = onMouseDown
+    }
+}
+
+private final class SplitActionMouseDownNSView: NSView {
+    var onMouseDown: (() -> Void)?
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        onMouseDown?()
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -328,6 +328,7 @@ enum TabBarStyling {
     struct SplitActionSystemImage: Equatable {
         let name: String
         let rotationDegrees: Double
+        let pointSize: CGFloat
     }
 
     static let maximumSplitButtonLaneWidthFraction: CGFloat = 0.25
@@ -358,12 +359,12 @@ enum TabBarStyling {
 
     static func splitActionSystemImage(for name: String) -> SplitActionSystemImage {
         if NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil {
-            return SplitActionSystemImage(name: name, rotationDegrees: 0)
+            return SplitActionSystemImage(name: name, rotationDegrees: 0, pointSize: 12)
         }
         if name == "ellipsis.vertical" {
-            return SplitActionSystemImage(name: "ellipsis", rotationDegrees: 90)
+            return SplitActionSystemImage(name: "ellipsis", rotationDegrees: 90, pointSize: 10.5)
         }
-        return SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0)
+        return SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0, pointSize: 12)
     }
 
     static func splitButtonBackdropSolidSurfaceWidth(
@@ -1816,7 +1817,7 @@ struct TabBarView: View {
         case .systemImage(let name):
             let image = TabBarStyling.splitActionSystemImage(for: name)
             Image(systemName: image.name)
-                .font(.system(size: 12))
+                .font(.system(size: image.pointSize))
                 .rotationEffect(.degrees(image.rotationDegrees))
         case .emoji(let value, let scale):
             Text(value)

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -272,6 +272,15 @@ extension BonsplitConfiguration {
         public var icon: Icon
         public var tooltip: String?
         public var action: Action
+        public var activatesOnMouseDown: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case icon
+            case tooltip
+            case action
+            case activatesOnMouseDown
+        }
 
         public var systemImage: String {
             if case .systemImage(let name) = icon {
@@ -284,13 +293,15 @@ extension BonsplitConfiguration {
             id: String,
             systemImage: String,
             tooltip: String? = nil,
-            action: Action
+            action: Action,
+            activatesOnMouseDown: Bool = false
         ) {
             self.init(
                 id: id,
                 icon: .systemImage(systemImage),
                 tooltip: tooltip,
-                action: action
+                action: action,
+                activatesOnMouseDown: activatesOnMouseDown
             )
         }
 
@@ -298,12 +309,34 @@ extension BonsplitConfiguration {
             id: String,
             icon: Icon,
             tooltip: String? = nil,
-            action: Action
+            action: Action,
+            activatesOnMouseDown: Bool = false
         ) {
             self.id = id
             self.icon = icon
             self.tooltip = tooltip
             self.action = action
+            self.activatesOnMouseDown = activatesOnMouseDown
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            icon = try container.decode(Icon.self, forKey: .icon)
+            tooltip = try container.decodeIfPresent(String.self, forKey: .tooltip)
+            action = try container.decode(Action.self, forKey: .action)
+            activatesOnMouseDown = try container.decodeIfPresent(Bool.self, forKey: .activatesOnMouseDown) ?? false
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(icon, forKey: .icon)
+            try container.encodeIfPresent(tooltip, forKey: .tooltip)
+            try container.encode(action, forKey: .action)
+            if activatesOnMouseDown {
+                try container.encode(activatesOnMouseDown, forKey: .activatesOnMouseDown)
+            }
         }
 
         public static let newTerminal = SplitActionButton(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -406,19 +406,19 @@ final class BonsplitTests: XCTestCase {
     func testSplitActionSystemImageKeepsSupportedSymbols() {
         let image = TabBarStyling.splitActionSystemImage(for: "terminal")
 
-        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "terminal", rotationDegrees: 0))
+        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "terminal", rotationDegrees: 0, pointSize: 12))
     }
 
     func testSplitActionSystemImageRendersVerticalEllipsisFallback() {
         let image = TabBarStyling.splitActionSystemImage(for: "ellipsis.vertical")
 
-        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "ellipsis", rotationDegrees: 90))
+        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "ellipsis", rotationDegrees: 90, pointSize: 10.5))
     }
 
     func testSplitActionSystemImageUsesFallbackForUnknownSymbols() {
         let image = TabBarStyling.splitActionSystemImage(for: "cmux.definitely.missing.symbol")
 
-        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0))
+        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0, pointSize: 12))
     }
 
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -273,6 +273,36 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(decoded, button)
     }
 
+    func testCustomSplitActionButtonCanActivateOnMouseDown() throws {
+        let button = BonsplitConfiguration.SplitActionButton(
+            id: "tools",
+            systemImage: "ellipsis.vertical",
+            tooltip: "Tools",
+            action: .custom("tools"),
+            activatesOnMouseDown: true
+        )
+
+        let data = try JSONEncoder().encode(button)
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertEqual(decoded, button)
+        XCTAssertTrue(decoded.activatesOnMouseDown)
+    }
+
+    func testSplitActionButtonDecodesMissingMouseDownActivationAsFalse() throws {
+        let data = #"""
+        {
+          "id": "terminal",
+          "icon": { "type": "systemImage", "name": "terminal" },
+          "action": "newTerminal"
+        }
+        """#.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(BonsplitConfiguration.SplitActionButton.self, from: data)
+
+        XCTAssertFalse(decoded.activatesOnMouseDown)
+    }
+
     func testCustomSplitActionButtonPreservesReservedActionName() throws {
         let button = BonsplitConfiguration.SplitActionButton(
             id: "custom-terminal",

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -373,6 +373,24 @@ final class BonsplitTests: XCTestCase {
         XCTAssertTrue(first === second)
     }
 
+    func testSplitActionSystemImageKeepsSupportedSymbols() {
+        let image = TabBarStyling.splitActionSystemImage(for: "terminal")
+
+        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "terminal", rotationDegrees: 0))
+    }
+
+    func testSplitActionSystemImageRendersVerticalEllipsisFallback() {
+        let image = TabBarStyling.splitActionSystemImage(for: "ellipsis.vertical")
+
+        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "ellipsis", rotationDegrees: 90))
+    }
+
+    func testSplitActionSystemImageUsesFallbackForUnknownSymbols() {
+        let image = TabBarStyling.splitActionSystemImage(for: "cmux.definitely.missing.symbol")
+
+        XCTAssertEqual(image, TabBarStyling.SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0))
+    }
+
     func testMinimalModeDoesNotReserveHiddenSplitButtonStrip() {
         XCTAssertEqual(
             TabBarStyling.trailingTabContentInset(showSplitButtons: true, isMinimalMode: true),
@@ -435,7 +453,7 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(layout.trailingTabContentInset, 160)
     }
 
-    func testTabBarLayoutCapsSplitButtonLaneToQuarterOfAvailableWidth() {
+    func testTabBarLayoutKeepsFiveActionButtonsVisibleBeforeClipping() {
         let layout = TabBarLayout(
             tabBarHeight: 28,
             availableWidth: 240,
@@ -444,11 +462,12 @@ final class BonsplitTests: XCTestCase {
             reservesSplitButtonLane: true,
             measuredSplitButtonLaneWidth: 400
         )
+        let minimumVisibleWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: 5)
 
         XCTAssertEqual(layout.fullSplitButtonLaneWidth, 400)
-        XCTAssertEqual(layout.maximumSplitButtonLaneWidth, 60)
-        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, 60)
-        XCTAssertEqual(layout.trailingTabContentInset, 60)
+        XCTAssertEqual(layout.maximumSplitButtonLaneWidth, minimumVisibleWidth)
+        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, minimumVisibleWidth)
+        XCTAssertEqual(layout.trailingTabContentInset, minimumVisibleWidth)
         XCTAssertTrue(layout.splitButtonLaneOverflowsViewport)
     }
 
@@ -463,9 +482,10 @@ final class BonsplitTests: XCTestCase {
             measuredSplitButtonLaneWidth: 400
         )
 
-        XCTAssertEqual(layout.maximumSplitButtonLaneWidth, 60)
-        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, 60)
-        XCTAssertEqual(layout.trailingTabContentInset, 60)
+        let minimumVisibleWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: 5)
+        XCTAssertEqual(layout.maximumSplitButtonLaneWidth, minimumVisibleWidth)
+        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, minimumVisibleWidth)
+        XCTAssertEqual(layout.trailingTabContentInset, minimumVisibleWidth)
     }
 
     func testTabBarLayoutUsesTrailingWhitespaceBeforeClippingSplitButtons() {
@@ -523,9 +543,10 @@ final class BonsplitTests: XCTestCase {
             masksTabContent: true
         )
 
-        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, 60, accuracy: 0.0001)
-        XCTAssertEqual(geometry.backgroundSolidWidth, 60, accuracy: 0.0001)
-        XCTAssertEqual(geometry.contentOcclusionWidth, 60, accuracy: 0.0001)
+        let minimumVisibleWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: 5)
+        XCTAssertEqual(layout.visibleSplitButtonLaneWidth, minimumVisibleWidth, accuracy: 0.0001)
+        XCTAssertEqual(geometry.backgroundSolidWidth, minimumVisibleWidth, accuracy: 0.0001)
+        XCTAssertEqual(geometry.contentOcclusionWidth, minimumVisibleWidth, accuracy: 0.0001)
     }
 
     func testActionLaneSolidSurfaceAllowsTrimWhenButtonsDoNotOverflow() {


### PR DESCRIPTION
Merge the task-keep-five-split-buttons-visible work into main so cmux can safely reference f23ccf920811da85761640e814ca7bc7cc82d5e5 from the bonsplit submodule pointer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784102224&installation_id=133855650&pr_number=148&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F148&signature=b730ec8d8a7dcfdb7eed4583418e5e2935bd0aabd6c1d0894ade154324b0f6a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the first five split action buttons in the tab bar visible at all times and add optional mouse-down activation for menu-style actions. Also normalizes the vertical ellipsis icon and adds fallbacks for unknown symbols. Supports Linear CMUX-4332 by guaranteeing five default actions remain visible.

- **New Features**
  - Enforce a minimum split-button lane width so up to five buttons stay visible before clipping.
  - Add `activatesOnMouseDown` to `BonsplitConfiguration.SplitActionButton` (Codable, defaults to false) and handle it with a mouse-down overlay.
  - Map action icons via `splitActionSystemImage`: rotate `ellipsis.vertical` to `ellipsis` with a smaller size; fallback to `questionmark.circle` for unknown symbols.

<sup>Written for commit f69ba293d41e0b5a2a371d126578fe6f92f72f82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Split action buttons now support mouse-down activation mode via a new configuration option.

* **Improvements**
  * Enhanced icon rendering for split buttons with intelligent sizing and rotation based on button type.
  * Refined split button lane width calculations for more consistent layout behavior and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->