### PR TITLE
Per-pane full-width tab mode with prominent title header

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -1,0 +1,84 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+extension SplitViewController {
+    @discardableResult
+    func beginTabDrag(_ tab: TabItem, from paneId: PaneID) -> Int {
+#if DEBUG
+        dlog("tab.dragStart pane=\(paneId.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5)) title=\"\(tab.title)\"")
+#endif
+        dragGeneration += 1
+        draggingTab = tab
+        dragSourcePaneId = paneId
+        activeDragTab = tab
+        activeDragSourcePaneId = paneId
+        return dragGeneration
+    }
+
+    func clearTabDragState() {
+        draggingTab = nil
+        dragSourcePaneId = nil
+        activeDragTab = nil
+        activeDragSourcePaneId = nil
+    }
+
+    func cancelTabDragIfGenerationMatches(_ generation: Int) {
+        guard dragGeneration == generation else { return }
+        if draggingTab != nil || activeDragTab != nil {
+#if DEBUG
+            dlog("tab.dragCancel (stale draggingTab cleared)")
+#endif
+            clearTabDragState()
+        }
+    }
+
+    func makeTabDragItemProvider(
+        for tab: TabItem,
+        from paneId: PaneID,
+        clearDropState: () -> Void
+    ) -> NSItemProvider {
+#if DEBUG
+        NSLog("[Bonsplit Drag] createItemProvider for tab: \(tab.title)")
+#endif
+        clearDropState()
+        let dragGeneration = beginTabDrag(tab, from: paneId)
+        installCancelledTabDragCleanup(forGeneration: dragGeneration)
+
+        let transfer = TabTransferData(tab: tab, sourcePaneId: paneId.id)
+        if let data = try? JSONEncoder().encode(transfer) {
+            let provider = NSItemProvider()
+            provider.registerDataRepresentation(
+                forTypeIdentifier: UTType.tabTransfer.identifier,
+                visibility: .ownProcess
+            ) { completion in
+                completion(data, nil)
+                return nil
+            }
+#if DEBUG
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+                let types = NSPasteboard(name: .drag).types?.map(\.rawValue).joined(separator: ",") ?? "-"
+                dlog("tab.dragPasteboard types=\(types)")
+            }
+#endif
+            return provider
+        }
+        return NSItemProvider()
+    }
+
+    private func installCancelledTabDragCleanup(forGeneration generation: Int) {
+        var monitorRef: Any?
+        monitorRef = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+            // One-shot: remove ourselves AND nil the capture box, or the cycle
+            // monitor -> closure -> box -> monitor leaks one monitor per drag.
+            if let m = monitorRef {
+                NSEvent.removeMonitor(m)
+                monitorRef = nil
+            }
+            DispatchQueue.main.async {
+                self?.cancelTabDragIfGenerationMatches(generation)
+            }
+            return event
+        }
+    }
+}

--- a/Sources/Bonsplit/Internal/Models/PaneState.swift
+++ b/Sources/Bonsplit/Internal/Models/PaneState.swift
@@ -7,15 +7,18 @@ final class PaneState: Identifiable {
     let id: PaneID
     var tabs: [TabItem]
     var selectedTabId: UUID?
+    var isFullWidthTabMode: Bool = false
 
     init(
         id: PaneID = PaneID(),
         tabs: [TabItem] = [],
-        selectedTabId: UUID? = nil
+        selectedTabId: UUID? = nil,
+        isFullWidthTabMode: Bool = false
     ) {
         self.id = id
         self.tabs = tabs
         self.selectedTabId = selectedTabId ?? tabs.first?.id
+        self.isFullWidthTabMode = isFullWidthTabMode
     }
 
     /// Currently selected tab

--- a/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
+++ b/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
@@ -9,6 +9,7 @@ struct FullWidthTabHeaderView: View {
 
     @Bindable var pane: PaneState
     let isFocused: Bool
+    let showSplitButtons: Bool
 
     @State private var dropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
@@ -40,6 +41,15 @@ struct FullWidthTabHeaderView: View {
 
     private var appendDropTargetIndex: Int {
         pane.tabs.count
+    }
+
+    private var visibleSplitButtons: [BonsplitConfiguration.SplitActionButton] {
+        guard showSplitButtons else { return [] }
+        return appearance.splitButtons
+    }
+
+    private var showsTrailingControls: Bool {
+        pane.tabs.count > 1 || !visibleSplitButtons.isEmpty
     }
 
     var body: some View {
@@ -140,29 +150,23 @@ struct FullWidthTabHeaderView: View {
                     )
                     .saturation(saturation)
             }
-            .padding(.horizontal, 44)
+            .padding(.horizontal, showsTrailingControls ? 92 : 44)
             .frame(maxWidth: .infinity, alignment: .center)
 
-            if pane.tabs.count > 1 {
-                HStack {
+            if showsTrailingControls {
+                HStack(spacing: 6) {
                     Spacer(minLength: 0)
-                    Text("\(index + 1)/\(pane.tabs.count)")
-                        .font(.system(size: max(9, appearance.tabTitleFontSize - 1), weight: .medium))
-                        .foregroundStyle(TabBarColors.inactiveText(for: appearance))
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(TabBarColors.hoveredTabBackground(for: appearance))
-                        )
-                        .saturation(saturation)
+                    if pane.tabs.count > 1 {
+                        tabSwitcherMenu(selectedIndex: index)
+                    }
+                    if !visibleSplitButtons.isEmpty {
+                        splitActionsMenu
+                    }
                 }
                 .padding(.trailing, 8)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(tab.title)
     }
 
     private var activeHeaderIndicator: some View {
@@ -190,6 +194,101 @@ struct FullWidthTabHeaderView: View {
             .padding(.vertical, 3)
     }
 
+    private func tabSwitcherMenu(selectedIndex: Int) -> some View {
+        Menu {
+            ForEach(Array(pane.tabs.enumerated()), id: \.element.id) { index, tab in
+                Button {
+                    withTransaction(Transaction(animation: nil)) {
+                        controller.selectTab(TabID(id: tab.id))
+                    }
+                } label: {
+                    Text(tab.title)
+                    if index == selectedIndex {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text("\(selectedIndex + 1)/\(pane.tabs.count)")
+                    .font(.system(size: max(9, appearance.tabTitleFontSize - 1), weight: .medium))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: max(7, appearance.tabTitleFontSize - 4), weight: .semibold))
+            }
+            .foregroundStyle(TabBarColors.inactiveText(for: appearance))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(TabBarColors.hoveredTabBackground(for: appearance))
+            )
+            .saturation(saturation)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .accessibilityLabel(localized("tabContext.switchTab", defaultValue: "Switch Tab"))
+    }
+
+    private var splitActionsMenu: some View {
+        Menu {
+            ForEach(visibleSplitButtons) { button in
+                Button(splitActionButtonTitle(button)) {
+                    performSplitActionButton(button)
+                }
+            }
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: max(11, appearance.tabTitleFontSize), weight: .semibold))
+                .foregroundStyle(TabBarColors.inactiveText(for: appearance))
+                .frame(width: 22, height: 20)
+                .background(
+                    Circle()
+                        .fill(TabBarColors.hoveredTabBackground(for: appearance))
+                )
+                .saturation(saturation)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .accessibilityLabel(localized("tabContext.paneActions", defaultValue: "Pane Actions"))
+    }
+
+    private func splitActionButtonTitle(_ button: BonsplitConfiguration.SplitActionButton) -> String {
+        if let tooltip = button.tooltip, !tooltip.isEmpty {
+            return tooltip
+        }
+
+        let tooltips = appearance.splitButtonTooltips
+        switch button.action {
+        case .newTerminal:
+            return tooltips.newTerminal
+        case .newBrowser:
+            return tooltips.newBrowser
+        case .splitRight:
+            return tooltips.splitRight
+        case .splitDown:
+            return tooltips.splitDown
+        case .custom(let identifier):
+            return identifier
+        }
+    }
+
+    private func performSplitActionButton(_ button: BonsplitConfiguration.SplitActionButton) {
+        guard splitViewController.isInteractive else { return }
+
+        switch button.action {
+        case .newTerminal:
+            controller.requestNewTab(kind: "terminal", inPane: pane.id)
+        case .newBrowser:
+            controller.requestNewTab(kind: "browser", inPane: pane.id)
+        case .splitRight:
+            controller.splitPane(pane.id, orientation: .horizontal)
+        case .splitDown:
+            controller.splitPane(pane.id, orientation: .vertical)
+        case .custom(let identifier):
+            controller.requestCustomAction(identifier, inPane: pane.id)
+        }
+    }
+
     @ViewBuilder
     private func tabIcon(for tab: TabItem) -> some View {
         let iconSize = max(14, appearance.tabTitleFontSize + 3)
@@ -215,5 +314,9 @@ struct FullWidthTabHeaderView: View {
     private func clearDropState() {
         dropTargetIndex = nil
         dropLifecycle = .idle
+    }
+
+    private func localized(_ key: String, defaultValue: String) -> String {
+        Bundle.module.localizedString(forKey: key, value: defaultValue, table: nil)
     }
 }

--- a/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
+++ b/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
@@ -1,0 +1,147 @@
+import AppKit
+import SwiftUI
+
+/// Header shown when a pane renders its selected tab as the full-width title.
+struct FullWidthTabHeaderView: View {
+    @Environment(BonsplitController.self) private var controller
+    @Environment(SplitViewController.self) private var splitViewController
+
+    @Bindable var pane: PaneState
+    let isFocused: Bool
+
+    private var appearance: BonsplitConfiguration.Appearance {
+        controller.configuration.appearance
+    }
+
+    private var selectedTab: TabItem? {
+        pane.selectedTab ?? pane.tabs.first
+    }
+
+    private var selectedIndex: Int? {
+        guard let selectedTab else { return nil }
+        return pane.tabs.firstIndex(where: { $0.id == selectedTab.id })
+    }
+
+    private var saturation: Double {
+        isFocused || splitViewController.dragSourcePaneId == pane.id ? 1.0 : 0.0
+    }
+
+    private var backgroundColor: Color {
+        let baseBarColor = TabBarColors.nsColorBarBackground(for: appearance)
+        let resolved = appearance.usesSharedBackdrop || isFocused
+            ? baseBarColor
+            : baseBarColor.withAlphaComponent(baseBarColor.alphaComponent * 0.95)
+        return Color(nsColor: resolved)
+    }
+
+    var body: some View {
+        Group {
+            if let selectedTab, let selectedIndex {
+                headerContent(tab: selectedTab, index: selectedIndex)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(height: appearance.tabBarHeight)
+                    .contentShape(Rectangle())
+                    .background(
+                        TabContextMenuPresenter(
+                            snapshot: TabContextMenuSnapshot(
+                                tabId: selectedTab.id,
+                                state: TabContextMenuState(
+                                    tab: selectedTab,
+                                    index: selectedIndex,
+                                    pane: pane,
+                                    controller: controller,
+                                    splitViewController: splitViewController
+                                ),
+                                moveDestinationsProvider: {
+                                    controller.tabContextMoveDestinationsProvider?(TabID(id: selectedTab.id), pane.id) ?? []
+                                }
+                            ),
+                            onContextAction: { action in
+                                controller.requestTabContextAction(action, for: TabID(id: selectedTab.id), inPane: pane.id)
+                            },
+                            onMoveDestination: { destinationId in
+                                controller.requestTabMove(toDestination: destinationId, for: TabID(id: selectedTab.id), inPane: pane.id)
+                            }
+                        )
+                    )
+            } else {
+                Color.clear
+            }
+        }
+        .frame(height: appearance.tabBarHeight)
+        .background(backgroundColor)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(TabBarColors.separator(for: appearance))
+                .frame(height: 1)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withTransaction(Transaction(animation: nil)) {
+                controller.focusPane(pane.id)
+            }
+        }
+    }
+
+    private func headerContent(tab: TabItem, index: Int) -> some View {
+        ZStack {
+            HStack(spacing: 8) {
+                tabIcon(for: tab)
+
+                Text(tab.title)
+                    .font(.system(size: appearance.tabTitleFontSize + 2, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(
+                        isFocused
+                            ? TabBarColors.activeText(for: appearance)
+                            : TabBarColors.inactiveText(for: appearance)
+                    )
+                    .saturation(saturation)
+            }
+            .padding(.horizontal, 44)
+            .frame(maxWidth: .infinity, alignment: .center)
+
+            if pane.tabs.count > 1 {
+                HStack {
+                    Spacer(minLength: 0)
+                    Text("\(index + 1)/\(pane.tabs.count)")
+                        .font(.system(size: max(9, appearance.tabTitleFontSize - 1), weight: .medium))
+                        .foregroundStyle(TabBarColors.inactiveText(for: appearance))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(TabBarColors.hoveredTabBackground(for: appearance))
+                        )
+                        .saturation(saturation)
+                }
+                .padding(.trailing, 8)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(tab.title)
+    }
+
+    @ViewBuilder
+    private func tabIcon(for tab: TabItem) -> some View {
+        let iconSize = max(14, appearance.tabTitleFontSize + 3)
+        let iconTint = isFocused
+            ? TabBarColors.activeText(for: appearance)
+            : TabBarColors.inactiveText(for: appearance)
+
+        if let imageData = tab.iconImageData, let image = NSImage(data: imageData) {
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: iconSize, height: iconSize)
+        } else if let iconName = tab.icon {
+            Image(systemName: iconName)
+                .font(.system(size: iconSize, weight: .medium))
+                .foregroundStyle(iconTint)
+                .frame(width: iconSize, height: iconSize)
+                .saturation(saturation)
+        }
+    }
+}

--- a/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
+++ b/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
@@ -48,7 +48,6 @@ struct FullWidthTabHeaderView: View {
                 headerContent(tab: selectedTab, index: selectedIndex)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .frame(height: appearance.tabBarHeight)
-                    .contentShape(Rectangle())
                     .background(
                         TabContextMenuPresenter(
                             snapshot: TabContextMenuSnapshot(
@@ -62,6 +61,9 @@ struct FullWidthTabHeaderView: View {
                                 ),
                                 moveDestinationsProvider: {
                                     controller.tabContextMoveDestinationsProvider?(TabID(id: selectedTab.id), pane.id) ?? []
+                                },
+                                forkConversationOpenAvailabilityProvider: {
+                                    controller.tabContextForkConversationOpenAvailabilityProvider?(TabID(id: selectedTab.id), pane.id)
                                 }
                             ),
                             onContextAction: { action in
@@ -93,6 +95,10 @@ struct FullWidthTabHeaderView: View {
         }
         .frame(height: appearance.tabBarHeight)
         .background(backgroundColor)
+        .overlay(alignment: .topLeading) {
+            activeHeaderIndicator
+                .allowsHitTesting(false)
+        }
         .overlay {
             if dropTargetIndex == appendDropTargetIndex {
                 headerDropHighlight
@@ -159,6 +165,20 @@ struct FullWidthTabHeaderView: View {
         .accessibilityLabel(tab.title)
     }
 
+    private var activeHeaderIndicator: some View {
+        HStack(spacing: 0) {
+            Rectangle()
+                .fill(TabBarColors.activeIndicator(saturation: saturation))
+                .frame(height: TabBarMetrics.activeIndicatorHeight)
+            Color.clear
+                .frame(width: TabBarMetrics.activeIndicatorTrailingInset)
+        }
+        .frame(height: TabBarMetrics.activeIndicatorHeight, alignment: .top)
+        .transaction { transaction in
+            transaction.animation = nil
+        }
+    }
+
     private var headerDropHighlight: some View {
         RoundedRectangle(cornerRadius: 6)
             .fill(TabBarColors.dropIndicator(for: appearance).opacity(0.12))
@@ -182,6 +202,7 @@ struct FullWidthTabHeaderView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: iconSize, height: iconSize)
+                .saturation(saturation)
         } else if let iconName = tab.icon {
             Image(systemName: iconName)
                 .font(.system(size: iconSize, weight: .medium))

--- a/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
+++ b/Sources/Bonsplit/Internal/Views/FullWidthTabHeaderView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Header shown when a pane renders its selected tab as the full-width title.
 struct FullWidthTabHeaderView: View {
@@ -8,6 +9,9 @@ struct FullWidthTabHeaderView: View {
 
     @Bindable var pane: PaneState
     let isFocused: Bool
+
+    @State private var dropTargetIndex: Int?
+    @State private var dropLifecycle: TabDropLifecycle = .idle
 
     private var appearance: BonsplitConfiguration.Appearance {
         controller.configuration.appearance
@@ -32,6 +36,10 @@ struct FullWidthTabHeaderView: View {
             ? baseBarColor
             : baseBarColor.withAlphaComponent(baseBarColor.alphaComponent * 0.95)
         return Color(nsColor: resolved)
+    }
+
+    private var appendDropTargetIndex: Int {
+        pane.tabs.count
     }
 
     var body: some View {
@@ -64,12 +72,34 @@ struct FullWidthTabHeaderView: View {
                             }
                         )
                     )
+                    .onDrag {
+                        splitViewController.makeTabDragItemProvider(for: selectedTab, from: pane.id) {
+                            clearDropState()
+                        }
+                    } preview: {
+                        TabDragPreview(tab: selectedTab, appearance: appearance)
+                    }
+                    .onDrop(of: [.tabTransfer, .fileURL], delegate: TabDropDelegate(
+                        targetIndex: appendDropTargetIndex,
+                        pane: pane,
+                        bonsplitController: controller,
+                        controller: splitViewController,
+                        dropTargetIndex: $dropTargetIndex,
+                        dropLifecycle: $dropLifecycle
+                    ))
             } else {
                 Color.clear
             }
         }
         .frame(height: appearance.tabBarHeight)
         .background(backgroundColor)
+        .overlay {
+            if dropTargetIndex == appendDropTargetIndex {
+                headerDropHighlight
+                    .saturation(saturation)
+                    .allowsHitTesting(false)
+            }
+        }
         .overlay(alignment: .bottom) {
             Rectangle()
                 .fill(TabBarColors.separator(for: appearance))
@@ -79,6 +109,11 @@ struct FullWidthTabHeaderView: View {
         .onTapGesture {
             withTransaction(Transaction(animation: nil)) {
                 controller.focusPane(pane.id)
+            }
+        }
+        .onChange(of: splitViewController.draggingTab) { _, newValue in
+            if newValue == nil {
+                clearDropState()
             }
         }
     }
@@ -124,6 +159,17 @@ struct FullWidthTabHeaderView: View {
         .accessibilityLabel(tab.title)
     }
 
+    private var headerDropHighlight: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .fill(TabBarColors.dropIndicator(for: appearance).opacity(0.12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(TabBarColors.dropIndicator(for: appearance), lineWidth: 2)
+            )
+            .padding(.horizontal, 4)
+            .padding(.vertical, 3)
+    }
+
     @ViewBuilder
     private func tabIcon(for tab: TabItem) -> some View {
         let iconSize = max(14, appearance.tabTitleFontSize + 3)
@@ -143,5 +189,10 @@ struct FullWidthTabHeaderView: View {
                 .frame(width: iconSize, height: iconSize)
                 .saturation(saturation)
         }
+    }
+
+    private func clearDropState() {
+        dropTargetIndex = nil
+        dropLifecycle = .idle
     }
 }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -174,7 +174,8 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
                 if pane.isFullWidthTabMode, !pane.tabs.isEmpty {
                     FullWidthTabHeaderView(
                         pane: pane,
-                        isFocused: isFocused
+                        isFocused: isFocused,
+                        showSplitButtons: showSplitButtons
                     )
                 } else {
                     TabBarView(

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -170,7 +170,12 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if tabBarVisibility.showsTabBar(tabCount: pane.tabs.count) {
+            if pane.isFullWidthTabMode, !pane.tabs.isEmpty {
+                FullWidthTabHeaderView(
+                    pane: pane,
+                    isFocused: isFocused
+                )
+            } else if tabBarVisibility.showsTabBar(tabCount: pane.tabs.count) {
                 TabBarView(
                     pane: pane,
                     isFocused: isFocused,

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -170,17 +170,19 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if pane.isFullWidthTabMode, !pane.tabs.isEmpty {
-                FullWidthTabHeaderView(
-                    pane: pane,
-                    isFocused: isFocused
-                )
-            } else if tabBarVisibility.showsTabBar(tabCount: pane.tabs.count) {
-                TabBarView(
-                    pane: pane,
-                    isFocused: isFocused,
-                    showSplitButtons: showSplitButtons
-                )
+            if tabBarVisibility.showsTabBar(tabCount: pane.tabs.count) {
+                if pane.isFullWidthTabMode, !pane.tabs.isEmpty {
+                    FullWidthTabHeaderView(
+                        pane: pane,
+                        isFocused: isFocused
+                    )
+                } else {
+                    TabBarView(
+                        pane: pane,
+                        isFocused: isFocused,
+                        showSplitButtons: showSplitButtons
+                    )
+                }
             }
 
             // Content area with drop zones

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1514,71 +1514,10 @@ struct TabBarView: View {
     // MARK: - Item Provider
 
     private func createItemProvider(for tab: TabItem) -> NSItemProvider {
-        #if DEBUG
-        NSLog("[Bonsplit Drag] createItemProvider for tab: \(tab.title)")
-        #endif
-#if DEBUG
-        dlog("tab.dragStart pane=\(pane.id.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5)) title=\"\(tab.title)\"")
-#endif
-        // Clear any stale drop indicator from previous incomplete drag
-        dropTargetIndex = nil
-        dropLifecycle = .idle
-
-        // Set drag source for visual feedback (observable) and drop delegates (non-observable).
-        splitViewController.dragGeneration += 1
-        splitViewController.draggingTab = tab
-        splitViewController.dragSourcePaneId = pane.id
-        splitViewController.activeDragTab = tab
-        splitViewController.activeDragSourcePaneId = pane.id
-
-        // Install a one-shot mouse-up monitor to clear stale drag state if the drag is
-        // cancelled (dropped outside any valid target). SwiftUI's onDrag doesn't provide
-        // a drag-cancelled callback, so performDrop never fires and draggingTab stays set,
-        // which disables hit testing on all content views.
-        let controller = splitViewController
-        let dragGen = controller.dragGeneration
-        var monitorRef: Any?
-        monitorRef = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { event in
-            // One-shot: remove ourselves, then clean up stale drag state.
-            if let m = monitorRef {
-                NSEvent.removeMonitor(m)
-                monitorRef = nil
-            }
-            // Use async to avoid mutating @Observable state during event dispatch.
-            DispatchQueue.main.async {
-                guard controller.dragGeneration == dragGen else { return }
-                if controller.draggingTab != nil || controller.activeDragTab != nil {
-#if DEBUG
-                    dlog("tab.dragCancel (stale draggingTab cleared)")
-#endif
-                    controller.draggingTab = nil
-                    controller.dragSourcePaneId = nil
-                    controller.activeDragTab = nil
-                    controller.activeDragSourcePaneId = nil
-                }
-            }
-            return event
+        splitViewController.makeTabDragItemProvider(for: tab, from: pane.id) {
+            dropTargetIndex = nil
+            dropLifecycle = .idle
         }
-
-        let transfer = TabTransferData(tab: tab, sourcePaneId: pane.id.id)
-        if let data = try? JSONEncoder().encode(transfer) {
-            let provider = NSItemProvider()
-            provider.registerDataRepresentation(
-                forTypeIdentifier: UTType.tabTransfer.identifier,
-                visibility: .ownProcess
-            ) { completion in
-                completion(data, nil)
-                return nil
-            }
-#if DEBUG
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
-                let types = NSPasteboard(name: .drag).types?.map(\.rawValue).joined(separator: ",") ?? "-"
-                dlog("tab.dragPasteboard types=\(types)")
-            }
-#endif
-            return provider
-        }
-        return NSItemProvider()
     }
 
     private func tabControlShortcutDigit(for index: Int, tabCount: Int) -> Int? {
@@ -2538,11 +2477,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                     "tab=\(session.sourceTab.id.uuidString.prefix(5)) title=\"\(session.sourceTab.title)\""
             )
 #endif
-            splitViewController.dragGeneration += 1
-            splitViewController.draggingTab = session.sourceTab
-            splitViewController.dragSourcePaneId = session.sourcePaneId
-            splitViewController.activeDragTab = session.sourceTab
-            splitViewController.activeDragSourcePaneId = session.sourcePaneId
+            _ = splitViewController.beginTabDrag(session.sourceTab, from: session.sourcePaneId)
         }
 
         private func clearManualDrag() {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -915,6 +915,7 @@ struct TabContextMenuState {
     let canForkConversation: Bool
     let forkConversationDefaultAction: TabContextAction
     let isZoomed: Bool
+    let isFullWidthTabMode: Bool
     let hasSplits: Bool
     let shortcuts: [TabContextAction: KeyboardShortcut]
 
@@ -924,6 +925,89 @@ struct TabContextMenuState {
 
     var canMarkAsRead: Bool {
         isUnread
+    }
+
+    init(
+        isPinned: Bool,
+        isUnread: Bool,
+        isBrowser: Bool,
+        isAudioMuted: Bool,
+        isTerminal: Bool,
+        hasCustomTitle: Bool,
+        canCloseToLeft: Bool,
+        canCloseToRight: Bool,
+        canCloseOthers: Bool,
+        canMoveToNewWorkspace: Bool,
+        canMoveToLeftPane: Bool,
+        canMoveToRightPane: Bool,
+        canForkConversation: Bool,
+        forkConversationDefaultAction: TabContextAction,
+        isZoomed: Bool,
+        isFullWidthTabMode: Bool = false,
+        hasSplits: Bool,
+        shortcuts: [TabContextAction: KeyboardShortcut]
+    ) {
+        self.isPinned = isPinned
+        self.isUnread = isUnread
+        self.isBrowser = isBrowser
+        self.isAudioMuted = isAudioMuted
+        self.isTerminal = isTerminal
+        self.hasCustomTitle = hasCustomTitle
+        self.canCloseToLeft = canCloseToLeft
+        self.canCloseToRight = canCloseToRight
+        self.canCloseOthers = canCloseOthers
+        self.canMoveToNewWorkspace = canMoveToNewWorkspace
+        self.canMoveToLeftPane = canMoveToLeftPane
+        self.canMoveToRightPane = canMoveToRightPane
+        self.canForkConversation = canForkConversation
+        self.forkConversationDefaultAction = forkConversationDefaultAction
+        self.isZoomed = isZoomed
+        self.isFullWidthTabMode = isFullWidthTabMode
+        self.hasSplits = hasSplits
+        self.shortcuts = shortcuts
+    }
+
+    @MainActor
+    init(
+        tab: TabItem,
+        index: Int,
+        pane: PaneState,
+        controller: BonsplitController,
+        splitViewController: SplitViewController
+    ) {
+        let allowsCloseTabs = controller.configuration.allowCloseTabs
+        let leftTabs = pane.tabs.prefix(index)
+        let canCloseToLeft = allowsCloseTabs && leftTabs.contains(where: { !$0.isPinned })
+        let canCloseToRight: Bool
+        if (index + 1) < pane.tabs.count {
+            canCloseToRight = allowsCloseTabs && pane.tabs.suffix(from: index + 1).contains(where: { !$0.isPinned })
+        } else {
+            canCloseToRight = false
+        }
+        let canCloseOthers = allowsCloseTabs
+            && pane.tabs.enumerated().contains { itemIndex, item in
+                itemIndex != index && !item.isPinned
+            }
+        self.init(
+            isPinned: tab.isPinned,
+            isUnread: tab.showsNotificationBadge,
+            isBrowser: tab.kind == "browser",
+            isAudioMuted: tab.isAudioMuted,
+            isTerminal: tab.kind == "terminal",
+            hasCustomTitle: tab.hasCustomTitle,
+            canCloseToLeft: canCloseToLeft,
+            canCloseToRight: canCloseToRight,
+            canCloseOthers: canCloseOthers,
+            canMoveToNewWorkspace: controller.allTabIds.count > 1,
+            canMoveToLeftPane: controller.adjacentPane(to: pane.id, direction: .left) != nil,
+            canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
+            canForkConversation: controller.tabContextForkConversationAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false,
+            forkConversationDefaultAction: controller.tabContextForkConversationDefaultActionProvider?(TabID(id: tab.id), pane.id) ?? .defaultForkConversationDestination,
+            isZoomed: splitViewController.zoomedPaneId == pane.id,
+            isFullWidthTabMode: pane.isFullWidthTabMode,
+            hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
+            shortcuts: controller.contextMenuShortcuts
+        )
     }
 }
 
@@ -1418,37 +1502,12 @@ struct TabBarView: View {
     }
 
     private func contextMenuState(for tab: TabItem, at index: Int) -> TabContextMenuState {
-        let allowsCloseTabs = controller.configuration.allowCloseTabs
-        let leftTabs = pane.tabs.prefix(index)
-        let canCloseToLeft = allowsCloseTabs && leftTabs.contains(where: { !$0.isPinned })
-        let canCloseToRight: Bool
-        if (index + 1) < pane.tabs.count {
-            canCloseToRight = allowsCloseTabs && pane.tabs.suffix(from: index + 1).contains(where: { !$0.isPinned })
-        } else {
-            canCloseToRight = false
-        }
-        let canCloseOthers = allowsCloseTabs
-            && pane.tabs.enumerated().contains { itemIndex, item in
-                itemIndex != index && !item.isPinned
-            }
         return TabContextMenuState(
-            isPinned: tab.isPinned,
-            isUnread: tab.showsNotificationBadge,
-            isBrowser: tab.kind == "browser",
-            isAudioMuted: tab.isAudioMuted,
-            isTerminal: tab.kind == "terminal",
-            hasCustomTitle: tab.hasCustomTitle,
-            canCloseToLeft: canCloseToLeft,
-            canCloseToRight: canCloseToRight,
-            canCloseOthers: canCloseOthers,
-            canMoveToNewWorkspace: controller.allTabIds.count > 1,
-            canMoveToLeftPane: controller.adjacentPane(to: pane.id, direction: .left) != nil,
-            canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
-            canForkConversation: controller.tabContextForkConversationAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false,
-            forkConversationDefaultAction: controller.tabContextForkConversationDefaultActionProvider?(TabID(id: tab.id), pane.id) ?? .defaultForkConversationDestination,
-            isZoomed: splitViewController.zoomedPaneId == pane.id,
-            hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
-            shortcuts: controller.contextMenuShortcuts
+            tab: tab,
+            index: index,
+            pane: pane,
+            controller: controller,
+            splitViewController: splitViewController
         )
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1278,6 +1278,16 @@ enum TabContextMenuBuilder {
         }
 
         addAction(
+            title: state.isFullWidthTabMode
+                ? localized("tabContext.exitFullWidthTab", defaultValue: "Exit Full Width Tab")
+                : localized("tabContext.enterFullWidthTab", defaultValue: "Full Width Tab"),
+            action: .toggleFullWidthTab,
+            state: state,
+            target: target,
+            to: menu
+        )
+
+        addAction(
             title: state.isPinned
                 ? localized("tabContext.unpinTab", defaultValue: "Unpin Tab")
                 : localized("tabContext.pinTab", defaultValue: "Pin Tab"),
@@ -1474,7 +1484,7 @@ private extension EventModifiers {
     }
 }
 
-private struct TabContextMenuPresenter: NSViewRepresentable {
+struct TabContextMenuPresenter: NSViewRepresentable {
     let snapshot: TabContextMenuSnapshot
     let onContextAction: (TabContextAction) -> Void
     let onMoveDestination: (String) -> Void

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -98,6 +98,10 @@ public final class BonsplitController {
     /// When set, the host owns the full toggle and should return whether it succeeded.
     @ObservationIgnored public var onTabZoomToggleRequest: (@MainActor (_ tabId: TabID, _ paneId: PaneID) -> Bool)?
 
+    /// Called when the user explicitly requests to toggle full-width-tab mode from tab chrome.
+    /// When set, the host owns the full toggle and should return whether it succeeded.
+    @ObservationIgnored public var onTabFullWidthToggleRequest: (@MainActor (_ tabId: TabID, _ paneId: PaneID) -> Bool)?
+
     // MARK: - Internal State
 
     internal var internalController: SplitViewController
@@ -216,6 +220,11 @@ public final class BonsplitController {
 
     /// Request the delegate to handle a tab context-menu action.
     public func requestTabContextAction(_ action: TabContextAction, for tabId: TabID, inPane pane: PaneID) {
+        if action == .toggleFullWidthTab {
+            _ = requestTabFullWidthToggle(for: tabId, inPane: pane)
+            return
+        }
+
         guard let tab = tab(tabId) else { return }
         delegate?.splitTabBar(self, didRequestTabContextAction: action, for: tab, inPane: pane)
     }
@@ -735,6 +744,18 @@ public final class BonsplitController {
         guard let paneState = internalController.rootNode.findPane(pane) else { return false }
         paneState.isFullWidthTabMode.toggle()
         return paneState.isFullWidthTabMode
+    }
+
+    /// Request a tab-chrome full-width-tab toggle for a specific tab.
+    /// Hosts can intercept this to run their own focus/layout reconciliation.
+    @discardableResult
+    public func requestTabFullWidthToggle(for tabId: TabID, inPane paneId: PaneID) -> Bool {
+        guard let (pane, _) = findTabInternal(tabId),
+              pane.id == paneId else { return false }
+        if let onTabFullWidthToggleRequest {
+            return onTabFullWidthToggleRequest(tabId, paneId)
+        }
+        return toggleFullWidthTabMode(inPane: paneId)
     }
 
     // MARK: - Context Menu Shortcut Hints

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -752,6 +752,9 @@ public final class BonsplitController {
     public func requestTabFullWidthToggle(for tabId: TabID, inPane paneId: PaneID) -> Bool {
         guard let (pane, _) = findTabInternal(tabId),
               pane.id == paneId else { return false }
+        if pane.selectedTabId != tabId.id {
+            selectTab(tabId)
+        }
         if let onTabFullWidthToggleRequest {
             return onTabFullWidthToggleRequest(tabId, paneId)
         }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -694,6 +694,46 @@ public final class BonsplitController {
         return togglePaneZoom(inPane: paneId)
     }
 
+    // MARK: - Full Width Tab Mode
+
+    /// Pane IDs whose tab chrome is currently rendered in full-width-tab mode.
+    public var fullWidthTabModePaneIds: [PaneID] {
+        internalController.rootNode.allPanes
+            .filter(\.isFullWidthTabMode)
+            .map(\.id)
+    }
+
+    /// Set full-width-tab mode for a pane.
+    ///
+    /// - Parameters:
+    ///   - enabled: Whether the pane should render the selected tab as a full-width title header.
+    ///   - pane: The pane to update.
+    /// - Returns: `true` when the pane exists and was updated; otherwise `false`.
+    @discardableResult
+    public func setFullWidthTabMode(_ enabled: Bool, inPane pane: PaneID) -> Bool {
+        guard let paneState = internalController.rootNode.findPane(pane) else { return false }
+        paneState.isFullWidthTabMode = enabled
+        return true
+    }
+
+    /// Return whether a pane is currently in full-width-tab mode.
+    ///
+    /// Unknown panes are treated as off and return `false`.
+    public func isFullWidthTabMode(inPane pane: PaneID) -> Bool {
+        internalController.rootNode.findPane(pane)?.isFullWidthTabMode ?? false
+    }
+
+    /// Toggle full-width-tab mode for a pane.
+    ///
+    /// - Parameter pane: The pane to toggle.
+    /// - Returns: The new mode state when the pane exists. Returns `false` without mutating state when the pane is unknown.
+    @discardableResult
+    public func toggleFullWidthTabMode(inPane pane: PaneID) -> Bool {
+        guard let paneState = internalController.rootNode.findPane(pane) else { return false }
+        paneState.isFullWidthTabMode.toggle()
+        return paneState.isFullWidthTabMode
+    }
+
     // MARK: - Context Menu Shortcut Hints
 
     /// Keyboard shortcuts to display in tab context menus, keyed by context action.

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -21,6 +21,7 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case markAsRead
     case markAsUnread
     case toggleZoom
+    case toggleFullWidthTab
     case forkConversation
     case forkConversationRight
     case forkConversationLeft

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -17,6 +17,8 @@
 "tabContext.audioMutedAccessibility" = "Muted";
 "tabContext.exitZoom" = "Exit Zoom";
 "tabContext.zoomPane" = "Zoom Pane";
+"tabContext.enterFullWidthTab" = "Full Width Tab";
+"tabContext.exitFullWidthTab" = "Exit Full Width Tab";
 "tabContext.unpinTab" = "Unpin Tab";
 "tabContext.pinTab" = "Pin Tab";
 "tabContext.markTabAsRead" = "Mark Tab as Read";

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "tabContext.zoomPane" = "Zoom Pane";
 "tabContext.enterFullWidthTab" = "Full Width Tab";
 "tabContext.exitFullWidthTab" = "Exit Full Width Tab";
+"tabContext.switchTab" = "Switch Tab";
+"tabContext.paneActions" = "Pane Actions";
 "tabContext.unpinTab" = "Unpin Tab";
 "tabContext.pinTab" = "Pin Tab";
 "tabContext.markTabAsRead" = "Mark Tab as Read";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -19,6 +19,8 @@
 "tabContext.zoomPane" = "ペインをズーム";
 "tabContext.enterFullWidthTab" = "タブを全幅表示";
 "tabContext.exitFullWidthTab" = "全幅表示を解除";
+"tabContext.switchTab" = "タブを切り替え";
+"tabContext.paneActions" = "ペイン操作";
 "tabContext.unpinTab" = "タブのピン留めを解除";
 "tabContext.pinTab" = "タブをピン留め";
 "tabContext.markTabAsRead" = "タブを既読にする";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -17,6 +17,8 @@
 "tabContext.audioMutedAccessibility" = "ミュート中";
 "tabContext.exitZoom" = "ズームを終了";
 "tabContext.zoomPane" = "ペインをズーム";
+"tabContext.enterFullWidthTab" = "タブを全幅表示";
+"tabContext.exitFullWidthTab" = "全幅表示を解除";
 "tabContext.unpinTab" = "タブのピン留めを解除";
 "tabContext.pinTab" = "タブをピン留め";
 "tabContext.markTabAsRead" = "タブを既読にする";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3960,7 +3960,7 @@ final class BonsplitTests: XCTestCase {
 
         let size = NSSize(width: 160, height: TabBarMetrics.barHeight)
         let hostingView = NSHostingView(
-            rootView: FullWidthTabHeaderView(pane: pane, isFocused: isFocused)
+            rootView: FullWidthTabHeaderView(pane: pane, isFocused: isFocused, showSplitButtons: true)
                 .environment(controller)
                 .environment(controller.internalController)
         )

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1907,7 +1907,8 @@ final class BonsplitTests: XCTestCase {
                 hasSplits: false,
                 shortcuts: [:]
             ),
-            moveDestinationsProvider: { [] }
+            moveDestinationsProvider: { [] },
+            forkConversationOpenAvailabilityProvider: { nil }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1943,7 +1944,8 @@ final class BonsplitTests: XCTestCase {
                 hasSplits: false,
                 shortcuts: [:]
             ),
-            moveDestinationsProvider: { [] }
+            moveDestinationsProvider: { [] },
+            forkConversationOpenAvailabilityProvider: { nil }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -2236,6 +2238,25 @@ final class BonsplitTests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 0, visibility: .multipleTabs)))
         XCTAssertFalse(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 1, visibility: .multipleTabs)))
         XCTAssertTrue(try XCTUnwrap(renderedPaneContainerHasTabBar(tabCount: 2, visibility: .multipleTabs)))
+    }
+
+    @MainActor
+    func testFullWidthTabModeRespectsPaneTabBarVisibility() throws {
+        XCTAssertEqual(
+            try XCTUnwrap(renderedFullWidthPaneChromeAlpha(tabCount: 1, visibility: .always)),
+            1,
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(renderedFullWidthPaneChromeAlpha(tabCount: 1, visibility: .multipleTabs)),
+            0,
+            accuracy: 0.01
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(renderedFullWidthPaneChromeAlpha(tabCount: 2, visibility: .multipleTabs)),
+            1,
+            accuracy: 0.01
+        )
     }
 
     func testIconSaturationKeepsRasterFaviconInColorWhenInactive() {
@@ -2855,6 +2876,18 @@ final class BonsplitTests: XCTestCase {
         guard let focusedSaturation = renderedTabBarIndicatorSaturation(isFocused: true),
               let unfocusedSaturation = renderedTabBarIndicatorSaturation(isFocused: false) else {
             XCTFail("Expected rendered tab bar colors")
+            return
+        }
+
+        XCTAssertGreaterThan(focusedSaturation, 0.4)
+        XCTAssertLessThan(unfocusedSaturation, 0.1)
+    }
+
+    @MainActor
+    func testFullWidthHeaderIndicatorUsesFocusedAccent() {
+        guard let focusedSaturation = renderedFullWidthHeaderIndicatorSaturation(isFocused: true),
+              let unfocusedSaturation = renderedFullWidthHeaderIndicatorSaturation(isFocused: false) else {
+            XCTFail("Expected rendered full-width header colors")
             return
         }
 
@@ -3882,6 +3915,47 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    private func renderedFullWidthHeaderIndicatorSaturation(isFocused: Bool) -> CGFloat? {
+        let controller = BonsplitController()
+        guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
+        let tab = TabItem(title: "", icon: nil)
+        pane.tabs = [tab]
+        pane.selectedTabId = tab.id
+        pane.isFullWidthTabMode = true
+
+        let size = NSSize(width: 160, height: TabBarMetrics.barHeight)
+        let hostingView = NSHostingView(
+            rootView: FullWidthTabHeaderView(pane: pane, isFocused: isFocused)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else { return nil }
+
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        let sampleRect = NSRect(x: 4, y: 0, width: size.width - 8, height: 4)
+        return maximumSaturation(in: hostingView, sampleRect: sampleRect)
+    }
+
+    @MainActor
     private func renderedTabBarIndicatorWidth(isFocused: Bool) -> CGFloat? {
         renderedTabBarValue(isFocused: isFocused) { hostingView in
             let sampleRect = NSRect(x: 0, y: 0, width: 80, height: 4)
@@ -4582,6 +4656,63 @@ final class BonsplitTests: XCTestCase {
             in: hostingView,
             timeout: 0.1
         ) != nil
+    }
+
+    @MainActor
+    private func renderedFullWidthPaneChromeAlpha(
+        tabCount: Int,
+        visibility: TabBarVisibility
+    ) -> CGFloat? {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(tabBarVisibility: visibility)
+        )
+        guard let pane = controller.internalController.rootNode.allPanes.first else { return nil }
+
+        let tabs = (0..<tabCount).map { index in
+            TabItem(title: "Tab \(index + 1)", icon: nil)
+        }
+        pane.tabs = tabs
+        pane.selectedTabId = tabs.first?.id
+        pane.isFullWidthTabMode = true
+
+        let size = NSSize(width: 320, height: 180)
+        let hostingView = NSHostingView(
+            rootView: PaneContainerView(
+                pane: pane,
+                controller: controller.internalController,
+                contentBuilder: { _, _ in Color.clear },
+                emptyPaneBuilder: { _ in Color.clear },
+                showSplitButtons: false,
+                tabBarVisibility: visibility
+            )
+            .environment(controller)
+            .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else { return nil }
+
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        return renderedColorInViewCoordinates(in: hostingView, at: NSPoint(x: 4, y: 0))?
+            .usingColorSpace(.sRGB)?
+            .alphaComponent
     }
 
     @MainActor

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1753,6 +1753,20 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testRequestTabContextActionSelectsTargetTabBeforeFullWidthToggle() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let firstTab = controller.createTab(title: "First", kind: "terminal")!
+        let secondTab = controller.createTab(title: "Second", kind: "terminal")!
+        controller.selectTab(firstTab)
+
+        controller.requestTabContextAction(.toggleFullWidthTab, for: secondTab, inPane: pane)
+
+        XCTAssertEqual(controller.selectedTab(inPane: pane)?.id, secondTab)
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: pane))
+    }
+
+    @MainActor
     func testRequestTabContextActionUsesFullWidthTabToggleHandlerWhenSet() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1738,6 +1738,41 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testRequestTabContextActionTogglesFullWidthTabModeWithoutDelegate() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Test", kind: "terminal")!
+
+        controller.requestTabContextAction(.toggleFullWidthTab, for: tabId, inPane: pane)
+
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: pane))
+
+        controller.requestTabContextAction(.toggleFullWidthTab, for: tabId, inPane: pane)
+
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: pane))
+    }
+
+    @MainActor
+    func testRequestTabContextActionUsesFullWidthTabToggleHandlerWhenSet() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let tabId = controller.createTab(title: "Test", kind: "terminal")!
+        var requestedTab: TabID?
+        var requestedPane: PaneID?
+        controller.onTabFullWidthToggleRequest = { tab, pane in
+            requestedTab = tab
+            requestedPane = pane
+            return true
+        }
+
+        controller.requestTabContextAction(.toggleFullWidthTab, for: tabId, inPane: pane)
+
+        XCTAssertEqual(requestedTab, tabId)
+        XCTAssertEqual(requestedPane, pane)
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: pane))
+    }
+
+    @MainActor
     func testRequestTabMoveDestinationForwardsToDelegate() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1594,6 +1594,66 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testFullWidthTabModeAPITracksStateAndUnknownPanesAreSafe() {
+        let controller = BonsplitController()
+        let pane = controller.focusedPaneId!
+        let unknownPane = PaneID()
+
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: pane))
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: unknownPane))
+        XCTAssertFalse(controller.setFullWidthTabMode(true, inPane: unknownPane))
+        XCTAssertFalse(controller.toggleFullWidthTabMode(inPane: unknownPane))
+
+        XCTAssertTrue(controller.setFullWidthTabMode(true, inPane: pane))
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: pane))
+
+        XCTAssertFalse(controller.toggleFullWidthTabMode(inPane: pane))
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: pane))
+
+        XCTAssertTrue(controller.toggleFullWidthTabMode(inPane: pane))
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: pane))
+    }
+
+    @MainActor
+    func testFullWidthTabModeIsIndependentPerPaneAndListed() {
+        let controller = BonsplitController()
+        let firstPane = controller.focusedPaneId!
+        guard let secondPane = controller.splitPane(firstPane, orientation: .horizontal) else {
+            return XCTFail("Expected splitPane to create a new pane")
+        }
+
+        XCTAssertTrue(controller.setFullWidthTabMode(true, inPane: firstPane))
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: secondPane))
+        XCTAssertEqual(controller.fullWidthTabModePaneIds, [firstPane])
+
+        XCTAssertTrue(controller.setFullWidthTabMode(true, inPane: secondPane))
+        XCTAssertEqual(Set(controller.fullWidthTabModePaneIds), Set([firstPane, secondPane]))
+
+        XCTAssertTrue(controller.setFullWidthTabMode(false, inPane: firstPane))
+        XCTAssertEqual(controller.fullWidthTabModePaneIds, [secondPane])
+    }
+
+    @MainActor
+    func testFullWidthTabModeDiesWithClosedPane() {
+        let controller = BonsplitController()
+        let firstPane = controller.focusedPaneId!
+        guard let closingPane = controller.splitPane(firstPane, orientation: .horizontal) else {
+            return XCTFail("Expected splitPane to create a new pane")
+        }
+
+        XCTAssertTrue(controller.setFullWidthTabMode(true, inPane: closingPane))
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: closingPane))
+
+        XCTAssertTrue(controller.closePane(closingPane))
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: closingPane))
+
+        guard let recreatedPane = controller.splitPane(firstPane, orientation: .horizontal) else {
+            return XCTFail("Expected splitPane to create another pane")
+        }
+        XCTAssertFalse(controller.isFullWidthTabMode(inPane: recreatedPane))
+    }
+
+    @MainActor
     func testRequestTabContextActionForwardsToDelegate() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!
@@ -1761,6 +1821,78 @@ final class BonsplitTests: XCTestCase {
 
         XCTAssertTrue(menu.items.contains { $0.title == "Unmute Tab" })
         XCTAssertFalse(menu.items.contains { $0.title == "Mute Tab" })
+    }
+
+    @MainActor
+    func testTabContextMenuCreatesFullWidthTabToggle() throws {
+        let target = TabContextMenuActionTarget()
+        var selectedAction: TabContextAction?
+        target.onContextAction = { selectedAction = $0 }
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: TabContextMenuState(
+                isPinned: false,
+                isUnread: false,
+                isBrowser: false,
+                isAudioMuted: false,
+                isTerminal: true,
+                hasCustomTitle: false,
+                canCloseToLeft: false,
+                canCloseToRight: false,
+                canCloseOthers: false,
+                canMoveToNewWorkspace: false,
+                canMoveToLeftPane: false,
+                canMoveToRightPane: false,
+                canForkConversation: false,
+                forkConversationDefaultAction: .forkConversationRight,
+                isZoomed: false,
+                isFullWidthTabMode: false,
+                hasSplits: false,
+                shortcuts: [:]
+            ),
+            moveDestinationsProvider: { [] }
+        )
+
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+        let item = try XCTUnwrap(menu.items.first { $0.title == "Full Width Tab" })
+        target.performContextAction(item)
+
+        XCTAssertEqual(selectedAction, .toggleFullWidthTab)
+        XCTAssertFalse(menu.items.contains { $0.title == "Exit Full Width Tab" })
+    }
+
+    @MainActor
+    func testTabContextMenuUsesExitFullWidthTabTitleWhenEnabled() {
+        let target = TabContextMenuActionTarget()
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: TabContextMenuState(
+                isPinned: false,
+                isUnread: false,
+                isBrowser: false,
+                isAudioMuted: false,
+                isTerminal: true,
+                hasCustomTitle: false,
+                canCloseToLeft: false,
+                canCloseToRight: false,
+                canCloseOthers: false,
+                canMoveToNewWorkspace: false,
+                canMoveToLeftPane: false,
+                canMoveToRightPane: false,
+                canForkConversation: false,
+                forkConversationDefaultAction: .forkConversationRight,
+                isZoomed: false,
+                isFullWidthTabMode: true,
+                hasSplits: false,
+                shortcuts: [:]
+            ),
+            moveDestinationsProvider: { [] }
+        )
+
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+
+        XCTAssertTrue(menu.items.contains { $0.title == "Exit Full Width Tab" })
+        XCTAssertFalse(menu.items.contains { $0.title == "Full Width Tab" })
     }
 
     @MainActor

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1654,6 +1654,60 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testBeginTabDragTracksStateAndCancelClearsMatchingGeneration() {
+        let controller = SplitViewController()
+        let pane = controller.focusedPane!
+        let tab = pane.selectedTab!
+
+        let generation = controller.beginTabDrag(tab, from: pane.id)
+
+        XCTAssertEqual(controller.dragGeneration, generation)
+        XCTAssertEqual(controller.draggingTab?.id, tab.id)
+        XCTAssertEqual(controller.dragSourcePaneId, pane.id)
+        XCTAssertEqual(controller.activeDragTab?.id, tab.id)
+        XCTAssertEqual(controller.activeDragSourcePaneId, pane.id)
+
+        controller.cancelTabDragIfGenerationMatches(generation)
+
+        XCTAssertNil(controller.draggingTab)
+        XCTAssertNil(controller.dragSourcePaneId)
+        XCTAssertNil(controller.activeDragTab)
+        XCTAssertNil(controller.activeDragSourcePaneId)
+    }
+
+    @MainActor
+    func testCancelTabDragIgnoresStaleGeneration() {
+        let controller = SplitViewController()
+        let firstPane = controller.focusedPane!
+        let firstTab = firstPane.selectedTab!
+
+        let staleGeneration = controller.beginTabDrag(firstTab, from: firstPane.id)
+
+        controller.splitPaneWithTab(
+            firstPane.id,
+            orientation: .horizontal,
+            tab: TabItem(title: "Second"),
+            insertFirst: false
+        )
+        guard let secondPaneId = controller.rootNode.allPaneIds.first(where: { $0 != firstPane.id }),
+              let secondPane = controller.rootNode.findPane(secondPaneId),
+              let secondTab = secondPane.selectedTab else {
+            return XCTFail("Expected splitPane to create another pane with a selected tab")
+        }
+
+        let currentGeneration = controller.beginTabDrag(secondTab, from: secondPane.id)
+        XCTAssertGreaterThan(currentGeneration, staleGeneration)
+
+        controller.cancelTabDragIfGenerationMatches(staleGeneration)
+
+        XCTAssertEqual(controller.dragGeneration, currentGeneration)
+        XCTAssertEqual(controller.draggingTab?.id, secondTab.id)
+        XCTAssertEqual(controller.dragSourcePaneId, secondPane.id)
+        XCTAssertEqual(controller.activeDragTab?.id, secondTab.id)
+        XCTAssertEqual(controller.activeDragSourcePaneId, secondPane.id)
+    }
+
+    @MainActor
     func testRequestTabContextActionForwardsToDelegate() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!


### PR DESCRIPTION
Adds a per-pane `fullWidthTabMode`: when enabled, the pane header renders a prominent full-width title of the selected tab instead of the tab strip. Same height as the tab bar, live title updates, subtle index/count badge when more tabs exist, right-click anywhere on the header opens the selected tab's context menu (the exit path), no new-tab button. Adds `TabContextAction.toggleFullWidthTab`, per-pane controller API (`setFullWidthTabMode`/`isFullWidthTabMode`/`toggleFullWidthTabMode`/`fullWidthTabModePaneIds`), en+ja strings, and tests (163 passing).

Consumed by the cmux PR that wires this to the command palette and tab context menu (link added there once open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785900517&installation_id=133855650&pr_number=159&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F159&signature=0e983a2f1b0f500de5b73a4b74c01758e4ffaa9823c842d2abdac573cf0d8a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-pane full-width tab mode that replaces the tab strip with a prominent, full-width title header for the selected tab. The header matches tab chrome, supports drag & drop, keeps key tab/pane actions, and toggling from context now selects the target tab first; it’s opt-in per pane.

- **New Features**
  - Header shows the selected tab’s title and icon with live updates, adds an index/total badge, aligns with tab bar chrome (height, active indicator, separator), and respects tab bar visibility; no new‑tab button.
  - Preserves actions: right‑click opens the selected tab’s context menu with a `toggleFullWidthTab` item (label switches between “Full Width Tab” and “Exit Full Width Tab”); adds a tab switcher menu via the badge and a pane actions menu for configured split buttons (`BonsplitConfiguration.splitButtons`).
  - Dragging from the header starts a tab drag with preview; dropping `.tabTransfer`/`.fileURL` appends at the end with a focus‑aware hover highlight. A shared `SplitViewController+TabDrag` helper is used by the header, tab strip, and manual reorder.
  - `BonsplitController` handles `TabContextAction.toggleFullWidthTab`; adds `onTabFullWidthToggleRequest` for hosts, plus per‑pane APIs: `setFullWidthTabMode(_:inPane:)`, `isFullWidthTabMode(inPane:)`, `toggleFullWidthTabMode(inPane:)`, `fullWidthTabModePaneIds`; en/ja strings and tests.

- **Bug Fixes**
  - Toggling full‑width from a tab’s context menu selects that tab first to keep state consistent.
  - Cancelled tab drags clear state and restore one‑shot event monitor cleanup to prevent leaks.

<sup>Written for commit f83584b933feb603d8c87b1f5d229f02e692849d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Full Width Tab Mode with a dedicated full-width selected-tab header layout when enabled for a pane.
  * Added a context-menu action to enter/exit full-width tab mode; tab title/icon presentation updates accordingly.
  * Exposed controller APIs to query, set, and toggle full-width mode per pane, plus a list of pane IDs currently in that mode.
* **Bug Fixes**
  * Full-width mode state is now reliably cleared when a pane is closed, including after split replacements.
* **Localization**
  * Added translations for “Full Width Tab” and “Exit Full Width Tab” in supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->