### PR TITLE
Preserve isAudioPlaying through split-pane Tab→TabItem conversion

### DIFF
--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -450,6 +450,7 @@ public final class BonsplitController {
                 showsNotificationBadge: tab.showsNotificationBadge,
                 isLoading: tab.isLoading,
                 isAudioMuted: tab.isAudioMuted,
+                isAudioPlaying: tab.isAudioPlaying,
                 isPinned: tab.isPinned
             )
         } else {
@@ -515,6 +516,7 @@ public final class BonsplitController {
             showsNotificationBadge: tab.showsNotificationBadge,
             isLoading: tab.isLoading,
             isAudioMuted: tab.isAudioMuted,
+            isAudioPlaying: tab.isAudioPlaying,
             isPinned: tab.isPinned
         )
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -197,6 +197,20 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testSplitPaneWithTabPreservesAudioPlaying() {
+        let controller = BonsplitController()
+        _ = controller.createTab(title: "Base", icon: "doc")
+        let playing = Bonsplit.Tab(title: "Playing", isAudioPlaying: true)
+
+        let newPane = controller.splitPane(orientation: .horizontal, withTab: playing)
+
+        XCTAssertNotNil(newPane)
+        // The supplied tab's audio-playing state must survive the public
+        // Tab -> internal TabItem conversion in the split path.
+        XCTAssertEqual(controller.tab(playing.id)?.isAudioPlaying, true)
+    }
+
+    @MainActor
     func testTabClose() {
         let controller = BonsplitController()
         let tabId = controller.createTab(title: "Test Tab", icon: "doc")!


### PR DESCRIPTION
Follow-up to #150. The split-pane paths (`splitPane(_:orientation:withTab:)` and `splitPaneInserting(...)`) rebuild an internal `TabItem` from the supplied public `Tab` but were not copying the new `isAudioPlaying` flag, so splitting/placing a tab already producing audio dropped the speaker affordance until the next host update. Copy `isAudioPlaying` in both conversions, with a split-path test.

Surfaced by autoreview on manaflow-ai/cmux#6517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784589053&installation_id=133855650&pr_number=151&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F151&signature=e18b86e8cbaec3177476911ce244ce8ab8ba3da93baf50af5633979ed582b8f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the audio-playing state during split-pane operations so tabs already producing audio keep the speaker indicator immediately.

- Bug Fixes
  - Copy `isAudioPlaying` when converting `Tab` → internal `TabItem` in `splitPane(orientation:withTab:)` and `splitPaneInserting(...)`.
  - Added a split-path test to verify `isAudioPlaying` is preserved.

<sup>Written for commit cd3facc0a69f150c90faaf81b92c569531c0c757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

