### PR TITLE
Add tab context menu open availability hook

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -912,7 +912,7 @@ struct TabContextMenuState {
     let canMoveToNewWorkspace: Bool
     let canMoveToLeftPane: Bool
     let canMoveToRightPane: Bool
-    let canForkConversation: Bool
+    var canForkConversation: Bool
     let forkConversationDefaultAction: TabContextAction
     let isZoomed: Bool
     let hasSplits: Bool
@@ -1348,6 +1348,9 @@ struct TabBarView: View {
             contextMenuState: contextMenuState,
             moveDestinationsProvider: {
                 controller.tabContextMoveDestinationsProvider?(TabID(id: tab.id), pane.id) ?? []
+            },
+            forkConversationOpenAvailabilityProvider: {
+                controller.tabContextForkConversationOpenAvailabilityProvider?(TabID(id: tab.id), pane.id)
             },
             onSelect: {
                 // Tab selection must be instant. Animating this transaction causes the pane

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -229,6 +229,7 @@ struct TabItemView: View {
     let allowsClose: Bool
     let contextMenuState: TabContextMenuState
     let moveDestinationsProvider: () -> [TabContextMoveDestination]
+    let forkConversationOpenAvailabilityProvider: () -> Bool?
     let onSelect: () -> Void
     let onClose: (TabCloseRequestSource) -> Void
     let onZoomToggle: () -> Void
@@ -281,7 +282,8 @@ struct TabItemView: View {
             snapshot: TabContextMenuSnapshot(
                 tabId: tab.id,
                 state: contextMenuState,
-                moveDestinationsProvider: moveDestinationsProvider
+                moveDestinationsProvider: moveDestinationsProvider,
+                forkConversationOpenAvailabilityProvider: forkConversationOpenAvailabilityProvider
             ),
             onContextAction: onContextAction,
             onMoveDestination: onMoveDestination
@@ -1112,6 +1114,7 @@ struct TabContextMenuSnapshot {
     let tabId: UUID
     let state: TabContextMenuState
     let moveDestinationsProvider: () -> [TabContextMoveDestination]
+    let forkConversationOpenAvailabilityProvider: () -> Bool?
 }
 
 final class TabContextMenuActionTarget: NSObject {
@@ -1137,7 +1140,10 @@ enum TabContextMenuBuilder {
         snapshot: TabContextMenuSnapshot,
         target: TabContextMenuActionTarget
     ) -> NSMenu {
-        let state = snapshot.state
+        var state = snapshot.state
+        if let canForkConversation = snapshot.forkConversationOpenAvailabilityProvider() {
+            state.canForkConversation = canForkConversation
+        }
         let menu = NSMenu()
         menu.autoenablesItems = false
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1141,9 +1141,9 @@ enum TabContextMenuBuilder {
         target: TabContextMenuActionTarget
     ) -> NSMenu {
         var state = snapshot.state
-        if let canForkConversation = snapshot.forkConversationOpenAvailabilityProvider() {
-            state.canForkConversation = canForkConversation
-        }
+        let canForkConversationAtOpen = snapshot.forkConversationOpenAvailabilityProvider()
+        let forkConversationEnabled = canForkConversationAtOpen ?? state.canForkConversation
+        state.canForkConversation = state.canForkConversation || forkConversationEnabled
         let menu = NSMenu()
         menu.autoenablesItems = false
 
@@ -1218,11 +1218,16 @@ enum TabContextMenuBuilder {
             addAction(
                 title: localized("tabContext.forkConversation", defaultValue: "Fork Conversation"),
                 action: .forkConversation,
+                enabled: forkConversationEnabled,
                 state: state,
                 target: target,
                 to: menu
             )
-            menu.addItem(forkConversationSubmenuItem(state: state, target: target))
+            menu.addItem(forkConversationSubmenuItem(
+                state: state,
+                target: target,
+                enabled: forkConversationEnabled
+            ))
         }
 
         menu.addItem(.separator())
@@ -1365,7 +1370,8 @@ enum TabContextMenuBuilder {
 
     private static func forkConversationSubmenuItem(
         state: TabContextMenuState,
-        target: TabContextMenuActionTarget
+        target: TabContextMenuActionTarget,
+        enabled: Bool
     ) -> NSMenuItem {
         let item = NSMenuItem(
             title: localized("tabContext.forkConversationTo", defaultValue: "Fork Conversation To"),
@@ -1381,6 +1387,7 @@ enum TabContextMenuBuilder {
         addAction(
             title: localized("tabContext.forkConversation.right", defaultValue: "Right Split"),
             action: .forkConversationRight,
+            enabled: enabled,
             state: state,
             target: target,
             to: submenu,
@@ -1389,6 +1396,7 @@ enum TabContextMenuBuilder {
         addAction(
             title: localized("tabContext.forkConversation.left", defaultValue: "Left Split"),
             action: .forkConversationLeft,
+            enabled: enabled,
             state: state,
             target: target,
             to: submenu,
@@ -1397,6 +1405,7 @@ enum TabContextMenuBuilder {
         addAction(
             title: localized("tabContext.forkConversation.top", defaultValue: "Top Split"),
             action: .forkConversationTop,
+            enabled: enabled,
             state: state,
             target: target,
             to: submenu,
@@ -1405,6 +1414,7 @@ enum TabContextMenuBuilder {
         addAction(
             title: localized("tabContext.forkConversation.bottom", defaultValue: "Bottom Split"),
             action: .forkConversationBottom,
+            enabled: enabled,
             state: state,
             target: target,
             to: submenu,
@@ -1414,6 +1424,7 @@ enum TabContextMenuBuilder {
         addAction(
             title: localized("tabContext.forkConversation.newTab", defaultValue: "New Tab"),
             action: .forkConversationNewTab,
+            enabled: enabled,
             state: state,
             target: target,
             to: submenu,
@@ -1422,6 +1433,7 @@ enum TabContextMenuBuilder {
         addAction(
             title: localized("tabContext.forkConversation.newWorkspace", defaultValue: "New Workspace"),
             action: .forkConversationNewWorkspace,
+            enabled: enabled,
             state: state,
             target: target,
             to: submenu,
@@ -1429,7 +1441,7 @@ enum TabContextMenuBuilder {
         )
 
         item.submenu = submenu
-        item.isEnabled = true
+        item.isEnabled = enabled
         return item
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -82,6 +82,9 @@ public final class BonsplitController {
     /// session). Return `true` to enable the item, `false` (or omit the provider) to hide it.
     @ObservationIgnored public var tabContextForkConversationAvailabilityProvider: ((TabID, PaneID) -> Bool)?
 
+    /// Host-provided check evaluated only when the tab context menu is opening.
+    @ObservationIgnored public var tabContextForkConversationOpenAvailabilityProvider: ((TabID, PaneID) -> Bool)?
+
     /// Host-provided default destination for the tab context menu's primary "Fork
     /// Conversation" action. Return a destination-specific fork action; invalid values
     /// fall back to `.forkConversationRight`.

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1673,7 +1673,8 @@ final class BonsplitTests: XCTestCase {
                 return [
                     TabContextMoveDestination(id: "workspace:abc", title: "Workspace A", isEnabled: false)
                 ]
-            }
+            },
+            forkConversationOpenAvailabilityProvider: { nil }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1720,7 +1721,8 @@ final class BonsplitTests: XCTestCase {
                 hasSplits: false,
                 shortcuts: [:]
             ),
-            moveDestinationsProvider: { [] }
+            moveDestinationsProvider: { [] },
+            forkConversationOpenAvailabilityProvider: { nil }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1754,7 +1756,8 @@ final class BonsplitTests: XCTestCase {
                 hasSplits: false,
                 shortcuts: [:]
             ),
-            moveDestinationsProvider: { [] }
+            moveDestinationsProvider: { [] },
+            forkConversationOpenAvailabilityProvider: { nil }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1790,7 +1793,8 @@ final class BonsplitTests: XCTestCase {
         let snapshot = TabContextMenuSnapshot(
             tabId: UUID(),
             state: state,
-            moveDestinationsProvider: { [] }
+            moveDestinationsProvider: { [] },
+            forkConversationOpenAvailabilityProvider: { nil }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1816,6 +1816,45 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabContextMenuBuilderKeepsForkConversationVisibleWhenOpenAvailabilityIsRefreshing() throws {
+        let target = TabContextMenuActionTarget()
+        let state = TabContextMenuState(
+            isPinned: false,
+            isUnread: false,
+            isBrowser: false,
+            isAudioMuted: false,
+            isTerminal: true,
+            hasCustomTitle: false,
+            canCloseToLeft: true,
+            canCloseToRight: true,
+            canCloseOthers: true,
+            canMoveToNewWorkspace: false,
+            canMoveToLeftPane: false,
+            canMoveToRightPane: false,
+            canForkConversation: true,
+            forkConversationDefaultAction: .forkConversationLeft,
+            isZoomed: false,
+            hasSplits: false,
+            shortcuts: [:]
+        )
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: state,
+            moveDestinationsProvider: { [] },
+            forkConversationOpenAvailabilityProvider: { false }
+        )
+
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation" })
+        let forkSubmenuItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation To" })
+        let destinationItems = try XCTUnwrap(forkSubmenuItem.submenu?.items.filter { !$0.isSeparatorItem })
+
+        XCTAssertFalse(forkItem.isEnabled)
+        XCTAssertFalse(forkSubmenuItem.isEnabled)
+        XCTAssertEqual(destinationItems.map(\.isEnabled), Array(repeating: false, count: 6))
+    }
+
+    @MainActor
     func testDoubleClickingEmptyTrailingTabBarSpaceRequestsNewTerminalTab() {
         let appearance = BonsplitConfiguration.Appearance()
         let configuration = BonsplitConfiguration(appearance: appearance)


### PR DESCRIPTION
Adds an open-time tab context menu availability hook so hosts can run expensive/probing checks only when an NSMenu is opening, not while SwiftUI renders tab rows.\n\nNeeded by manaflow-ai/cmux#7352 for Fork Conversation availability.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785811681&installation_id=133855650&pr_number=158&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F158&signature=faa72fab4c5f98e3741095f1cb905f88bf06a98d3904881c0bba866e84715c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an open-time availability hook for the tab context menu so hosts can run checks only when the menu opens. Keeps “Fork Conversation” visible (but disabled) while availability refreshes, and supports `manaflow-ai/cmux#7352`.

- **New Features**
  - Added `tabContextForkConversationOpenAvailabilityProvider` on `BonsplitController`; runs when the menu opens.
  - “Fork Conversation” and all destinations stay visible but disabled when the open-time check returns false; behavior is unchanged when no provider is set.
  - Wired through TabBarView → TabItemView → TabContextMenuBuilder; made `canForkConversation` mutable; tests updated.

<sup>Written for commit 222f9a75bf6df5d0a1bc4c44becaa7b48257c015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for determining whether “Fork Conversation” should be available when a tab’s context menu opens.
  * Introduced a host-provided availability check per tab and pane to dynamically enable or disable the option.

* **Bug Fixes**
  * Ensure the “Fork Conversation” context menu items remain visible while updating their enabled/disabled state based on the latest availability result (falling back to prior behavior when no check is provided).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->