### PR TITLE
Route split action hits from layout points

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -367,6 +367,23 @@ enum TabBarStyling {
         return SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0, pointSize: 12)
     }
 
+    static func splitActionButtonHitWidth(for icon: BonsplitConfiguration.SplitActionButton.Icon) -> CGFloat {
+        switch icon {
+        case .systemImage(let name):
+            let image = splitActionSystemImage(for: name)
+            let configuration = NSImage.SymbolConfiguration(pointSize: image.pointSize, weight: .regular)
+            if let symbol = NSImage(systemSymbolName: image.name, accessibilityDescription: nil)?
+                .withSymbolConfiguration(configuration) {
+                return max(18, ceil(symbol.size.width))
+            }
+            return 18
+        case .emoji(_, let scale):
+            return max(18, ceil(13 * CGFloat(scale)))
+        case .imageData:
+            return 18
+        }
+    }
+
     static func splitButtonBackdropSolidSurfaceWidth(
         effectSolidWidth: CGFloat,
         visibleLaneWidth: CGFloat,

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -206,6 +206,37 @@ public final class BonsplitController {
         delegate?.splitTabBar(self, didRequestNewTab: kind, inPane: pane)
     }
 
+    /// Performs the split action button at a point in the current layout's
+    /// coordinate space.
+    ///
+    /// Hosts that transform the full split tree, such as a magnified outer
+    /// scroll view, can use this as the Bonsplit-owned fallback when SwiftUI's
+    /// internal hit testing cannot deliver a physical mouse-down to the button
+    /// overlay. The action still flows through the same controller/delegate path
+    /// as the native tab-bar controls.
+    @discardableResult
+    public func performSplitActionButton(atLayoutPoint point: CGPoint) -> Bool {
+        guard isInteractive,
+              let hit = splitActionButtonHit(atLayoutPoint: point) else {
+            return false
+        }
+
+        focusPane(hit.paneId)
+        switch hit.button.action {
+        case .newTerminal:
+            requestNewTab(kind: "terminal", inPane: hit.paneId)
+        case .newBrowser:
+            requestNewTab(kind: "browser", inPane: hit.paneId)
+        case .splitRight:
+            _ = splitPane(hit.paneId, orientation: .horizontal)
+        case .splitDown:
+            _ = splitPane(hit.paneId, orientation: .vertical)
+        case .custom(let identifier):
+            requestCustomAction(identifier, inPane: hit.paneId)
+        }
+        return true
+    }
+
     /// Request the delegate to handle a host-defined tab bar action.
     public func requestCustomAction(_ identifier: String, inPane pane: PaneID) {
         delegate?.splitTabBar(self, didRequestCustomAction: identifier, inPane: pane)
@@ -885,6 +916,63 @@ public final class BonsplitController {
     }
 
     // MARK: - Private Helpers
+
+    private struct SplitActionButtonHit {
+        let paneId: PaneID
+        let button: BonsplitConfiguration.SplitActionButton
+    }
+
+    private func splitActionButtonHit(atLayoutPoint point: CGPoint) -> SplitActionButtonHit? {
+        let buttons = configuration.appearance.splitButtons
+        guard !buttons.isEmpty else { return nil }
+
+        let snapshot = layoutSnapshot()
+        let tabBarHeight = configuration.appearance.tabBarHeight
+        let laneWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: buttons.count)
+        guard laneWidth > 0 else { return nil }
+
+        for pane in snapshot.panes.reversed() {
+            guard let paneUUID = UUID(uuidString: pane.paneId) else { continue }
+            let paneFrame = CGRect(
+                x: pane.frame.x - snapshot.containerFrame.x,
+                y: pane.frame.y - snapshot.containerFrame.y,
+                width: pane.frame.width,
+                height: pane.frame.height
+            )
+            guard paneFrame.contains(point),
+                  point.y <= paneFrame.minY + tabBarHeight else {
+                continue
+            }
+
+            let visibleLaneWidth = min(max(0, paneFrame.width), laneWidth)
+            let laneMinX = paneFrame.maxX - visibleLaneWidth
+            guard point.x >= laneMinX, point.x <= paneFrame.maxX else { return nil }
+
+            let visualWidths = buttons.map { TabBarStyling.splitActionButtonHitWidth(for: $0.icon) }
+            let buttonsWidth = visualWidths.reduce(0, +)
+                + (CGFloat(max(0, buttons.count - 1)) * TabBarStyling.splitButtonsSpacing)
+            let rowWidth = TabBarStyling.splitButtonsLeadingPadding
+                + buttonsWidth
+                + TabBarStyling.splitButtonsTrailingPadding
+            let rowMinX = laneMinX + max(0, visibleLaneWidth - rowWidth)
+            let localPoint = CGPoint(x: point.x - rowMinX, y: point.y - paneFrame.minY)
+            var buttonX = TabBarStyling.splitButtonsLeadingPadding
+            for (button, buttonWidth) in zip(buttons, visualWidths) {
+                let buttonRect = CGRect(
+                    x: buttonX,
+                    y: 0,
+                    width: buttonWidth,
+                    height: tabBarHeight
+                )
+                if buttonRect.contains(localPoint) {
+                    return SplitActionButtonHit(paneId: PaneID(id: paneUUID), button: button)
+                }
+                buttonX += buttonWidth + TabBarStyling.splitButtonsSpacing
+            }
+            return nil
+        }
+        return nil
+    }
 
     private func findTabInternal(_ tabId: TabID) -> (PaneState, Int)? {
         for pane in internalController.rootNode.allPanes {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -144,6 +144,22 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    private final class SplitActionButtonDelegateSpy: BonsplitDelegate {
+        var requestedKind: String?
+        var requestedPaneId: PaneID?
+        var customIdentifier: String?
+
+        func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID) {
+            requestedKind = kind
+            requestedPaneId = pane
+        }
+
+        func splitTabBar(_ controller: BonsplitController, didRequestCustomAction identifier: String, inPane pane: PaneID) {
+            customIdentifier = identifier
+            requestedPaneId = pane
+        }
+    }
+
     @MainActor
     func testControllerCreation() {
         let controller = BonsplitController()
@@ -289,6 +305,52 @@ final class BonsplitTests: XCTestCase {
             BonsplitConfiguration.SplitActionButton.defaults,
             [.newTerminal, .newBrowser, .splitRight, .splitDown]
         )
+    }
+
+    @MainActor
+    func testPerformSplitActionButtonAtLayoutPointRequestsMatchingBuiltInTabKind() {
+        let controller = BonsplitController()
+        _ = controller.createTab(title: "Base")
+        controller.setContainerFrame(CGRect(x: 0, y: 0, width: 800, height: 600))
+        let delegate = SplitActionButtonDelegateSpy()
+        controller.delegate = delegate
+        let pane = controller.focusedPaneId
+        let paneFrame = try! XCTUnwrap(controller.layoutSnapshot().panes.first?.frame)
+        let buttons = BonsplitConfiguration.SplitActionButton.defaults
+        let visualWidths = buttons.map { TabBarStyling.splitActionButtonHitWidth(for: $0.icon) }
+        let laneWidth = TabBarStyling.splitButtonsBackdropWidth(buttonCount: buttons.count)
+        let rowWidth = TabBarStyling.splitButtonsLeadingPadding
+            + visualWidths.reduce(0, +)
+            + (CGFloat(buttons.count - 1) * TabBarStyling.splitButtonsSpacing)
+            + TabBarStyling.splitButtonsTrailingPadding
+        let rowMinX = paneFrame.x + paneFrame.width - Double(rowWidth)
+        let firstButtonX = rowMinX + Double(TabBarStyling.splitButtonsLeadingPadding + visualWidths[0] / 2)
+        let secondButtonX = firstButtonX + Double((visualWidths[0] + visualWidths[1]) / 2 + TabBarStyling.splitButtonsSpacing)
+        let buttonY = paneFrame.y + 15
+
+        XCTAssertLessThan(rowWidth, laneWidth)
+        XCTAssertTrue(controller.performSplitActionButton(atLayoutPoint: CGPoint(x: firstButtonX, y: buttonY)))
+        XCTAssertEqual(delegate.requestedKind, "terminal")
+        XCTAssertEqual(delegate.requestedPaneId, pane)
+
+        delegate.requestedKind = nil
+        XCTAssertTrue(controller.performSplitActionButton(atLayoutPoint: CGPoint(x: secondButtonX, y: buttonY)))
+        XCTAssertEqual(delegate.requestedKind, "browser")
+        XCTAssertEqual(delegate.requestedPaneId, pane)
+    }
+
+    @MainActor
+    func testPerformSplitActionButtonAtLayoutPointIgnoresNonButtonChrome() {
+        let controller = BonsplitController()
+        _ = controller.createTab(title: "Base")
+        controller.setContainerFrame(CGRect(x: 0, y: 0, width: 800, height: 600))
+        let delegate = SplitActionButtonDelegateSpy()
+        controller.delegate = delegate
+        let paneFrame = try! XCTUnwrap(controller.layoutSnapshot().panes.first?.frame)
+
+        XCTAssertFalse(controller.performSplitActionButton(atLayoutPoint: CGPoint(x: paneFrame.x + 100, y: paneFrame.y + 15)))
+        XCTAssertNil(delegate.requestedKind)
+        XCTAssertNil(delegate.customIdentifier)
     }
 
     func testCustomSplitActionButtonRoundTrips() throws {


### PR DESCRIPTION
Adds a Bonsplit-owned controller API for performing split action buttons from layout-space points. This lets transformed hosts route physical pointer hits through Bonsplit's own button geometry and delegate actions instead of duplicating action mapping in the host.\n\nTests cover terminal/browser hit selection and non-button chrome misses.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784779607&installation_id=133855650&pr_number=152&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F152&signature=abb6e6f5f41f0d261f347335af1785ee8087c05d5bb4d7f9f0a346f085477ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add performSplitActionButton(atLayoutPoint:) to BonsplitController to route split action clicks from layout-space points. Hosts that transform the split tree can now forward pointer hits to Bonsplit’s button geometry instead of re-implementing action mapping.

- **New Features**
  - Hit-tests the split button lane using per-icon widths, finds the pane, focuses it, and returns a Bool on hit/miss.
  - Dispatches built-in actions (newTerminal, newBrowser, splitRight, splitDown) and custom actions via the delegate; tests cover terminal/browser hits and ignore non-button chrome.

<sup>Written for commit 105d069c05a1bc17530e64255a6357d62c67b2ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive split action buttons have been added, enabling users to easily create new terminal tabs, new browser tabs, and trigger custom actions directly from dedicated controls positioned in the tab bar interface.

* **Tests**
  * Added comprehensive test coverage for split action button interactions, including verification of built-in actions and proper handling of clicks in non-button areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->