### PR TITLE
Render pinned browser tabs icon-only

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -15,6 +15,13 @@ extension UTType {
 
 /// Represents a single tab in a pane's tab bar (internal representation)
 struct TabItem: Identifiable, Hashable, Codable {
+    /// Consumer ``kind`` identifiers that render as pinned, icon-only (favicon)
+    /// tabs when pinned. These are browser-backed surfaces whose favicons stay
+    /// distinct at chip size, mirroring pinned tabs in macOS browsers. Kept in
+    /// sync with the cmux `SurfaceKind` browser raw values (`browser`,
+    /// `extensionBrowser`).
+    static let iconOnlyPinnedKinds: Set<String> = ["browser", "extensionBrowser"]
+
     let id: UUID
     var title: String
     var hasCustomTitle: Bool

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -105,9 +105,28 @@ struct TabItemView: View {
             if isIconOnlyPinned {
                 // Pinned browser tabs collapse to a favicon-only chip, mirroring
                 // pinned tabs in macOS browsers so long-lived utilities take less
-                // horizontal space in the tab bar.
-                leadingIcon
-                    .frame(maxWidth: .infinity, alignment: .center)
+                // horizontal space in the tab bar. The title and trailing close/pin
+                // accessory are hidden, but transient state stays visible: status
+                // dots (muted/unread/modified) overlay the favicon corner, and the
+                // control-shortcut hint takes over the chip while the modifier is
+                // held (matching how normal tabs surface the hint).
+                ZStack {
+                    leadingIcon
+                        .opacity(showsShortcutHint ? 0 : 1)
+                        .overlay(alignment: .topTrailing) {
+                            iconOnlyStatusBadge
+                                .opacity(showsShortcutHint ? 0 : 1)
+                                .offset(x: 4, y: -4)
+                        }
+
+                    if let shortcutHintLabel {
+                        shortcutHintCapsule(shortcutHintLabel)
+                            .opacity(showsShortcutHint ? 1 : 0)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
             } else {
                 // Icon + title block uses the standard spacing, but keep the close affordance tight.
                 HStack(spacing: scaledContentSpacing) {
@@ -368,31 +387,7 @@ struct TabItemView: View {
     private var trailingAccessory: some View {
         ZStack(alignment: .center) {
             if let shortcutHintLabel {
-                Text(shortcutHintLabel)
-                    .font(.system(size: accessoryFontSize, weight: .semibold, design: .rounded))
-                    .monospacedDigit()
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .foregroundStyle(
-                        isSelected
-                            ? TabBarColors.activeText(for: appearance)
-                            : TabBarColors.inactiveText(for: appearance)
-                    )
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 1)
-                    .background(
-                        Capsule(style: .continuous)
-                            .fill(.regularMaterial)
-                            .overlay(
-                                Capsule(style: .continuous)
-                                    .stroke(Color.white.opacity(0.30), lineWidth: 0.8)
-                            )
-                            .shadow(color: Color.black.opacity(0.22), radius: 2, x: 0, y: 1)
-                    )
-                    .offset(
-                        x: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintXOffset),
-                        y: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintYOffset)
-                    )
+                shortcutHintCapsule(shortcutHintLabel)
                     .opacity(showsShortcutHint ? 1 : 0)
                     .allowsHitTesting(false)
             }
@@ -403,6 +398,63 @@ struct TabItemView: View {
         }
         .frame(width: shortcutHintSlotWidth, height: accessorySlotSize, alignment: .center)
         .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
+    }
+
+    /// The control-shortcut hint capsule (e.g. "⌃1"), shared by the normal
+    /// trailing accessory and the pinned icon-only overlay.
+    @ViewBuilder
+    private func shortcutHintCapsule(_ label: String) -> some View {
+        Text(label)
+            .font(.system(size: accessoryFontSize, weight: .semibold, design: .rounded))
+            .monospacedDigit()
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .foregroundStyle(
+                isSelected
+                    ? TabBarColors.activeText(for: appearance)
+                    : TabBarColors.inactiveText(for: appearance)
+            )
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(.regularMaterial)
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .stroke(Color.white.opacity(0.30), lineWidth: 0.8)
+                    )
+                    .shadow(color: Color.black.opacity(0.22), radius: 2, x: 0, y: 1)
+            )
+            .offset(
+                x: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintXOffset),
+                y: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintYOffset)
+            )
+    }
+
+    /// Compact status indicators (muted, unread, modified) overlaid on the
+    /// favicon of a pinned icon-only tab, where the title and trailing accessory
+    /// are hidden. Mirrors the activity/audio dots macOS browsers keep on pinned
+    /// tabs so state stays visible at chip size.
+    @ViewBuilder
+    private var iconOnlyStatusBadge: some View {
+        HStack(spacing: 1.5) {
+            if tab.isAudioMuted {
+                Image(systemName: "speaker.slash.fill")
+                    .font(.system(size: max(6, accessoryFontSize - 3), weight: .semibold))
+                    .foregroundStyle(TabBarColors.inactiveText(for: appearance))
+            }
+            if tab.showsNotificationBadge {
+                Circle()
+                    .fill(TabBarColors.notificationBadge(for: appearance))
+                    .frame(width: TabBarMetrics.notificationBadgeSize, height: TabBarMetrics.notificationBadgeSize)
+            }
+            if tab.isDirty {
+                Circle()
+                    .fill(TabBarColors.dirtyIndicator(for: appearance))
+                    .frame(width: TabBarMetrics.dirtyIndicatorSize, height: TabBarMetrics.dirtyIndicatorSize)
+            }
+        }
+        .saturation(saturation)
     }
 
     private func updateGlobeFallback() {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -49,10 +49,12 @@ enum TabItemStyling {
 
     /// Whether a tab should render in the pinned, icon-only (favicon) layout.
     ///
-    /// Only browser-backed surfaces (see ``TabItem/iconOnlyPinnedKinds``) collapse
-    /// to a favicon chip when pinned, matching pinned tabs in macOS browsers.
-    static func isIconOnlyPinned(isPinned: Bool, kind: String?) -> Bool {
-        isPinned && TabItem.iconOnlyPinnedKinds.contains(kind ?? "")
+    /// Only pinned browser-backed surfaces (see ``TabItem/iconOnlyPinnedKinds``)
+    /// that have a distinct favicon image collapse to a favicon chip, matching
+    /// pinned tabs in macOS browsers. Requiring a favicon avoids collapsing
+    /// several tabs into identical spinner/globe chips before their icons load.
+    static func isIconOnlyPinned(isPinned: Bool, kind: String?, hasFaviconImage: Bool) -> Bool {
+        isPinned && hasFaviconImage && TabItem.iconOnlyPinnedKinds.contains(kind ?? "")
     }
 
     static func resolvedFaviconImage(existing: NSImage?, incomingData: Data?) -> NSImage? {
@@ -297,11 +299,19 @@ struct TabItemView: View {
 
     /// Whether this tab should render in the pinned, icon-only (favicon) layout.
     ///
-    /// Scoped to browser-backed surfaces: their favicons stay visually distinct
-    /// at chip size, matching pinned tabs in macOS browsers. Other pinned tabs
-    /// (e.g. terminals) keep their title so they remain distinguishable.
+    /// Scoped to pinned browser-backed surfaces that carry a distinct favicon:
+    /// those stay visually distinguishable at chip size, matching pinned tabs in
+    /// macOS browsers. Tabs without a favicon (still loading, or no icon), other
+    /// kinds (e.g. terminals), and the selected tab of a zoomed pane (which needs
+    /// its Exit-zoom affordance) keep the full layout.
     private var isIconOnlyPinned: Bool {
-        TabItemStyling.isIconOnlyPinned(isPinned: tab.isPinned, kind: tab.kind)
+        guard !showsZoomIndicator else { return false }
+        let hasFaviconImage = tab.iconImageData != nil || renderedFaviconImage != nil
+        return TabItemStyling.isIconOnlyPinned(
+            isPinned: tab.isPinned,
+            kind: tab.kind,
+            hasFaviconImage: hasFaviconImage
+        )
     }
 
     /// Fixed width of a pinned icon-only tab: the icon slot centered with

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -47,6 +47,14 @@ enum TabItemStyling {
         return minimum...maximum
     }
 
+    /// Whether a tab should render in the pinned, icon-only (favicon) layout.
+    ///
+    /// Only browser-backed surfaces (see ``TabItem/iconOnlyPinnedKinds``) collapse
+    /// to a favicon chip when pinned, matching pinned tabs in macOS browsers.
+    static func isIconOnlyPinned(isPinned: Bool, kind: String?) -> Bool {
+        isPinned && TabItem.iconOnlyPinnedKinds.contains(kind ?? "")
+    }
+
     static func resolvedFaviconImage(existing: NSImage?, incomingData: Data?) -> NSImage? {
         guard let incomingData else { return nil }
         if let decoded = NSImage(data: incomingData) {
@@ -94,124 +102,83 @@ struct TabItemView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // Icon + title block uses the standard spacing, but keep the close affordance tight.
-            HStack(spacing: scaledContentSpacing) {
-                let iconSlotSize = scaledIconSize
-                let iconTintColor = isSelected
-                    ? TabBarColors.nsColorActiveText(for: appearance)
-                    : TabBarColors.nsColorInactiveText(for: appearance)
-                let iconTint = Color(nsColor: iconTintColor)
-                let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { NSImage(data: $0) }
+            if isIconOnlyPinned {
+                // Pinned browser tabs collapse to a favicon-only chip, mirroring
+                // pinned tabs in macOS browsers so long-lived utilities take less
+                // horizontal space in the tab bar.
+                leadingIcon
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                // Icon + title block uses the standard spacing, but keep the close affordance tight.
+                HStack(spacing: scaledContentSpacing) {
+                    leadingIcon
 
-                Group {
-                    if tab.isLoading {
-                        // Slightly smaller than the icon slot so it reads cleaner at tab scale.
-                        TabLoadingSpinner(size: iconSlotSize * 0.86, color: iconTintColor)
-                    } else if let image = faviconImage {
-                        FaviconIconView(image: image)
-                            .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
-                            .clipped()
-                    } else if let iconName = tab.icon {
-                        if iconName == "globe", !showGlobeFallback {
-                            // Avoid a distracting "globe -> favicon" flash: show a neutral placeholder
-                            // briefly while the favicon fetch finishes. If no favicon arrives, we
-                            // reveal the globe after a short delay.
-                            RoundedRectangle(cornerRadius: 3)
-                                .stroke(iconTint.opacity(0.25), lineWidth: 1)
-                        } else {
-                            Image(systemName: iconName)
-                                .font(.system(size: glyphSize(for: iconName)))
-                                .foregroundStyle(iconTint)
-                        }
-                    }
-                }
-                // Keep downloaded favicon bitmaps in full color even for inactive tab bars.
-                .saturation(TabItemStyling.iconSaturation(hasRasterIcon: faviconImage != nil, tabSaturation: saturation))
-                .transaction { tx in
-                    // Prevent incidental parent animations from briefly fading icon content.
-                    tx.animation = nil
-                }
-                .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
-                .onAppear {
-                    updateRenderedFaviconImage()
-                    updateGlobeFallback()
-                }
-                .onDisappear {
-                    globeFallbackWorkItem?.cancel()
-                    globeFallbackWorkItem = nil
-                }
-                .onChange(of: tab.isLoading) { _ in updateGlobeFallback() }
-                .onChange(of: tab.iconImageData) { _ in
-                    updateRenderedFaviconImage()
-                    updateGlobeFallback()
-                }
-                .onChange(of: tab.icon) { _ in updateGlobeFallback() }
-
-                Text(tab.title)
-                    .font(.system(size: appearance.tabTitleFontSize))
-                    .lineLimit(1)
-                    .foregroundStyle(
-                        isSelected
-                            ? TabBarColors.activeText(for: appearance)
-                            : TabBarColors.inactiveText(for: appearance)
-                    )
-                    .saturation(saturation)
-
-                if tab.isAudioMuted {
-                    Image(systemName: "speaker.slash")
-                        .font(.system(size: accessoryFontSize, weight: .semibold))
+                    Text(tab.title)
+                        .font(.system(size: appearance.tabTitleFontSize))
+                        .lineLimit(1)
                         .foregroundStyle(
-                            (isSelected
+                            isSelected
                                 ? TabBarColors.activeText(for: appearance)
-                                : TabBarColors.inactiveText(for: appearance))
-                                .opacity(0.78)
+                                : TabBarColors.inactiveText(for: appearance)
                         )
                         .saturation(saturation)
-                        .accessibilityHidden(true)
-                }
 
-                if showsZoomIndicator {
-                    Button {
-                        onZoomToggle()
-                    } label: {
-                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    if tab.isAudioMuted {
+                        Image(systemName: "speaker.slash")
                             .font(.system(size: accessoryFontSize, weight: .semibold))
                             .foregroundStyle(
-                                isZoomHovered
+                                (isSelected
                                     ? TabBarColors.activeText(for: appearance)
-                                    : TabBarColors.inactiveText(for: appearance)
+                                    : TabBarColors.inactiveText(for: appearance))
+                                    .opacity(0.78)
                             )
-                            .frame(width: accessorySlotSize, height: accessorySlotSize)
-                            .background(
-                                Circle()
-                                    .fill(
-                                        isZoomHovered
-                                            ? TabBarColors.hoveredTabBackground(for: appearance)
-                                            : .clear
-                                    )
-                            )
+                            .saturation(saturation)
+                            .accessibilityHidden(true)
                     }
-                    .buttonStyle(.plain)
-                    .onHover { hovering in
-                        withTransaction(Transaction(animation: nil)) {
-                            isZoomHovered = hovering
+
+                    if showsZoomIndicator {
+                        Button {
+                            onZoomToggle()
+                        } label: {
+                            Image(systemName: "arrow.up.left.and.arrow.down.right")
+                                .font(.system(size: accessoryFontSize, weight: .semibold))
+                                .foregroundStyle(
+                                    isZoomHovered
+                                        ? TabBarColors.activeText(for: appearance)
+                                        : TabBarColors.inactiveText(for: appearance)
+                                )
+                                .frame(width: accessorySlotSize, height: accessorySlotSize)
+                                .background(
+                                    Circle()
+                                        .fill(
+                                            isZoomHovered
+                                                ? TabBarColors.hoveredTabBackground(for: appearance)
+                                                : .clear
+                                        )
+                                )
                         }
+                        .buttonStyle(.plain)
+                        .onHover { hovering in
+                            withTransaction(Transaction(animation: nil)) {
+                                isZoomHovered = hovering
+                            }
+                        }
+                        .saturation(saturation)
+                        .accessibilityLabel("Exit zoom")
+                        .tabBarButtonAnimationsDisabled()
                     }
-                    .saturation(saturation)
-                    .accessibilityLabel("Exit zoom")
-                    .tabBarButtonAnimationsDisabled()
                 }
+
+                Spacer(minLength: 0)
+
+                // Close button / dirty indicator / shortcut hint share the same trailing slot.
+                trailingAccessory
             }
-
-            Spacer(minLength: 0)
-
-            // Close button / dirty indicator / shortcut hint share the same trailing slot.
-            trailingAccessory
         }
         .padding(.horizontal, TabBarMetrics.tabHorizontalPadding)
         .frame(
-            minWidth: tabWidthRange.lowerBound,
-            maxWidth: tabWidthRange.upperBound,
+            minWidth: isIconOnlyPinned ? pinnedIconOnlyWidth : tabWidthRange.lowerBound,
+            maxWidth: isIconOnlyPinned ? pinnedIconOnlyWidth : tabWidthRange.upperBound,
             minHeight: tabHeight,
             maxHeight: tabHeight
         )
@@ -251,6 +218,77 @@ struct TabItemView: View {
         .accessibilityValue(accessibilityValue)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .safeHelp(tab.title)
+    }
+
+    /// Leading icon (favicon / SF Symbol / loading spinner) shared by the normal
+    /// and the pinned icon-only tab layouts.
+    @ViewBuilder
+    private var leadingIcon: some View {
+        let iconSlotSize = scaledIconSize
+        let iconTintColor = isSelected
+            ? TabBarColors.nsColorActiveText(for: appearance)
+            : TabBarColors.nsColorInactiveText(for: appearance)
+        let iconTint = Color(nsColor: iconTintColor)
+        let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { NSImage(data: $0) }
+
+        Group {
+            if tab.isLoading {
+                // Slightly smaller than the icon slot so it reads cleaner at tab scale.
+                TabLoadingSpinner(size: iconSlotSize * 0.86, color: iconTintColor)
+            } else if let image = faviconImage {
+                FaviconIconView(image: image)
+                    .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
+                    .clipped()
+            } else if let iconName = tab.icon {
+                if iconName == "globe", !showGlobeFallback {
+                    // Avoid a distracting "globe -> favicon" flash: show a neutral placeholder
+                    // briefly while the favicon fetch finishes. If no favicon arrives, we
+                    // reveal the globe after a short delay.
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(iconTint.opacity(0.25), lineWidth: 1)
+                } else {
+                    Image(systemName: iconName)
+                        .font(.system(size: glyphSize(for: iconName)))
+                        .foregroundStyle(iconTint)
+                }
+            }
+        }
+        // Keep downloaded favicon bitmaps in full color even for inactive tab bars.
+        .saturation(TabItemStyling.iconSaturation(hasRasterIcon: faviconImage != nil, tabSaturation: saturation))
+        .transaction { tx in
+            // Prevent incidental parent animations from briefly fading icon content.
+            tx.animation = nil
+        }
+        .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
+        .onAppear {
+            updateRenderedFaviconImage()
+            updateGlobeFallback()
+        }
+        .onDisappear {
+            globeFallbackWorkItem?.cancel()
+            globeFallbackWorkItem = nil
+        }
+        .onChange(of: tab.isLoading) { _ in updateGlobeFallback() }
+        .onChange(of: tab.iconImageData) { _ in
+            updateRenderedFaviconImage()
+            updateGlobeFallback()
+        }
+        .onChange(of: tab.icon) { _ in updateGlobeFallback() }
+    }
+
+    /// Whether this tab should render in the pinned, icon-only (favicon) layout.
+    ///
+    /// Scoped to browser-backed surfaces: their favicons stay visually distinct
+    /// at chip size, matching pinned tabs in macOS browsers. Other pinned tabs
+    /// (e.g. terminals) keep their title so they remain distinguishable.
+    private var isIconOnlyPinned: Bool {
+        TabItemStyling.isIconOnlyPinned(isPinned: tab.isPinned, kind: tab.kind)
+    }
+
+    /// Fixed width of a pinned icon-only tab: the icon slot centered with
+    /// symmetric horizontal padding.
+    private var pinnedIconOnlyWidth: CGFloat {
+        ceil(scaledIconSize + TabBarMetrics.tabHorizontalPadding * 2 + 8 * fontScale)
     }
 
     /// Scale factor of the configured tab title font relative to the default.

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1354,6 +1354,20 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(pane.tabs.suffix(2).allSatisfy { !$0.isPinned }, true)
     }
 
+    func testIconOnlyPinnedAppliesOnlyToPinnedBrowserSurfaces() {
+        // Pinned browser surfaces collapse to a favicon-only chip.
+        XCTAssertTrue(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "browser"))
+        XCTAssertTrue(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "extensionBrowser"))
+
+        // Unpinned browser tabs keep their title.
+        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: false, kind: "browser"))
+
+        // Pinned non-browser tabs (e.g. terminals) keep their title so they stay
+        // distinguishable.
+        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "terminal"))
+        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: nil))
+    }
+
     @MainActor
     func testCreateTabStoresKindAndPinnedState() {
         let controller = BonsplitController()

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1354,18 +1354,22 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(pane.tabs.suffix(2).allSatisfy { !$0.isPinned }, true)
     }
 
-    func testIconOnlyPinnedAppliesOnlyToPinnedBrowserSurfaces() {
-        // Pinned browser surfaces collapse to a favicon-only chip.
-        XCTAssertTrue(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "browser"))
-        XCTAssertTrue(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "extensionBrowser"))
+    func testIconOnlyPinnedAppliesOnlyToPinnedBrowserSurfacesWithFavicon() {
+        // Pinned browser surfaces with a favicon collapse to a favicon-only chip.
+        XCTAssertTrue(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "browser", hasFaviconImage: true))
+        XCTAssertTrue(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "extensionBrowser", hasFaviconImage: true))
+
+        // No favicon yet (loading / globe fallback): keep the title so tabs stay
+        // distinguishable instead of collapsing to identical placeholder chips.
+        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "browser", hasFaviconImage: false))
 
         // Unpinned browser tabs keep their title.
-        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: false, kind: "browser"))
+        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: false, kind: "browser", hasFaviconImage: true))
 
         // Pinned non-browser tabs (e.g. terminals) keep their title so they stay
         // distinguishable.
-        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "terminal"))
-        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: nil))
+        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: "terminal", hasFaviconImage: true))
+        XCTAssertFalse(TabItemStyling.isIconOnlyPinned(isPinned: true, kind: nil, hasFaviconImage: true))
     }
 
     @MainActor


### PR DESCRIPTION
Supports cmux issue manaflow-ai/cmux#6298 (pinned browser surfaces with icon-only display).

## What
Pinned tabs whose `kind` is a browser surface (`browser`, `extensionBrowser`) now collapse to a favicon-only chip in the tab bar — title and trailing accessory are hidden and the tab uses a fixed narrow width — mirroring pinned tabs in macOS browsers. Other pinned tabs (e.g. terminals) keep their title so they stay distinguishable.

## How
- `TabItemView`: extracted the shared leading-icon view; added an icon-only branch gated on `isIconOnlyPinned` plus a fixed `pinnedIconOnlyWidth`.
- `TabItemStyling.isIconOnlyPinned(isPinned:kind:)`: pure, testable decision helper.
- `TabItem.iconOnlyPinnedKinds`: the browser-kind set (kept in sync with cmux `SurfaceKind`).

## Tests
`BonsplitTests.testIconOnlyPinnedAppliesOnlyToPinnedBrowserSurfaces` covers the gating (pinned browser → true; unpinned/terminal/nil → false). `swift test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784316200&installation_id=133855650&pr_number=149&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F149&signature=297087e3c09115de92841da4ee8eac3e356ad68d4ed68ee961680ca2c3b6b51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned browser tabs now collapse to a favicon‑only chip to save space and match macOS browsers. Status dots and the control‑shortcut hint stay visible; non‑browser pinned tabs keep their title.

- **New Features**
  - Pinned `browser`/`extensionBrowser` tabs render icon‑only only when a favicon image is available; loading/globe states keep the title, and the selected tab of a zoomed pane keeps the full layout to show Exit‑zoom.
  - Icon‑only chips show compact status (muted/unread/modified) and the control‑shortcut hint, and use a fixed narrow width.

- **Refactors**
  - Extracted shared `leadingIcon` and `shortcutHintCapsule`; added `iconOnlyStatusBadge` and `pinnedIconOnlyWidth`.
  - Added `TabItemStyling.isIconOnlyPinned(isPinned:kind:hasFaviconImage:)` and `TabItem.iconOnlyPinnedKinds`; updated tests to cover the gating.

<sup>Written for commit 9d7e7e4e87cc127a4204d1af27cfcc05bb3783f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser tabs now support a compact, pinned icon-only mode that displays the favicon centered, with the status/badge and shortcut hint overlaid where applicable.
  * This mode is limited to pinned browser-related tab types and does not apply to pinned non-browser kinds.

* **Tests**
  * Added unit test coverage to confirm the icon-only pinned behavior applies only to the intended pinned browser tab kinds and returns false for non-pinned, non-browser, or missing kinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->