### PR TITLE
Add per-tab audio-playing indicator with click-to-mute

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -25,6 +25,9 @@ struct TabItem: Identifiable, Hashable, Codable {
     var showsNotificationBadge: Bool
     var isLoading: Bool
     var isAudioMuted: Bool
+    /// Whether the tab is actively producing audible audio (library
+    /// consumer-defined meaning, e.g. a browser page playing sound).
+    var isAudioPlaying: Bool
     var isPinned: Bool
 
     init(
@@ -38,6 +41,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
         isAudioMuted: Bool = false,
+        isAudioPlaying: Bool = false,
         isPinned: Bool = false
     ) {
         self.id = id
@@ -50,6 +54,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.showsNotificationBadge = showsNotificationBadge
         self.isLoading = isLoading
         self.isAudioMuted = isAudioMuted
+        self.isAudioPlaying = isAudioPlaying
         self.isPinned = isPinned
     }
 
@@ -72,6 +77,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         case showsNotificationBadge
         case isLoading
         case isAudioMuted
+        case isAudioPlaying
         case isPinned
     }
 
@@ -87,6 +93,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.showsNotificationBadge = try c.decodeIfPresent(Bool.self, forKey: .showsNotificationBadge) ?? false
         self.isLoading = try c.decodeIfPresent(Bool.self, forKey: .isLoading) ?? false
         self.isAudioMuted = try c.decodeIfPresent(Bool.self, forKey: .isAudioMuted) ?? false
+        self.isAudioPlaying = try c.decodeIfPresent(Bool.self, forKey: .isAudioPlaying) ?? false
         self.isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
     }
 
@@ -102,6 +109,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         try c.encode(showsNotificationBadge, forKey: .showsNotificationBadge)
         try c.encode(isLoading, forKey: .isLoading)
         try c.encode(isAudioMuted, forKey: .isAudioMuted)
+        try c.encode(isAudioPlaying, forKey: .isAudioPlaying)
         try c.encode(isPinned, forKey: .isPinned)
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -100,6 +100,7 @@ struct TabItemView: View {
     @State private var isHovered = false
     @State private var isCloseHovered = false
     @State private var isZoomHovered = false
+    @State private var isAudioHovered = false
     @State private var showGlobeFallback = true
     @State private var globeFallbackWorkItem: DispatchWorkItem?
     @State private var lastIsLoadingObserved = false
@@ -175,17 +176,53 @@ struct TabItemView: View {
                     )
                     .saturation(saturation)
 
-                if tab.isAudioMuted {
-                    Image(systemName: "speaker.slash")
-                        .font(.system(size: accessoryFontSize, weight: .semibold))
-                        .foregroundStyle(
-                            (isSelected
-                                ? TabBarColors.activeText(for: appearance)
-                                : TabBarColors.inactiveText(for: appearance))
-                                .opacity(0.78)
-                        )
-                        .saturation(saturation)
-                        .accessibilityHidden(true)
+                // Chrome/Safari-style audio affordance: a speaker glyph appears
+                // when the tab is producing audible audio (click to mute) or has
+                // been muted (click to unmute). Reuses the existing
+                // `.toggleAudioMute` context action so the host owns the mute
+                // route. Hidden when the tab is neither playing nor muted.
+                if tab.isAudioMuted || tab.isAudioPlaying {
+                    let isMuted = tab.isAudioMuted
+                    let audioLabel = Bundle.module.localizedString(
+                        forKey: isMuted ? "tabContext.unmuteTab" : "tabContext.muteTab",
+                        value: isMuted ? "Unmute Tab" : "Mute Tab",
+                        table: nil
+                    )
+                    Button {
+                        onContextAction(.toggleAudioMute)
+                    } label: {
+                        Image(systemName: isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                            .font(.system(size: accessoryFontSize, weight: .semibold))
+                            .foregroundStyle(
+                                isAudioHovered
+                                    ? (isSelected
+                                        ? TabBarColors.activeText(for: appearance)
+                                        : TabBarColors.inactiveText(for: appearance))
+                                    : (isSelected
+                                        ? TabBarColors.activeText(for: appearance)
+                                        : TabBarColors.inactiveText(for: appearance))
+                                        .opacity(0.78)
+                            )
+                            .frame(width: accessorySlotSize, height: accessorySlotSize)
+                            .background(
+                                Circle()
+                                    .fill(
+                                        isAudioHovered
+                                            ? TabBarColors.hoveredTabBackground(for: appearance)
+                                            : .clear
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        withTransaction(Transaction(animation: nil)) {
+                            isAudioHovered = hovering
+                        }
+                    }
+                    .saturation(saturation)
+                    .safeHelp(audioLabel)
+                    .accessibilityLabel(audioLabel)
+                    .tabBarButtonAnimationsDisabled()
                 }
 
                 if showsZoomIndicator {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -134,6 +134,7 @@ public final class BonsplitController {
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
         isAudioMuted: Bool = false,
+        isAudioPlaying: Bool = false,
         isPinned: Bool = false,
         inPane pane: PaneID? = nil
     ) -> TabID? {
@@ -149,6 +150,7 @@ public final class BonsplitController {
             showsNotificationBadge: showsNotificationBadge,
             isLoading: isLoading,
             isAudioMuted: isAudioMuted,
+            isAudioPlaying: isAudioPlaying,
             isPinned: isPinned
         )
         let targetPane = pane ?? focusedPaneId ?? PaneID(id: internalController.rootNode.allPaneIds.first!.id)
@@ -187,6 +189,7 @@ public final class BonsplitController {
             showsNotificationBadge: showsNotificationBadge,
             isLoading: isLoading,
             isAudioMuted: isAudioMuted,
+            isAudioPlaying: isAudioPlaying,
             isPinned: isPinned
         )
         internalController.addTab(tabItem, toPane: PaneID(id: targetPane.id), atIndex: insertIndex)
@@ -232,6 +235,7 @@ public final class BonsplitController {
     ///   - showsNotificationBadge: New badge state (pass nil to keep current)
     ///   - isLoading: New loading/busy state (pass nil to keep current)
     ///   - isAudioMuted: New browser-audio mute state (pass nil to keep current)
+    ///   - isAudioPlaying: New audible-audio state (pass nil to keep current)
     ///   - isPinned: New pinned state (pass nil to keep current)
     public func updateTab(
         _ tabId: TabID,
@@ -244,6 +248,7 @@ public final class BonsplitController {
         showsNotificationBadge: Bool? = nil,
         isLoading: Bool? = nil,
         isAudioMuted: Bool? = nil,
+        isAudioPlaying: Bool? = nil,
         isPinned: Bool? = nil
     ) {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return }
@@ -274,6 +279,9 @@ public final class BonsplitController {
         }
         if let isAudioMuted = isAudioMuted {
             pane.tabs[tabIndex].isAudioMuted = isAudioMuted
+        }
+        if let isAudioPlaying = isAudioPlaying {
+            pane.tabs[tabIndex].isAudioPlaying = isAudioPlaying
         }
         if let isPinned = isPinned {
             pane.tabs[tabIndex].isPinned = isPinned

--- a/Sources/Bonsplit/Public/Types/Tab.swift
+++ b/Sources/Bonsplit/Public/Types/Tab.swift
@@ -17,6 +17,9 @@ public struct Tab: Identifiable, Hashable, Sendable {
     public let isLoading: Bool
     /// Whether the tab should show browser audio as muted.
     public let isAudioMuted: Bool
+    /// Whether the tab is actively producing audible audio (for example, a
+    /// browser page playing sound). Drives a click-to-mute speaker affordance.
+    public let isAudioPlaying: Bool
     /// Whether the tab is pinned in its pane.
     public let isPinned: Bool
 
@@ -31,6 +34,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         showsNotificationBadge: Bool = false,
         isLoading: Bool = false,
         isAudioMuted: Bool = false,
+        isAudioPlaying: Bool = false,
         isPinned: Bool = false
     ) {
         self.id = id
@@ -43,6 +47,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.showsNotificationBadge = showsNotificationBadge
         self.isLoading = isLoading
         self.isAudioMuted = isAudioMuted
+        self.isAudioPlaying = isAudioPlaying
         self.isPinned = isPinned
     }
 
@@ -57,6 +62,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.showsNotificationBadge = tabItem.showsNotificationBadge
         self.isLoading = tabItem.isLoading
         self.isAudioMuted = tabItem.isAudioMuted
+        self.isAudioPlaying = tabItem.isAudioPlaying
         self.isPinned = tabItem.isPinned
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -179,6 +179,24 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabAudioPlayingRoundTrips() {
+        let controller = BonsplitController()
+        let tabId = controller.createTab(title: "Audio", icon: "globe", isAudioPlaying: true)!
+
+        XCTAssertEqual(controller.tab(tabId)?.isAudioPlaying, true)
+
+        // A nil update leaves the flag untouched; an explicit false clears it.
+        controller.updateTab(tabId, title: "Audio 2")
+        XCTAssertEqual(controller.tab(tabId)?.isAudioPlaying, true)
+
+        controller.updateTab(tabId, isAudioPlaying: false)
+        XCTAssertEqual(controller.tab(tabId)?.isAudioPlaying, false)
+
+        controller.updateTab(tabId, isAudioPlaying: true)
+        XCTAssertEqual(controller.tab(tabId)?.isAudioPlaying, true)
+    }
+
+    @MainActor
     func testTabClose() {
         let controller = BonsplitController()
         let tabId = controller.createTab(title: "Test Tab", icon: "doc")!


### PR DESCRIPTION
## What

Adds a Chrome/Safari-style audio affordance to the tab strip:

- New `isAudioPlaying` field on `Tab` / `TabItem` (+ `Codable`, defaulted for back-compat) and on the `createTab` / `updateTab` APIs.
- The tab's audio glyph is now a clickable button:
  - `speaker.wave.2.fill` while the tab is producing audible audio → click to mute
  - `speaker.slash.fill` when muted → click to unmute
  - hidden when the tab is neither playing nor muted
- The button reuses the existing `.toggleAudioMute` context action (host owns the mute route) and the existing localized `tabContext.muteTab` / `tabContext.unmuteTab` strings (en + ja). No new strings.

## Why

Supports the cmux Chrome-style media indicator: manaflow-ai/cmux#6100. The cmux side drives `isAudioPlaying` from WebKit's private `_isPlayingAudio` KVO.

## Tests

- `testTabAudioPlayingRoundTrips` covers the field round-tripping through `createTab` / `updateTab` (including the nil-keeps-current / explicit-false-clears contract).
- `swift build` + `swift test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784586643&installation_id=133855650&pr_number=150&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F150&signature=fc1e4f1270e9c59fabea352e46d9ade8c8626f9f0bcfa4ef65a2da43f404e875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-tab audio indicator with click-to-mute/unmute, matching Chrome/Safari behavior. Introduces `isAudioPlaying` to drive the UI and hooks the speaker glyph to the existing mute action.

- **New Features**
  - Added `isAudioPlaying` to `Tab`/`TabItem` (`Codable`, defaults to false for back-compat).
  - `createTab`/`updateTab` now accept `isAudioPlaying` (nil keeps current; false clears).
  - Tab shows a speaker button: `speaker.wave.2.fill` when playing (click to mute), `speaker.slash.fill` when muted (click to unmute), hidden otherwise.
  - Reuses `.toggleAudioMute` and existing `tabContext.muteTab`/`tabContext.unmuteTab` strings (en + ja).
  - Supports the Chrome-style media indicator in `cmux` (manaflow-ai/cmux#6100).

<sup>Written for commit 15c235e7fc6004c606275c1638aba1c799b48afd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio playback state tracking for tabs.
  * Enhanced audio controls UI to display and interact with tabs actively playing audio.
  * Extended controller API to create and update tabs with audio playing state.

* **Tests**
  * Added test coverage for audio playback state round-trip scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->