### PR TITLE
Hug tab content in fixed-width mode; tighten close slot

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -258,7 +258,18 @@ struct TabItemView: View {
                 }
             }
 
-            Spacer(minLength: 0)
+            if fillsWidth {
+                // Fill mode stretches each tab to share the strip width, so a
+                // flexible spacer pushes the close button to the trailing edge.
+                Spacer(minLength: 0)
+            } else {
+                // Fixed mode hugs each tab to its content. A greedy spacer here
+                // would inflate the tab's ideal width so the `maxWidth` clamp
+                // resolves to the maximum, leaving a large empty gap on short
+                // titles (e.g. "~"). A fixed gap keeps the close button off the
+                // title while letting the tab size to its content.
+                Color.clear.frame(width: scaledContentSpacing)
+            }
 
             // Close button / dirty indicator / shortcut hint share the same trailing slot.
             trailingAccessory
@@ -272,6 +283,12 @@ struct TabItemView: View {
             minHeight: tabHeight,
             maxHeight: tabHeight
         )
+        // Fixed mode: size each tab to its own content and ignore the width the
+        // tab strip would otherwise propose. Without this the flexible `maxWidth`
+        // frame lets SwiftUI distribute slack equally across tabs, so a single
+        // long-titled tab drags every other tab wider (and over-truncates short
+        // titles). Fill mode keeps the flexible behavior so tabs share the strip.
+        .fixedSize(horizontal: !fillsWidth, vertical: false)
         .background(tabBackground.saturation(saturation))
         .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
         .contentShape(Rectangle().inset(by: -BonsplitTabItemHitTesting.horizontalSlop))
@@ -357,7 +374,10 @@ struct TabItemView: View {
     }
 
     private var shortcutHintSlotWidth: CGFloat {
-        guard let label = shortcutHintLabel else {
+        // Only reserve the wider shortcut-hint width while the hint is actually
+        // visible. Otherwise size the trailing slot to the close button so a tab
+        // hugs its content instead of leaving a gap before the close affordance.
+        guard showsShortcutHint, let label = shortcutHintLabel else {
             return accessorySlotSize
         }
         let positiveDebugInset = max(0, CGFloat(TabControlShortcutHintDebugSettings.clamped(controlShortcutHintXOffset))) + 2


### PR DESCRIPTION
In the default fixed tab-width mode, size each surface tab to its own content instead of stretching it to match the strip or other tabs:

- Drop the greedy trailing `Spacer` (it pushed the close button to the far edge and left short titles like `~` with a large empty gap); use a small fixed gap before the close affordance.
- Add `.fixedSize(horizontal:)` so each tab uses its own content width and is not stretched/equalized by the strip's width distribution when a longer-titled tab is present.
- Only reserve the wider shortcut-hint slot while the hint is actually visible.

Fill-mode behavior is unchanged.

Consumed by cmux PR manaflow-ai/cmux#6653 (fixes manaflow-ai/cmux#6652). Verified in a cmux dev build: short `~` tabs are tight, browser tabs hug their full title, adding a longer-titled tab doesn't widen the others, and the strip is stable (no jitter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784788525&installation_id=133855650&pr_number=153&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F153&signature=28b409cb1d794322e49e495b5a11fbbcf8b26bc1ee6eefede081ff763dacf641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make fixed-width tabs hug their content so each tab sizes to its own title and the close area stays tight. Stops short titles like "~" from showing big gaps and prevents other tabs from widening when a long tab is present; fill mode is unchanged.

- **Bug Fixes**
  - In fixed mode, replace the trailing flexible spacer with a small fixed gap before the close button.
  - Use `.fixedSize(horizontal: true)` in fixed mode so tabs size to their content instead of shared strip width.
  - Only reserve the wider shortcut-hint slot while the hint is visible; otherwise size the trailing slot to the close button.

<sup>Written for commit f4676e6274c9120ace8af87c39e0f8b6c37c4c2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized tab item layout behavior for improved spacing and alignment of close affordances across different sizing modes.
  * Fixed shortcut hint display to only reserve space when visible, eliminating unnecessary gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->