### PR TITLE
Keep tab hint slot width constant across focus

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1340,7 +1340,8 @@ struct TabBarView: View {
                 ? TabBarMetrics.selectedTabLeftSeparatorBottomInset
                 : 0,
             controlShortcutDigit: tabControlShortcutDigit(for: index, tabCount: pane.tabs.count),
-            allowsShortcutHints: isFocused && splitViewController.tabShortcutHintsEnabled,
+            tabShortcutHintsEnabled: splitViewController.tabShortcutHintsEnabled,
+            isFocused: isFocused,
             showsControlShortcutHint: showsControlShortcutHints,
             shortcutModifierSymbol: controlKeyMonitor.shortcutModifierSymbol,
             allowsClose: controller.configuration.allowCloseTabs,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -146,6 +146,33 @@ enum TabItemStyling {
         return max(accessorySlotSize, shortcutHintWidth(for: label) + positiveDebugInset)
     }
 
+    /// Width of a tab's trailing accessory slot, reserving room for the keyboard
+    /// shortcut hint pill.
+    ///
+    /// `isFocused` is accepted but MUST NOT affect the result. The reserved width
+    /// has to stay constant as focus moves between panes; if it shrinks when a
+    /// pane loses focus, every tab carrying a ⌃/⌘ digit visibly resizes and the
+    /// whole tab bar shifts on focus. Hint *visibility* depends on focus and
+    /// modifier-hold and is handled separately via opacity, not width.
+    static func reservedShortcutHintSlotWidth(
+        shortcutHintLabel: String?,
+        tabShortcutHintsEnabled: Bool,
+        isFocused: Bool,
+        accessorySlotSize: CGFloat,
+        xOffset: Double
+    ) -> CGFloat {
+        let reservesHint = tabShortcutHintsEnabled && isFocused
+        return shortcutHintSlotWidth(
+            label: shortcutHintSlotLabel(
+                label: shortcutHintLabel,
+                allowsShortcutHints: reservesHint
+            ),
+            showsShortcutHint: false,
+            accessorySlotSize: accessorySlotSize,
+            xOffset: xOffset
+        )
+    }
+
     static func resolvedFaviconImage(existing: NSImage?, incomingData: Data?) -> NSImage? {
         guard let incomingData else { return nil }
         if let decoded = NSImage(data: incomingData) {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -118,42 +118,26 @@ enum TabItemStyling {
         isHovered && !isSelected
     }
 
-    static func shortcutHintSlotLabel(label: String?, allowsShortcutHints: Bool) -> String? {
-        allowsShortcutHints ? label : nil
-    }
-
     static func tabWidthRange(for appearance: BonsplitConfiguration.Appearance) -> ClosedRange<CGFloat> {
         let minimum = max(1, TabBarMetrics.tabMinWidth)
         let maximum = max(minimum, appearance.tabMaxWidth)
         return minimum...maximum
     }
 
-    static func shortcutHintWidth(for label: String) -> CGFloat {
-        let textWidth = (label as NSString).size(withAttributes: TabControlShortcutHintStyle.measurementAttributes).width
-        return ceil(textWidth) + (TabControlShortcutHintStyle.horizontalPadding * 2)
-    }
-
-    static func shortcutHintSlotWidth(
-        label: String?,
-        showsShortcutHint _: Bool,
-        accessorySlotSize: CGFloat,
-        xOffset: Double
-    ) -> CGFloat {
-        guard let label else {
-            return accessorySlotSize
-        }
-        let positiveDebugInset = max(0, CGFloat(TabControlShortcutHintDebugSettings.clamped(xOffset))) + 2
-        return max(accessorySlotSize, shortcutHintWidth(for: label) + positiveDebugInset)
-    }
-
-    /// Width of a tab's trailing accessory slot, reserving room for the keyboard
-    /// shortcut hint pill.
+    /// Width of a tab's trailing accessory slot.
     ///
-    /// `isFocused` is accepted but MUST NOT affect the result. The reserved width
-    /// has to stay constant as focus moves between panes; if it shrinks when a
-    /// pane loses focus, every tab carrying a ⌃/⌘ digit visibly resizes and the
-    /// whole tab bar shifts on focus. Hint *visibility* depends on focus and
-    /// modifier-hold and is handled separately via opacity, not width.
+    /// The slot reserves only the close-button (`accessorySlotSize`) width and
+    /// never widens for the keyboard-shortcut hint. The ⌃/⌘ digit pill overlays
+    /// this same slot (it is mutually exclusive with the close button and
+    /// non-interactive), rendering at its natural size within the tab's trailing
+    /// padding instead of pushing layout. Two consequences, both intended:
+    ///   1. A tab carrying a ⌃/⌘ digit is exactly as wide as one without, so the
+    ///      hint feature no longer makes tabs wider.
+    ///   2. The reserved width is a constant, independent of `isFocused`,
+    ///      `tabShortcutHintsEnabled`, the label, and the debug `xOffset`, so the
+    ///      tab bar never shifts when a pane gains/loses focus or ⌃/⌘ is held.
+    /// The parameters are accepted so the call site can pass the live state, but
+    /// none of them may affect the result.
     static func reservedShortcutHintSlotWidth(
         shortcutHintLabel: String?,
         tabShortcutHintsEnabled: Bool,
@@ -161,18 +145,11 @@ enum TabItemStyling {
         accessorySlotSize: CGFloat,
         xOffset: Double
     ) -> CGFloat {
-        // Deliberately independent of `isFocused`: see the doc comment above.
-        _ = isFocused
-        let reservesHint = tabShortcutHintsEnabled
-        return shortcutHintSlotWidth(
-            label: shortcutHintSlotLabel(
-                label: shortcutHintLabel,
-                allowsShortcutHints: reservesHint
-            ),
-            showsShortcutHint: false,
-            accessorySlotSize: accessorySlotSize,
-            xOffset: xOffset
-        )
+        // Deliberately ignores every hint/focus input: the pill overlays the
+        // accessory slot, so the reserved layout width is always just the
+        // close-button size. See the doc comment above.
+        _ = (shortcutHintLabel, tabShortcutHintsEnabled, isFocused, xOffset)
+        return accessorySlotSize
     }
 
     static func resolvedFaviconImage(existing: NSImage?, incomingData: Data?) -> NSImage? {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -161,7 +161,9 @@ enum TabItemStyling {
         accessorySlotSize: CGFloat,
         xOffset: Double
     ) -> CGFloat {
-        let reservesHint = tabShortcutHintsEnabled && isFocused
+        // Deliberately independent of `isFocused`: see the doc comment above.
+        _ = isFocused
+        let reservesHint = tabShortcutHintsEnabled
         return shortcutHintSlotWidth(
             label: shortcutHintSlotLabel(
                 label: shortcutHintLabel,
@@ -196,7 +198,11 @@ struct TabItemView: View {
     let saturation: Double
     let trailingSeparatorBottomInset: CGFloat
     let controlShortcutDigit: Int?
-    let allowsShortcutHints: Bool
+    /// Whether tab keyboard-shortcut hints are enabled at all (a global setting,
+    /// independent of which pane is focused). Drives the reserved hint-slot width.
+    let tabShortcutHintsEnabled: Bool
+    /// Whether this tab's pane is focused. Gates hint *visibility*, never width.
+    let isFocused: Bool
     let showsControlShortcutHint: Bool
     let shortcutModifierSymbol: String
     let allowsClose: Bool
@@ -476,6 +482,12 @@ struct TabItemView: View {
         return "\(shortcutModifierSymbol)\(controlShortcutDigit)"
     }
 
+    /// Hints are only ever shown on the focused pane; gating on focus here keeps
+    /// hint visibility scoped to the focused pane while leaving width untouched.
+    private var allowsShortcutHints: Bool {
+        isFocused && tabShortcutHintsEnabled
+    }
+
     private var showsShortcutHint: Bool {
         allowsShortcutHints && (showsControlShortcutHint || alwaysShowShortcutHints) && shortcutHintLabel != nil
     }
@@ -485,15 +497,14 @@ struct TabItemView: View {
     }
 
     private var shortcutHintSlotWidth: CGFloat {
-        // Reserve the wider shortcut-hint width whenever this tab has a hint,
-        // not only while the modifier is held. Modifier-hold should change
-        // opacity, not the tab strip's measured width.
-        TabItemStyling.shortcutHintSlotWidth(
-            label: TabItemStyling.shortcutHintSlotLabel(
-                label: shortcutHintLabel,
-                allowsShortcutHints: allowsShortcutHints
-            ),
-            showsShortcutHint: showsShortcutHint,
+        // Reserve the wider shortcut-hint width whenever hints are enabled and
+        // this tab has a digit, regardless of focus or modifier-hold. Both focus
+        // and modifier-hold change the pill's opacity, not the measured width, so
+        // the tab bar never shifts when a pane is focused or ⌃/⌘ is held.
+        TabItemStyling.reservedShortcutHintSlotWidth(
+            shortcutHintLabel: shortcutHintLabel,
+            tabShortcutHintsEnabled: tabShortcutHintsEnabled,
+            isFocused: isFocused,
             accessorySlotSize: accessorySlotSize,
             xOffset: controlShortcutHintXOffset
         )

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2446,27 +2446,6 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(range.upperBound, 220)
     }
 
-    func testTabShortcutHintSlotWidthDoesNotChangeWithVisibility() {
-        let label = "⌃9"
-        let accessorySlotSize: CGFloat = 18
-
-        let hiddenWidth = TabItemStyling.shortcutHintSlotWidth(
-            label: label,
-            showsShortcutHint: false,
-            accessorySlotSize: accessorySlotSize,
-            xOffset: 0
-        )
-        let visibleWidth = TabItemStyling.shortcutHintSlotWidth(
-            label: label,
-            showsShortcutHint: true,
-            accessorySlotSize: accessorySlotSize,
-            xOffset: 0
-        )
-
-        XCTAssertEqual(hiddenWidth, visibleWidth)
-        XCTAssertGreaterThanOrEqual(hiddenWidth, accessorySlotSize)
-    }
-
     func testTabShortcutHintSlotWidthDoesNotChangeWithFocus() {
         let label = "⌃9"
         let accessorySlotSize: CGFloat = 18
@@ -2486,10 +2465,30 @@ final class BonsplitTests: XCTestCase {
             xOffset: 0
         )
 
-        // Focusing a pane must not resize its tabs: both states reserve the same
-        // (wide) hint slot, so the tab bar never shifts as focus moves.
+        // Focusing a pane must not resize its tabs: the reserved width is
+        // focus-independent, so the tab bar never shifts as focus moves.
         XCTAssertEqual(focusedWidth, unfocusedWidth)
-        XCTAssertGreaterThan(focusedWidth, accessorySlotSize)
+    }
+
+    func testTabShortcutHintSlotReservesOnlyAccessoryWidth() {
+        // The trailing accessory reserves just the close-button width. The
+        // shortcut-hint pill overlays that slot (mutually exclusive with the
+        // close button, non-interactive) instead of widening the tab, so a tab
+        // carrying a ⌃/⌘ digit is no wider than one without. Prevents the
+        // "digit tabs are permanently ~11pt too wide" regression.
+        let label = "⌃9"
+        let accessorySlotSize: CGFloat = 18
+
+        for isFocused in [true, false] {
+            let width = TabItemStyling.reservedShortcutHintSlotWidth(
+                shortcutHintLabel: label,
+                tabShortcutHintsEnabled: true,
+                isFocused: isFocused,
+                accessorySlotSize: accessorySlotSize,
+                xOffset: 0
+            )
+            XCTAssertEqual(width, accessorySlotSize)
+        }
     }
 
     func testTabShortcutHintSlotWidthCollapsesWhenHintsDisabled() {
@@ -2507,30 +2506,6 @@ final class BonsplitTests: XCTestCase {
             // With hints disabled no hint width is reserved, regardless of focus.
             XCTAssertEqual(width, accessorySlotSize)
         }
-    }
-
-    func testTabShortcutHintSlotLabelRequiresHintEligibility() {
-        let label = "⌃9"
-
-        XCTAssertEqual(
-            TabItemStyling.shortcutHintSlotLabel(label: label, allowsShortcutHints: true),
-            label
-        )
-        XCTAssertNil(
-            TabItemStyling.shortcutHintSlotLabel(label: label, allowsShortcutHints: false)
-        )
-    }
-
-    func testTabShortcutHintWidthUsesSharedPillPadding() {
-        let label = "⌘9"
-        let textWidth = (label as NSString).size(
-            withAttributes: TabControlShortcutHintStyle.measurementAttributes
-        ).width
-
-        XCTAssertEqual(
-            TabItemStyling.shortcutHintWidth(for: label),
-            ceil(textWidth) + (TabControlShortcutHintStyle.horizontalPadding * 2)
-        )
     }
 
     func testTabShortcutHintStyleMatchesCommandHintPillFont() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2467,6 +2467,48 @@ final class BonsplitTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(hiddenWidth, accessorySlotSize)
     }
 
+    func testTabShortcutHintSlotWidthDoesNotChangeWithFocus() {
+        let label = "⌃9"
+        let accessorySlotSize: CGFloat = 18
+
+        let focusedWidth = TabItemStyling.reservedShortcutHintSlotWidth(
+            shortcutHintLabel: label,
+            tabShortcutHintsEnabled: true,
+            isFocused: true,
+            accessorySlotSize: accessorySlotSize,
+            xOffset: 0
+        )
+        let unfocusedWidth = TabItemStyling.reservedShortcutHintSlotWidth(
+            shortcutHintLabel: label,
+            tabShortcutHintsEnabled: true,
+            isFocused: false,
+            accessorySlotSize: accessorySlotSize,
+            xOffset: 0
+        )
+
+        // Focusing a pane must not resize its tabs: both states reserve the same
+        // (wide) hint slot, so the tab bar never shifts as focus moves.
+        XCTAssertEqual(focusedWidth, unfocusedWidth)
+        XCTAssertGreaterThan(focusedWidth, accessorySlotSize)
+    }
+
+    func testTabShortcutHintSlotWidthCollapsesWhenHintsDisabled() {
+        let label = "⌃9"
+        let accessorySlotSize: CGFloat = 18
+
+        for isFocused in [true, false] {
+            let width = TabItemStyling.reservedShortcutHintSlotWidth(
+                shortcutHintLabel: label,
+                tabShortcutHintsEnabled: false,
+                isFocused: isFocused,
+                accessorySlotSize: accessorySlotSize,
+                xOffset: 0
+            )
+            // With hints disabled no hint width is reserved, regardless of focus.
+            XCTAssertEqual(width, accessorySlotSize)
+        }
+    }
+
     func testTabShortcutHintSlotLabelRequiresHintEligibility() {
         let label = "⌃9"
 


### PR DESCRIPTION
Focusing a pane/surface visibly shifted the tab bar: every tab carrying a ⌃/⌘ shortcut digit (tabs 1-8 and the last tab) grew ~11pt when its pane gained focus and shrank when it lost focus.

Cause: #154 moved the reserved shortcut-hint slot width from `showsShortcutHint` (modifier-held) to `allowsShortcutHints = isFocused && tabShortcutHintsEnabled`. That fixed the modifier-hold jump but left the reserved width gated on focus, so the slot collapsed from the wide hint pill width back to the bare accessory width whenever the pane was unfocused.

Fix: reserve the hint slot based on `tabShortcutHintsEnabled` alone (focus-independent) via `reservedShortcutHintSlotWidth`, which takes `isFocused` but deliberately ignores it. `TabItemView` now receives `tabShortcutHintsEnabled` + `isFocused` separately: width uses the focus-independent reservation, while hint *visibility* still derives `allowsShortcutHints = isFocused && tabShortcutHintsEnabled`. Neither focus nor modifier-hold changes measured width now; both only change the pill's opacity.

Regression test (red→green commits): `testTabShortcutHintSlotWidthDoesNotChangeWithFocus` asserts the reserved slot is identical focused vs unfocused (was 29 vs 18). `testTabShortcutHintSlotWidthCollapsesWhenHintsDisabled` covers the hints-off case. Full suite: 152 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785051832&installation_id=133855650&pr_number=155&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F155&signature=b623d56075b7bbb12667a9dd515c7079a3829cad32e67f75043ff870ed98be3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the tab bar from shifting on focus and remove extra width on digit tabs by overlaying the shortcut-hint pill instead of reserving its width. Pinned icon-only tabs still reserve the pill’s natural width; hints follow focus with opacity only.

- **Bug Fixes**
  - Reserve only the close-button (`accessorySlotSize`) via `reservedShortcutHintSlotWidth`; ignore focus/label and overlay the hint pill so digit tabs aren’t wider.
  - Pass `tabShortcutHintsEnabled` and `isFocused` separately to `TabItemView`; width uses the former, visibility uses both. Update `TabBarView` to pass new props.
  - Restore `TabItemStyling.shortcutHintWidth` for icon-only pinned tabs that must reserve pill width; keep pinned-tab tests. Remove obsolete `shortcutHintSlotLabel`/`shortcutHintSlotWidth` and their tests. Add regressions for focus-independent width and compact width equal to `accessorySlotSize`.

<sup>Written for commit 21ef9b42daf9218ec5ddb8c29be3d51ca6e2508d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab bar shortcut-hint layout so spacing remains stable as focus moves, reducing unexpected shifting.
  * Refined shortcut-hint behavior so hint visibility depends on focus, while the reserved layout space follows a consistent sizing rule.
* **Tests**
  * Updated and expanded unit tests to verify shortcut-hint slot sizing consistency across focus states and when shortcut hints are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->