### PR TITLE
Stabilize tab shortcut hint width

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3193,6 +3193,10 @@ enum TabControlShortcutHintPolicy {
         return defaults.bool(forKey: showHintsOnControlHoldKey)
     }
 
+    static func configuredShortcutModifierSymbol(defaults: UserDefaults = .standard) -> String {
+        TabControlShortcutSettings.surfaceByNumberShortcut(defaults: defaults).modifierSymbol
+    }
+
     private static func triggerAllowsHintReveal(
         for modifierFlags: NSEvent.ModifierFlags,
         defaults: UserDefaults = .standard
@@ -3273,7 +3277,7 @@ private struct TabBarHostWindowReader: NSViewRepresentable {
 @MainActor
 private final class TabControlShortcutKeyMonitor: ObservableObject {
     @Published private(set) var isShortcutHintVisible = false
-    @Published private(set) var shortcutModifierSymbol = "⌃"
+    @Published private(set) var shortcutModifierSymbol = TabControlShortcutHintPolicy.configuredShortcutModifierSymbol()
 
     private weak var hostWindow: NSWindow?
     private var hostWindowDidBecomeKeyObserver: NSObjectProtocol?
@@ -3432,6 +3436,7 @@ private final class TabControlShortcutKeyMonitor: ObservableObject {
         pendingShowWorkItem = nil
         pendingModifier = nil
         if resetVisible {
+            shortcutModifierSymbol = TabControlShortcutHintPolicy.configuredShortcutModifierSymbol()
             withAnimation(TabControlShortcutHintAnimation.visibility) {
                 isShortcutHintVisible = false
             }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -118,6 +118,10 @@ enum TabItemStyling {
         isHovered && !isSelected
     }
 
+    static func shortcutHintSlotLabel(label: String?, allowsShortcutHints: Bool) -> String? {
+        allowsShortcutHints ? label : nil
+    }
+
     static func tabWidthRange(for appearance: BonsplitConfiguration.Appearance) -> ClosedRange<CGFloat> {
         let minimum = max(1, TabBarMetrics.tabMinWidth)
         let maximum = max(minimum, appearance.tabMaxWidth)
@@ -460,7 +464,10 @@ struct TabItemView: View {
         // not only while the modifier is held. Modifier-hold should change
         // opacity, not the tab strip's measured width.
         TabItemStyling.shortcutHintSlotWidth(
-            label: shortcutHintLabel,
+            label: TabItemStyling.shortcutHintSlotLabel(
+                label: shortcutHintLabel,
+                allowsShortcutHints: allowsShortcutHints
+            ),
             showsShortcutHint: showsShortcutHint,
             accessorySlotSize: accessorySlotSize,
             xOffset: controlShortcutHintXOffset

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -62,15 +62,15 @@ enum TabControlShortcutHintStyle {
     static let shadowX: CGFloat = 0
     static let shadowY: CGFloat = 1
 
-    static var font: Font {
-        .system(size: fontSize, weight: fontWeight, design: fontDesign)
-    }
-
-    static var measurementFont: NSFont {
+    static let font: Font = .system(size: fontSize, weight: fontWeight, design: fontDesign)
+    static let measurementFont: NSFont = {
         let baseFont = NSFont.systemFont(ofSize: fontSize, weight: nsFontWeight)
         return baseFont.fontDescriptor.withDesign(.rounded)
             .flatMap { NSFont(descriptor: $0, size: fontSize) } ?? baseFont
-    }
+    }()
+    static let measurementAttributes: [NSAttributedString.Key: Any] = [
+        .font: measurementFont
+    ]
 }
 
 struct TabControlShortcutHintPillBackground: View {
@@ -129,9 +129,7 @@ enum TabItemStyling {
     }
 
     static func shortcutHintWidth(for label: String) -> CGFloat {
-        let textWidth = (label as NSString).size(withAttributes: [
-            .font: TabControlShortcutHintStyle.measurementFont
-        ]).width
+        let textWidth = (label as NSString).size(withAttributes: TabControlShortcutHintStyle.measurementAttributes).width
         return ceil(textWidth) + (TabControlShortcutHintStyle.horizontalPadding * 2)
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -47,6 +47,55 @@ private enum TabControlShortcutHintDebugSettings {
     }
 }
 
+enum TabControlShortcutHintStyle {
+    static let foregroundColor = Color.primary
+    static let horizontalPadding: CGFloat = 6
+    static let verticalPadding: CGFloat = 2
+    static let strokeOpacity = 0.30
+    static let strokeWidth: CGFloat = 0.8
+    static let shadowOpacity = 0.22
+    static let shadowRadius: CGFloat = 2
+    static let shadowX: CGFloat = 0
+    static let shadowY: CGFloat = 1
+}
+
+struct TabControlShortcutHintPillBackground: View {
+    var body: some View {
+        Capsule(style: .continuous)
+            .fill(.regularMaterial)
+            .overlay(
+                Capsule(style: .continuous)
+                    .stroke(
+                        Color.white.opacity(TabControlShortcutHintStyle.strokeOpacity),
+                        lineWidth: TabControlShortcutHintStyle.strokeWidth
+                    )
+            )
+            .shadow(
+                color: Color.black.opacity(TabControlShortcutHintStyle.shadowOpacity),
+                radius: TabControlShortcutHintStyle.shadowRadius,
+                x: TabControlShortcutHintStyle.shadowX,
+                y: TabControlShortcutHintStyle.shadowY
+            )
+    }
+}
+
+struct TabControlShortcutHintPill: View {
+    let text: String
+    let fontSize: CGFloat
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: fontSize, weight: .semibold, design: .rounded))
+            .monospacedDigit()
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            .foregroundColor(TabControlShortcutHintStyle.foregroundColor)
+            .padding(.horizontal, TabControlShortcutHintStyle.horizontalPadding)
+            .padding(.vertical, TabControlShortcutHintStyle.verticalPadding)
+            .background(TabControlShortcutHintPillBackground())
+    }
+}
+
 enum TabItemStyling {
     static func iconSaturation(hasRasterIcon: Bool, tabSaturation: Double) -> Double {
         hasRasterIcon ? 1.0 : tabSaturation
@@ -65,7 +114,7 @@ enum TabItemStyling {
     static func shortcutHintWidth(for label: String, fontSize: CGFloat) -> CGFloat {
         let font = NSFont.systemFont(ofSize: fontSize, weight: .semibold)
         let textWidth = (label as NSString).size(withAttributes: [.font: font]).width
-        return ceil(textWidth) + 8
+        return ceil(textWidth) + (TabControlShortcutHintStyle.horizontalPadding * 2)
     }
 
     static func shortcutHintSlotWidth(
@@ -423,27 +472,7 @@ struct TabItemView: View {
     private var trailingAccessory: some View {
         ZStack(alignment: .center) {
             if let shortcutHintLabel {
-                Text(shortcutHintLabel)
-                    .font(.system(size: accessoryFontSize, weight: .semibold, design: .rounded))
-                    .monospacedDigit()
-                    .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
-                    .foregroundStyle(
-                        isSelected
-                            ? TabBarColors.activeText(for: appearance)
-                            : TabBarColors.inactiveText(for: appearance)
-                    )
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 1)
-                    .background(
-                        Capsule(style: .continuous)
-                            .fill(.regularMaterial)
-                            .overlay(
-                                Capsule(style: .continuous)
-                                    .stroke(Color.white.opacity(0.30), lineWidth: 0.8)
-                            )
-                            .shadow(color: Color.black.opacity(0.22), radius: 2, x: 0, y: 1)
-                    )
+                TabControlShortcutHintPill(text: shortcutHintLabel, fontSize: accessoryFontSize)
                     .offset(
                         x: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintXOffset),
                         y: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintYOffset)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -62,6 +62,26 @@ enum TabItemStyling {
         return minimum...maximum
     }
 
+    static func shortcutHintWidth(for label: String, fontSize: CGFloat) -> CGFloat {
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .semibold)
+        let textWidth = (label as NSString).size(withAttributes: [.font: font]).width
+        return ceil(textWidth) + 8
+    }
+
+    static func shortcutHintSlotWidth(
+        label: String?,
+        showsShortcutHint: Bool,
+        accessorySlotSize: CGFloat,
+        fontSize: CGFloat,
+        xOffset: Double
+    ) -> CGFloat {
+        guard showsShortcutHint, let label else {
+            return accessorySlotSize
+        }
+        let positiveDebugInset = max(0, CGFloat(TabControlShortcutHintDebugSettings.clamped(xOffset))) + 2
+        return max(accessorySlotSize, shortcutHintWidth(for: label, fontSize: fontSize) + positiveDebugInset)
+    }
+
     static func resolvedFaviconImage(existing: NSImage?, incomingData: Data?) -> NSImage? {
         guard let incomingData else { return nil }
         if let decoded = NSImage(data: incomingData) {
@@ -377,11 +397,13 @@ struct TabItemView: View {
         // Only reserve the wider shortcut-hint width while the hint is actually
         // visible. Otherwise size the trailing slot to the close button so a tab
         // hugs its content instead of leaving a gap before the close affordance.
-        guard showsShortcutHint, let label = shortcutHintLabel else {
-            return accessorySlotSize
-        }
-        let positiveDebugInset = max(0, CGFloat(TabControlShortcutHintDebugSettings.clamped(controlShortcutHintXOffset))) + 2
-        return max(accessorySlotSize, shortcutHintWidth(for: label) + positiveDebugInset)
+        TabItemStyling.shortcutHintSlotWidth(
+            label: shortcutHintLabel,
+            showsShortcutHint: showsShortcutHint,
+            accessorySlotSize: accessorySlotSize,
+            fontSize: accessoryFontSize,
+            xOffset: controlShortcutHintXOffset
+        )
     }
 
     private var accessoryFontSize: CGFloat {
@@ -395,12 +417,6 @@ struct TabItemView: View {
 
     private var tabHeight: CGFloat {
         max(1, appearance.tabBarHeight)
-    }
-
-    private func shortcutHintWidth(for label: String) -> CGFloat {
-        let font = NSFont.systemFont(ofSize: accessoryFontSize, weight: .semibold)
-        let textWidth = (label as NSString).size(withAttributes: [.font: font]).width
-        return ceil(textWidth) + 8
     }
 
     @ViewBuilder

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -70,12 +70,12 @@ enum TabItemStyling {
 
     static func shortcutHintSlotWidth(
         label: String?,
-        showsShortcutHint: Bool,
+        showsShortcutHint _: Bool,
         accessorySlotSize: CGFloat,
         fontSize: CGFloat,
         xOffset: Double
     ) -> CGFloat {
-        guard showsShortcutHint, let label else {
+        guard let label else {
             return accessorySlotSize
         }
         let positiveDebugInset = max(0, CGFloat(TabControlShortcutHintDebugSettings.clamped(xOffset))) + 2
@@ -394,9 +394,9 @@ struct TabItemView: View {
     }
 
     private var shortcutHintSlotWidth: CGFloat {
-        // Only reserve the wider shortcut-hint width while the hint is actually
-        // visible. Otherwise size the trailing slot to the close button so a tab
-        // hugs its content instead of leaving a gap before the close affordance.
+        // Reserve the wider shortcut-hint width whenever this tab has a hint,
+        // not only while the modifier is held. Modifier-hold should change
+        // opacity, not the tab strip's measured width.
         TabItemStyling.shortcutHintSlotWidth(
             label: shortcutHintLabel,
             showsShortcutHint: showsShortcutHint,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -48,6 +48,10 @@ private enum TabControlShortcutHintDebugSettings {
 }
 
 enum TabControlShortcutHintStyle {
+    static let fontSize: CGFloat = 9
+    static let fontWeight: Font.Weight = .semibold
+    static let nsFontWeight: NSFont.Weight = .semibold
+    static let fontDesign: Font.Design = .rounded
     static let foregroundColor = Color.primary
     static let horizontalPadding: CGFloat = 6
     static let verticalPadding: CGFloat = 2
@@ -57,6 +61,16 @@ enum TabControlShortcutHintStyle {
     static let shadowRadius: CGFloat = 2
     static let shadowX: CGFloat = 0
     static let shadowY: CGFloat = 1
+
+    static var font: Font {
+        .system(size: fontSize, weight: fontWeight, design: fontDesign)
+    }
+
+    static var measurementFont: NSFont {
+        let baseFont = NSFont.systemFont(ofSize: fontSize, weight: nsFontWeight)
+        return baseFont.fontDescriptor.withDesign(.rounded)
+            .flatMap { NSFont(descriptor: $0, size: fontSize) } ?? baseFont
+    }
 }
 
 struct TabControlShortcutHintPillBackground: View {
@@ -81,11 +95,10 @@ struct TabControlShortcutHintPillBackground: View {
 
 struct TabControlShortcutHintPill: View {
     let text: String
-    let fontSize: CGFloat
 
     var body: some View {
         Text(text)
-            .font(.system(size: fontSize, weight: .semibold, design: .rounded))
+            .font(TabControlShortcutHintStyle.font)
             .monospacedDigit()
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
@@ -111,9 +124,10 @@ enum TabItemStyling {
         return minimum...maximum
     }
 
-    static func shortcutHintWidth(for label: String, fontSize: CGFloat) -> CGFloat {
-        let font = NSFont.systemFont(ofSize: fontSize, weight: .semibold)
-        let textWidth = (label as NSString).size(withAttributes: [.font: font]).width
+    static func shortcutHintWidth(for label: String) -> CGFloat {
+        let textWidth = (label as NSString).size(withAttributes: [
+            .font: TabControlShortcutHintStyle.measurementFont
+        ]).width
         return ceil(textWidth) + (TabControlShortcutHintStyle.horizontalPadding * 2)
     }
 
@@ -121,14 +135,13 @@ enum TabItemStyling {
         label: String?,
         showsShortcutHint _: Bool,
         accessorySlotSize: CGFloat,
-        fontSize: CGFloat,
         xOffset: Double
     ) -> CGFloat {
         guard let label else {
             return accessorySlotSize
         }
         let positiveDebugInset = max(0, CGFloat(TabControlShortcutHintDebugSettings.clamped(xOffset))) + 2
-        return max(accessorySlotSize, shortcutHintWidth(for: label, fontSize: fontSize) + positiveDebugInset)
+        return max(accessorySlotSize, shortcutHintWidth(for: label) + positiveDebugInset)
     }
 
     static func resolvedFaviconImage(existing: NSImage?, incomingData: Data?) -> NSImage? {
@@ -450,7 +463,6 @@ struct TabItemView: View {
             label: shortcutHintLabel,
             showsShortcutHint: showsShortcutHint,
             accessorySlotSize: accessorySlotSize,
-            fontSize: accessoryFontSize,
             xOffset: controlShortcutHintXOffset
         )
     }
@@ -472,7 +484,7 @@ struct TabItemView: View {
     private var trailingAccessory: some View {
         ZStack(alignment: .center) {
             if let shortcutHintLabel {
-                TabControlShortcutHintPill(text: shortcutHintLabel, fontSize: accessoryFontSize)
+                TabControlShortcutHintPill(text: shortcutHintLabel)
                     .offset(
                         x: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintXOffset),
                         y: TabControlShortcutHintDebugSettings.clamped(controlShortcutHintYOffset)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2472,9 +2472,9 @@ final class BonsplitTests: XCTestCase {
 
     func testTabShortcutHintWidthUsesSharedPillPadding() {
         let label = "⌘9"
-        let textWidth = (label as NSString).size(withAttributes: [
-            .font: TabControlShortcutHintStyle.measurementFont
-        ]).width
+        let textWidth = (label as NSString).size(
+            withAttributes: TabControlShortcutHintStyle.measurementAttributes
+        ).width
 
         XCTAssertEqual(
             TabItemStyling.shortcutHintWidth(for: label),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1923,6 +1923,7 @@ final class BonsplitTests: XCTestCase {
             splitButtons: []
         )
         let controller = BonsplitController(configuration: BonsplitConfiguration(appearance: appearance))
+        controller.tabShortcutHintsEnabled = false
         let pane = controller.internalController.rootNode.allPanes.first!
         let tab = TabItem(title: "~", icon: "terminal.fill")
         pane.tabs = [tab]
@@ -4160,6 +4161,7 @@ final class BonsplitTests: XCTestCase {
         extract: (NSView) -> T?
     ) -> T? {
         let controller = BonsplitController(configuration: BonsplitConfiguration(appearance: appearance))
+        controller.tabShortcutHintsEnabled = false
         guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
         if let configurePane {
             configurePane(pane)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2458,6 +2458,18 @@ final class BonsplitTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(hiddenWidth, accessorySlotSize)
     }
 
+    func testTabShortcutHintSlotLabelRequiresHintEligibility() {
+        let label = "⌃9"
+
+        XCTAssertEqual(
+            TabItemStyling.shortcutHintSlotLabel(label: label, allowsShortcutHints: true),
+            label
+        )
+        XCTAssertNil(
+            TabItemStyling.shortcutHintSlotLabel(label: label, allowsShortcutHints: false)
+        )
+    }
+
     func testTabShortcutHintWidthUsesSharedPillPadding() {
         let label = "⌘9"
         let textWidth = (label as NSString).size(withAttributes: [

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2440,20 +2440,17 @@ final class BonsplitTests: XCTestCase {
     func testTabShortcutHintSlotWidthDoesNotChangeWithVisibility() {
         let label = "⌃9"
         let accessorySlotSize: CGFloat = 18
-        let fontSize: CGFloat = 10
 
         let hiddenWidth = TabItemStyling.shortcutHintSlotWidth(
             label: label,
             showsShortcutHint: false,
             accessorySlotSize: accessorySlotSize,
-            fontSize: fontSize,
             xOffset: 0
         )
         let visibleWidth = TabItemStyling.shortcutHintSlotWidth(
             label: label,
             showsShortcutHint: true,
             accessorySlotSize: accessorySlotSize,
-            fontSize: fontSize,
             xOffset: 0
         )
 
@@ -2463,14 +2460,20 @@ final class BonsplitTests: XCTestCase {
 
     func testTabShortcutHintWidthUsesSharedPillPadding() {
         let label = "⌘9"
-        let fontSize: CGFloat = 10
-        let font = NSFont.systemFont(ofSize: fontSize, weight: .semibold)
-        let textWidth = (label as NSString).size(withAttributes: [.font: font]).width
+        let textWidth = (label as NSString).size(withAttributes: [
+            .font: TabControlShortcutHintStyle.measurementFont
+        ]).width
 
         XCTAssertEqual(
-            TabItemStyling.shortcutHintWidth(for: label, fontSize: fontSize),
+            TabItemStyling.shortcutHintWidth(for: label),
             ceil(textWidth) + (TabControlShortcutHintStyle.horizontalPadding * 2)
         )
+    }
+
+    func testTabShortcutHintStyleMatchesCommandHintPillFont() {
+        XCTAssertEqual(TabControlShortcutHintStyle.fontSize, 9)
+        XCTAssertEqual(TabControlShortcutHintStyle.nsFontWeight, .semibold)
+        XCTAssertEqual(TabControlShortcutHintStyle.measurementFont.fontDescriptor.object(forKey: .face) as? String, "Semibold")
     }
 
     func testActiveTabIndicatorHeightIsOneAndHalfPixels() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2437,6 +2437,30 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(range.upperBound, 220)
     }
 
+    func testTabShortcutHintSlotWidthDoesNotChangeWithVisibility() {
+        let label = "⌃9"
+        let accessorySlotSize: CGFloat = 18
+        let fontSize: CGFloat = 10
+
+        let hiddenWidth = TabItemStyling.shortcutHintSlotWidth(
+            label: label,
+            showsShortcutHint: false,
+            accessorySlotSize: accessorySlotSize,
+            fontSize: fontSize,
+            xOffset: 0
+        )
+        let visibleWidth = TabItemStyling.shortcutHintSlotWidth(
+            label: label,
+            showsShortcutHint: true,
+            accessorySlotSize: accessorySlotSize,
+            fontSize: fontSize,
+            xOffset: 0
+        )
+
+        XCTAssertEqual(hiddenWidth, visibleWidth)
+        XCTAssertGreaterThanOrEqual(hiddenWidth, accessorySlotSize)
+    }
+
     func testActiveTabIndicatorHeightIsOneAndHalfPixels() {
         XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 1.5)
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2147,6 +2147,10 @@ final class BonsplitTests: XCTestCase {
                 TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
                 "⌃"
             )
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.configuredShortcutModifierSymbol(defaults: defaults),
+                "⌃"
+            )
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [], defaults: defaults))
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control, .shift], defaults: defaults))
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command, .option], defaults: defaults))
@@ -2164,6 +2168,10 @@ final class BonsplitTests: XCTestCase {
 
             let custom = TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)
             XCTAssertEqual(custom?.symbol, "⌥⌘")
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.configuredShortcutModifierSymbol(defaults: defaults),
+                "⌥⌘"
+            )
             XCTAssertEqual(
                 TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
                 "⌥⌘"

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2461,6 +2461,18 @@ final class BonsplitTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(hiddenWidth, accessorySlotSize)
     }
 
+    func testTabShortcutHintWidthUsesSharedPillPadding() {
+        let label = "⌘9"
+        let fontSize: CGFloat = 10
+        let font = NSFont.systemFont(ofSize: fontSize, weight: .semibold)
+        let textWidth = (label as NSString).size(withAttributes: [.font: font]).width
+
+        XCTAssertEqual(
+            TabItemStyling.shortcutHintWidth(for: label, fontSize: fontSize),
+            ceil(textWidth) + (TabControlShortcutHintStyle.horizontalPadding * 2)
+        )
+    }
+
     func testActiveTabIndicatorHeightIsOneAndHalfPixels() {
         XCTAssertEqual(TabBarMetrics.activeIndicatorHeight, 1.5)
     }


### PR DESCRIPTION
## Summary
- keep tab shortcut-hint accessory width stable across modifier-hold visibility
- add a regression test for hidden vs visible shortcut-hint slot width

## Testing
- swift test --filter BonsplitTests/testTabShortcutHintSlotWidthDoesNotChangeWithVisibility

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785028283&installation_id=133855650&pr_number=154&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F154&signature=325f8167f0d68e2cf8effbb062a5211efe124f324c7e0ce45a23c3fed25dfefc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes tab shortcut-hint width to prevent tab bar layout shifts, matches pill typography with command hints, and reserves width only when a tab is eligible and based on the configured modifier.

- **Bug Fixes**
  - Reserve shortcut-hint width using the configured modifier symbol and refresh it on visibility reset so measurements stay correct; reserve the slot whenever a hint is eligible, not only when visible.
  - Add `TabControlShortcutHintStyle` and pill views; centralize sizing in `TabItemStyling` (`shortcutHintWidth`, `shortcutHintSlotWidth`, `shortcutHintSlotLabel`), cache the measurement font, add tests for width stability, eligibility gating, shared font/padding, configured-modifier behavior, and disable hints in layout tests to avoid interference.

<sup>Written for commit c0f67172f54bfcfd8f9f8af924442a54a591544f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized tab shortcut-hint pill typography and styling for consistent appearance (typography, material fill, and capsule visuals).
  * Centralized shortcut-hint sizing/layout so the tab always reserves the correct trailing-space whenever a hint label is eligible, avoiding spacing changes when the hint is hidden.
* **Tests**
  * Added unit tests to verify shortcut-hint slot width invariance across visibility states, correct label eligibility behavior, and matching shared pill font/padding configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->