### PR TITLE
Skip no-op tab metadata updates

### DIFF
--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -264,6 +264,20 @@ public final class BonsplitController {
         isPinned: Bool? = nil
     ) {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return }
+        let currentTab = pane.tabs[tabIndex]
+        let didChange =
+            title.map { currentTab.title != $0 } ?? false ||
+            icon.map { currentTab.icon != $0 } ?? false ||
+            iconImageData.map { currentTab.iconImageData != $0 } ?? false ||
+            kind.map { currentTab.kind != $0 } ?? false ||
+            hasCustomTitle.map { currentTab.hasCustomTitle != $0 } ?? false ||
+            isDirty.map { currentTab.isDirty != $0 } ?? false ||
+            showsNotificationBadge.map { currentTab.showsNotificationBadge != $0 } ?? false ||
+            isLoading.map { currentTab.isLoading != $0 } ?? false ||
+            isAudioMuted.map { currentTab.isAudioMuted != $0 } ?? false ||
+            isAudioPlaying.map { currentTab.isAudioPlaying != $0 } ?? false ||
+            isPinned.map { currentTab.isPinned != $0 } ?? false
+        guard didChange else { return }
 
         if let title = title {
             pane.tabs[tabIndex].title = title

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -145,6 +145,10 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    private final class ObservationInvalidationFlag: @unchecked Sendable {
+        var didInvalidate = false
+    }
+
     @MainActor
     func testControllerCreation() {
         let controller = BonsplitController()
@@ -195,11 +199,11 @@ final class BonsplitTests: XCTestCase {
             isPinned: true
         )!
 
-        var didInvalidate = false
+        let invalidationFlag = ObservationInvalidationFlag()
         withObservationTracking {
             _ = controller.tab(tabId)
         } onChange: {
-            didInvalidate = true
+            invalidationFlag.didInvalidate = true
         }
 
         controller.updateTab(
@@ -217,7 +221,7 @@ final class BonsplitTests: XCTestCase {
         )
 
         XCTAssertFalse(
-            didInvalidate,
+            invalidationFlag.didInvalidate,
             "Updating a tab with identical metadata should not invalidate SwiftUI observers of tab metadata."
         )
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Bonsplit
 import AppKit
+import Observation
 import QuartzCore
 import SwiftUI
 
@@ -176,6 +177,49 @@ final class BonsplitTests: XCTestCase {
         let tab = controller.tab(tabId)
         XCTAssertEqual(tab?.title, "Updated")
         XCTAssertEqual(tab?.isDirty, true)
+    }
+
+    @MainActor
+    func testNoopTabUpdateDoesNotInvalidateObservedTabMetadata() {
+        let controller = BonsplitController()
+        let tabId = controller.createTab(
+            title: "Original",
+            hasCustomTitle: true,
+            icon: "doc",
+            kind: "terminal",
+            isDirty: true,
+            showsNotificationBadge: true,
+            isLoading: true,
+            isAudioMuted: true,
+            isAudioPlaying: true,
+            isPinned: true
+        )!
+
+        var didInvalidate = false
+        withObservationTracking {
+            _ = controller.tab(tabId)
+        } onChange: {
+            didInvalidate = true
+        }
+
+        controller.updateTab(
+            tabId,
+            title: "Original",
+            icon: .some("doc"),
+            kind: .some("terminal"),
+            hasCustomTitle: true,
+            isDirty: true,
+            showsNotificationBadge: true,
+            isLoading: true,
+            isAudioMuted: true,
+            isAudioPlaying: true,
+            isPinned: true
+        )
+
+        XCTAssertFalse(
+            didInvalidate,
+            "Updating a tab with identical metadata should not invalidate SwiftUI observers of tab metadata."
+        )
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- add a regression test proving no-op tab metadata updates should not invalidate observation readers
- return early from `BonsplitController.updateTab` when every supplied field matches current metadata

## Verification
- `swift test --filter BonsplitTests/testNoopTabUpdateDoesNotInvalidateObservedTabMetadata`
- `swift test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786044038&installation_id=133855650&pr_number=160&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F160&signature=94490c1d54443d112e64875069ded8ee9112213208b8aaa9fcc5d1ec81d5b6e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip no-op tab metadata updates so identical values no longer invalidate observers or mutate state. This prevents needless SwiftUI observation churn and redundant work.

- **Bug Fixes**
  - Early return in `BonsplitController.updateTab` when all supplied fields match current metadata.
  - Added regression test `BonsplitTests/testNoopTabUpdateDoesNotInvalidateObservedTabMetadata` to ensure observers aren’t invalidated on no-op updates.

<sup>Written for commit 89939c0ab2b08d3c5e65ce998edc869125394355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

