### PR TITLE
Pinned browser tabs: keep shortcut hint + click-to-mute in icon-only layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned browser tabs (`kind == "browser"` with `isPinned == true`) now collapse to an
   icon-only chip (favicon only) sized to a compact fixed width, mirroring pinned tabs in
   macOS browsers. The full title stays available via the tab tooltip and accessibility
-  label, and a small corner badge preserves audio / unread / dirty activity signals.
-  Pinned terminal (and other non-browser) tabs keep their titled layout.
+  label. A small corner badge preserves audio / unread / dirty activity signals (the
+  audio badge stays click-to-mute via the existing `.toggleAudioMute` route), and the
+  control-shortcut number hint still appears (crossfading over the favicon on
+  modifier-hold) with its width reserved so the tab never resizes. Pinned terminal (and
+  other non-browser) tabs keep their titled layout.
 
 ## [1.1.1] - 2025-01-29
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -176,6 +176,20 @@ enum TabItemStyling {
         let padding = max(0, horizontalPadding)
         return ceil(icon + padding * 2 + 6)
     }
+
+    /// Icon-only pinned width that also reserves room for the control-shortcut hint
+    /// pill when one can be shown, so holding the modifier never resizes the tab.
+    /// Pass `reservedShortcutHintWidth == nil` when the tab has no hint to reserve.
+    static func pinnedIconOnlyWidth(
+        iconSlotSize: CGFloat,
+        horizontalPadding: CGFloat,
+        reservedShortcutHintWidth: CGFloat?
+    ) -> CGFloat {
+        let base = pinnedIconOnlyWidth(iconSlotSize: iconSlotSize, horizontalPadding: horizontalPadding)
+        guard let reservedShortcutHintWidth else { return base }
+        let reserved = ceil(max(0, reservedShortcutHintWidth) + max(0, horizontalPadding) * 2)
+        return max(base, reserved)
+    }
 }
 
 /// Individual tab view with icon, title, close button, and dirty indicator
@@ -409,15 +423,28 @@ struct TabItemView: View {
 
     /// Compact pinned-browser layout: a centered favicon with a small status badge
     /// overlay for audio/unread/dirty activity. The full title stays reachable via
-    /// the tab tooltip and accessibility label.
+    /// the tab tooltip and accessibility label. When the tab-shortcut modifier is
+    /// held, the favicon crossfades to the modifier+number hint pill so number-based
+    /// selection stays discoverable (mirrors the standard layout's trailing slot).
     @ViewBuilder
     private var iconOnlyContent: some View {
-        leadingIcon
-            .overlay(alignment: .topTrailing) {
-                pinnedActivityBadge
-                    .offset(x: 4, y: -3)
+        ZStack {
+            leadingIcon
+                .overlay(alignment: .topTrailing) {
+                    pinnedActivityBadge
+                        .offset(x: 3, y: -2)
+                }
+                .opacity(showsShortcutHint ? 0 : 1)
+                // Suppress the audio badge's tap target while the hint pill is shown.
+                .allowsHitTesting(!showsShortcutHint)
+
+            if let shortcutHintLabel {
+                TabControlShortcutHintPill(text: shortcutHintLabel)
+                    .opacity(showsShortcutHint ? 1 : 0)
                     .allowsHitTesting(false)
             }
+        }
+        .tabControlShortcutHintVisibilityAnimation(value: showsShortcutHint)
     }
 
     /// Leading favicon / loading spinner / symbol icon. Shared by the standard and
@@ -478,28 +505,51 @@ struct TabItemView: View {
 
     /// Small corner badge for icon-only pinned tabs, preserving the audio/unread/
     /// dirty signals that the collapsed layout otherwise hides. A single slot keeps
-    /// the chip uncluttered: audio takes priority, then unread, then dirty.
+    /// the chip uncluttered: audio takes priority, then unread, then dirty. The audio
+    /// badge stays click-to-mute (same `.toggleAudioMute` route as the standard
+    /// layout); the unread/dirty dots are non-interactive indicators.
     @ViewBuilder
     private var pinnedActivityBadge: some View {
         if !tab.isLoading {
             if tab.isAudioMuted || tab.isAudioPlaying {
-                Image(systemName: tab.isAudioMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
-                    .font(.system(size: max(6, accessoryFontSize - 4), weight: .semibold))
-                    .foregroundStyle(
-                        isSelected
-                            ? TabBarColors.activeText(for: appearance)
-                            : TabBarColors.inactiveText(for: appearance)
-                    )
-                    .saturation(saturation)
+                let isMuted = tab.isAudioMuted
+                let audioLabel = Bundle.module.localizedString(
+                    forKey: isMuted ? "tabContext.unmuteTab" : "tabContext.muteTab",
+                    value: isMuted ? "Unmute Tab" : "Mute Tab",
+                    table: nil
+                )
+                Button {
+                    onContextAction(.toggleAudioMute)
+                } label: {
+                    Image(systemName: isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                        .font(.system(size: max(6, accessoryFontSize - 4), weight: .semibold))
+                        .foregroundStyle(
+                            isSelected
+                                ? TabBarColors.activeText(for: appearance)
+                                : TabBarColors.inactiveText(for: appearance)
+                        )
+                        .padding(2)
+                        .background(
+                            Circle().fill(TabBarColors.activeTabBackground(for: appearance))
+                        )
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .saturation(saturation)
+                .safeHelp(audioLabel)
+                .accessibilityLabel(audioLabel)
+                .tabBarButtonAnimationsDisabled()
             } else if tab.showsNotificationBadge {
                 Circle()
                     .fill(TabBarColors.notificationBadge(for: appearance))
                     .frame(width: TabBarMetrics.notificationBadgeSize, height: TabBarMetrics.notificationBadgeSize)
+                    .allowsHitTesting(false)
             } else if tab.isDirty {
                 Circle()
                     .fill(TabBarColors.dirtyIndicator(for: appearance))
                     .frame(width: TabBarMetrics.dirtyIndicatorSize, height: TabBarMetrics.dirtyIndicatorSize)
                     .saturation(saturation)
+                    .allowsHitTesting(false)
             }
         }
     }
@@ -517,11 +567,19 @@ struct TabItemView: View {
         return fillsWidth ? .infinity : tabWidthRange.upperBound
     }
 
-    /// Fixed compact width used for icon-only pinned browser tabs.
+    /// Fixed compact width used for icon-only pinned browser tabs. When the tab can
+    /// show a control-shortcut hint, the width also reserves room for the hint pill so
+    /// holding the modifier never changes the tab's width (avoids tab-bar layout shift,
+    /// mirroring the standard layout's always-reserved hint slot).
     private var pinnedIconOnlyWidth: CGFloat {
-        TabItemStyling.pinnedIconOnlyWidth(
+        let reservedHint: CGFloat? = {
+            guard allowsShortcutHints, let shortcutHintLabel else { return nil }
+            return TabItemStyling.shortcutHintWidth(for: shortcutHintLabel)
+        }()
+        return TabItemStyling.pinnedIconOnlyWidth(
             iconSlotSize: scaledIconSize,
-            horizontalPadding: TabBarMetrics.tabHorizontalPadding
+            horizontalPadding: TabBarMetrics.tabHorizontalPadding,
+            reservedShortcutHintWidth: reservedHint
         )
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2477,6 +2477,40 @@ final class BonsplitTests: XCTestCase {
         XCTAssertGreaterThan(width, 0)
     }
 
+    func testPinnedIconOnlyWidthKeepsBaseWhenNoShortcutHintReserved() {
+        let base = TabItemStyling.pinnedIconOnlyWidth(iconSlotSize: 14, horizontalPadding: 6)
+        let reserved = TabItemStyling.pinnedIconOnlyWidth(
+            iconSlotSize: 14,
+            horizontalPadding: 6,
+            reservedShortcutHintWidth: nil
+        )
+        XCTAssertEqual(reserved, base)
+    }
+
+    func testPinnedIconOnlyWidthReservesShortcutHintPillToAvoidLayoutShift() {
+        // A wide hint pill expands the chip so the pill (shown only on modifier-hold)
+        // always fits without resizing the tab.
+        let pill: CGFloat = 30
+        let width = TabItemStyling.pinnedIconOnlyWidth(
+            iconSlotSize: 14,
+            horizontalPadding: 6,
+            reservedShortcutHintWidth: pill
+        )
+        XCTAssertEqual(width, ceil(pill + 6 * 2))
+        XCTAssertGreaterThan(width, TabItemStyling.pinnedIconOnlyWidth(iconSlotSize: 14, horizontalPadding: 6))
+    }
+
+    func testPinnedIconOnlyWidthKeepsBaseWhenReservedHintIsNarrow() {
+        // A narrow hint that fits inside the base chip must not shrink the tab.
+        let base = TabItemStyling.pinnedIconOnlyWidth(iconSlotSize: 14, horizontalPadding: 6)
+        let width = TabItemStyling.pinnedIconOnlyWidth(
+            iconSlotSize: 14,
+            horizontalPadding: 6,
+            reservedShortcutHintWidth: 1
+        )
+        XCTAssertEqual(width, base)
+    }
+
     func testTabShortcutHintSlotWidthDoesNotChangeWithVisibility() {
         let label = "⌃9"
         let accessorySlotSize: CGFloat = 18


### PR DESCRIPTION
Review follow-up to #156 (icon-only pinned browser tabs). Restores two affordances the compact layout dropped:

- **Control-shortcut number hint** — the icon-only layout now crossfades the favicon to the modifier+number hint pill while the tab-shortcut modifier is held, so number-based tab selection stays discoverable. The pill width is reserved up front so holding the modifier never resizes the tab (no tab-bar layout shift).
- **Audio mute** — the corner audio badge is again a button on the existing `.toggleAudioMute` route, so a pinned browser tab playing/muted audio can be toggled directly. Unread/dirty stay non-interactive indicator dots.

Adds unit tests for the new `pinnedIconOnlyWidth(...reservedShortcutHintWidth:)` overload. Consumed by manaflow-ai/cmux for https://github.com/manaflow-ai/cmux/issues/6298.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the control-shortcut hint and click-to-mute audio for icon-only pinned browser tabs, with reserved space to avoid tab-bar layout shifts.

- **New Features**
  - Crossfades favicon to the shortcut hint pill on modifier hold; width pre-reserved via `TabItemStyling.pinnedIconOnlyWidth(...reservedShortcutHintWidth:)` to prevent resizing.
  - Makes the audio badge a button using `.toggleAudioMute`; unread/dirty remain non-interactive.
  - Adds unit tests covering the new width-reservation behavior.

<sup>Written for commit 68028fe61fc2ec5d024d5594bf6ad0bc5685df09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

