### PR TITLE
Add TabItem.iconAsset: host asset-catalog icons in the fixed tab icon slot

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -20,6 +20,7 @@ struct TabItem: Identifiable, Hashable, Codable {
     var hasCustomTitle: Bool
     var icon: String?
     var iconImageData: Data?
+    var iconAsset: String?
     var kind: String?
     var isDirty: Bool
     var showsNotificationBadge: Bool
@@ -36,6 +37,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         hasCustomTitle: Bool = false,
         icon: String? = "doc.text",
         iconImageData: Data? = nil,
+        iconAsset: String? = nil,
         kind: String? = nil,
         isDirty: Bool = false,
         showsNotificationBadge: Bool = false,
@@ -49,6 +51,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.hasCustomTitle = hasCustomTitle
         self.icon = icon
         self.iconImageData = iconImageData
+        self.iconAsset = iconAsset
         self.kind = kind
         self.isDirty = isDirty
         self.showsNotificationBadge = showsNotificationBadge
@@ -72,6 +75,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         case hasCustomTitle
         case icon
         case iconImageData
+        case iconAsset
         case kind
         case isDirty
         case showsNotificationBadge
@@ -88,6 +92,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.hasCustomTitle = try c.decodeIfPresent(Bool.self, forKey: .hasCustomTitle) ?? false
         self.icon = try c.decodeIfPresent(String.self, forKey: .icon)
         self.iconImageData = try c.decodeIfPresent(Data.self, forKey: .iconImageData)
+        self.iconAsset = try c.decodeIfPresent(String.self, forKey: .iconAsset)
         self.kind = try c.decodeIfPresent(String.self, forKey: .kind)
         self.isDirty = try c.decodeIfPresent(Bool.self, forKey: .isDirty) ?? false
         self.showsNotificationBadge = try c.decodeIfPresent(Bool.self, forKey: .showsNotificationBadge) ?? false
@@ -104,6 +109,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         try c.encode(hasCustomTitle, forKey: .hasCustomTitle)
         try c.encodeIfPresent(icon, forKey: .icon)
         try c.encodeIfPresent(iconImageData, forKey: .iconImageData)
+        try c.encodeIfPresent(iconAsset, forKey: .iconAsset)
         try c.encodeIfPresent(kind, forKey: .kind)
         try c.encode(isDirty, forKey: .isDirty)
         try c.encode(showsNotificationBadge, forKey: .showsNotificationBadge)

--- a/Sources/Bonsplit/Internal/TabGeometryDebugLog.swift
+++ b/Sources/Bonsplit/Internal/TabGeometryDebugLog.swift
@@ -1,0 +1,183 @@
+import CoreGraphics
+import Foundation
+
+#if DEBUG
+enum TabGeometryDebugLog {
+    private static let queue = DispatchQueue(label: "com.bonsplit.tab-geometry-debug-log")
+    private static let sink = TabGeometryDebugLogSink()
+
+    static func geometry(
+        tabId: UUID,
+        which: String,
+        frame: CGRect,
+        tabWidth: CGFloat?,
+        tab: TabItem,
+        isSelected: Bool,
+        showsShortcutHint: Bool
+    ) {
+        queue.async {
+            sink.write(
+                tabId: tabId,
+                event: "geom",
+                fields: [
+                    "which=\(escaped(which))",
+                    "x=\(format(frame.origin.x))",
+                    "y=\(format(frame.origin.y))",
+                    "w=\(format(frame.width))",
+                    "tabW=\(format(tabWidth))",
+                    "title=\(escaped(truncated(tab.title)))",
+                    "icon=\(escaped(optional: tab.icon))",
+                    "iconAsset=\(escaped(optional: tab.iconAsset))",
+                    "loading=\(tab.isLoading)",
+                    "badge=\(tab.showsNotificationBadge)",
+                    "sel=\(isSelected)",
+                    "hint=\(showsShortcutHint)",
+                ]
+            )
+        }
+    }
+
+    static func stateChange(
+        tabId: UUID,
+        field: String,
+        oldValue: String,
+        newValue: String,
+        tab: TabItem,
+        isSelected: Bool,
+        showsShortcutHint: Bool
+    ) {
+        queue.async {
+            sink.write(
+                tabId: tabId,
+                event: "state",
+                fields: [
+                    "field=\(escaped(field))",
+                    "old=\(escaped(oldValue))",
+                    "new=\(escaped(newValue))",
+                    "change=\(escaped(oldValue))->\(escaped(newValue))",
+                    "title=\(escaped(truncated(tab.title)))",
+                    "icon=\(escaped(optional: tab.icon))",
+                    "iconAsset=\(escaped(optional: tab.iconAsset))",
+                    "loading=\(tab.isLoading)",
+                    "badge=\(tab.showsNotificationBadge)",
+                    "sel=\(isSelected)",
+                    "hint=\(showsShortcutHint)",
+                ]
+            )
+        }
+    }
+
+    static func optional(_ value: String?) -> String {
+        value ?? "<nil>"
+    }
+
+    static func optional(_ value: Bool?) -> String {
+        value.map(String.init) ?? "<nil>"
+    }
+
+    private static func format(_ value: CGFloat?) -> String {
+        guard let value else { return "unknown" }
+        return String(format: "%.3f", Double(value))
+    }
+
+    private static func truncated(_ value: String) -> String {
+        String(value.prefix(24))
+    }
+
+    private static func escaped(optional value: String?) -> String {
+        escaped(optional(value))
+    }
+
+    private static func escaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\t", with: "\\t")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+    }
+}
+
+private final class TabGeometryDebugLogSink {
+    private let path = "/tmp/cmux-tab-geometry.log"
+    private var handle: FileHandle?
+    private var wroteHeader = false
+    private let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter
+    }()
+
+    func write(tabId: UUID, event: String, fields: [String]) {
+        writeHeaderIfNeeded()
+        let lineFields = [
+            "ts=\(timestampFormatter.string(from: Date()))",
+            "tab=\(String(tabId.uuidString.prefix(8)))",
+            "ev=\(event)",
+        ] + fields
+        append(lineFields.joined(separator: "\t"))
+    }
+
+    private func writeHeaderIfNeeded() {
+        guard !wroteHeader else { return }
+        wroteHeader = true
+        append([
+            "ts=\(timestampFormatter.string(from: Date()))",
+            "tab=session",
+            "ev=session",
+            "pid=\(ProcessInfo.processInfo.processIdentifier)",
+            "bundle=\(Bundle.main.bundleIdentifier ?? "<nil>")",
+        ].joined(separator: "\t"))
+    }
+
+    private func append(_ line: String) {
+        guard let data = (line + "\n").data(using: .utf8),
+              let handle = fileHandle() else {
+            return
+        }
+        try? handle.write(contentsOf: data)
+    }
+
+    private func fileHandle() -> FileHandle? {
+        if let handle { return handle }
+        if !FileManager.default.fileExists(atPath: path) {
+            _ = FileManager.default.createFile(atPath: path, contents: nil)
+        }
+        guard let opened = try? FileHandle(forWritingTo: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        _ = try? opened.seekToEnd()
+        handle = opened
+        return opened
+    }
+}
+#else
+enum TabGeometryDebugLog {
+    static func geometry(
+        tabId: UUID,
+        which: String,
+        frame: CGRect,
+        tabWidth: CGFloat?,
+        tab: TabItem,
+        isSelected: Bool,
+        showsShortcutHint: Bool
+    ) {}
+
+    static func stateChange(
+        tabId: UUID,
+        field: String,
+        oldValue: String,
+        newValue: String,
+        tab: TabItem,
+        isSelected: Bool,
+        showsShortcutHint: Bool
+    ) {}
+
+    static func optional(_ value: String?) -> String {
+        value ?? "<nil>"
+    }
+
+    static func optional(_ value: Bool?) -> String {
+        value.map(String.init) ?? "<nil>"
+    }
+}
+#endif

--- a/Sources/Bonsplit/Internal/TabGeometryDebugLog.swift
+++ b/Sources/Bonsplit/Internal/TabGeometryDebugLog.swift
@@ -3,6 +3,8 @@ import Foundation
 
 #if DEBUG
 enum TabGeometryDebugLog {
+    static let isEnabled = ProcessInfo.processInfo.environment["CMUX_TAB_GEOMETRY_LOG"] != nil
+
     private static let queue = DispatchQueue(label: "com.bonsplit.tab-geometry-debug-log")
     private static let sink = TabGeometryDebugLogSink()
 
@@ -15,6 +17,7 @@ enum TabGeometryDebugLog {
         isSelected: Bool,
         showsShortcutHint: Bool
     ) {
+        guard isEnabled else { return }
         queue.async {
             sink.write(
                 tabId: tabId,
@@ -46,6 +49,7 @@ enum TabGeometryDebugLog {
         isSelected: Bool,
         showsShortcutHint: Bool
     ) {
+        guard isEnabled else { return }
         queue.async {
             sink.write(
                 tabId: tabId,
@@ -152,6 +156,8 @@ private final class TabGeometryDebugLogSink {
 }
 #else
 enum TabGeometryDebugLog {
+    static let isEnabled = false
+
     static func geometry(
         tabId: UUID,
         which: String,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -487,6 +487,11 @@ struct TabItemView: View {
                 FaviconIconView(image: image)
                     .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
                     .clipped()
+            } else if let iconAsset = tab.iconAsset {
+                Image(iconAsset, bundle: .main)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: compactMarkSize, height: compactMarkSize, alignment: .center)
             } else if let iconName = tab.icon {
                 if iconName == "globe", !showGlobeFallback {
                     // Avoid a distracting "globe -> favicon" flash: show a neutral placeholder
@@ -623,6 +628,11 @@ struct TabItemView: View {
         TabBarMetrics.closeIconSize * fontScale
     }
 
+    /// Optical mark size for compact glyphs and host-provided asset icons.
+    private var compactMarkSize: CGFloat {
+        max(10, TabBarMetrics.iconSize - 2.5) * fontScale
+    }
+
     /// Spacing between the leading icon and the title, scaled to the font.
     private var scaledContentSpacing: CGFloat {
         TabBarMetrics.contentSpacing * fontScale
@@ -632,7 +642,7 @@ struct TabItemView: View {
         // `terminal.fill` reads visually heavier than most symbols at the same point size.
         // Keep the base sizes hardcoded to avoid cross-glyph layout shifts, then scale to the font.
         if iconName == "terminal.fill" || iconName == "terminal" || iconName == "globe" {
-            return max(10, TabBarMetrics.iconSize - 2.5) * fontScale
+            return compactMarkSize
         }
         return scaledIconSize
     }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -31,6 +31,49 @@ extension View {
             self
         }
     }
+
+    @ViewBuilder
+    func tabGeometryDebugFrame(_ onFrame: @escaping (CGRect) -> Void) -> some View {
+#if DEBUG
+        background(
+            GeometryReader { proxy in
+                let frame = proxy.frame(in: .global)
+                Color.clear
+                    .onAppear {
+                        onFrame(frame)
+                    }
+                    .onChange(of: frame) { _, newFrame in
+                        onFrame(newFrame)
+                    }
+            }
+        )
+#else
+        self
+#endif
+    }
+
+    @ViewBuilder
+    func tabGeometryDebugOnAppear(_ action: @escaping () -> Void) -> some View {
+#if DEBUG
+        onAppear(perform: action)
+#else
+        self
+#endif
+    }
+
+    @ViewBuilder
+    func tabGeometryDebugOnChange<Value: Equatable>(
+        of value: Value,
+        perform action: @escaping (Value) -> Void
+    ) -> some View {
+#if DEBUG
+        onChange(of: value) { _, newValue in
+            action(newValue)
+        }
+#else
+        self
+#endif
+    }
 }
 
 private enum TabControlShortcutHintDebugSettings {
@@ -246,6 +289,15 @@ struct TabItemView: View {
     @State private var lastLoadingStoppedAt: Date?
     @State private var renderedFaviconData: Data?
     @State private var renderedFaviconImage: NSImage?
+#if DEBUG
+    @State private var debugLastIconFrame: CGRect?
+    @State private var debugLastTitleFrame: CGRect?
+    @State private var debugLastTabFrame: CGRect?
+    @State private var debugLastTitle: String?
+    @State private var debugLastIcon: String?
+    @State private var debugLastIconAsset: String?
+    @State private var debugLastIsLoading: Bool?
+#endif
     @AppStorage(TabControlShortcutHintDebugSettings.xKey) private var controlShortcutHintXOffset = TabControlShortcutHintDebugSettings.defaultX
     @AppStorage(TabControlShortcutHintDebugSettings.yKey) private var controlShortcutHintYOffset = TabControlShortcutHintDebugSettings.defaultY
     @AppStorage(TabControlShortcutHintDebugSettings.alwaysShowKey) private var alwaysShowShortcutHints = TabControlShortcutHintDebugSettings.defaultAlwaysShow
@@ -306,12 +358,143 @@ struct TabItemView: View {
         .accessibilityValue(accessibilityValue)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .safeHelp(tab.title)
+        .tabGeometryDebugFrame { frame in
+            debugRecordTabFrame(frame)
+        }
+        .tabGeometryDebugOnAppear {
+            debugRecordInitialStateSnapshot()
+        }
+        .tabGeometryDebugOnChange(of: tab.title) { newValue in
+            debugRecordTitleStateChange(newValue)
+        }
+        .tabGeometryDebugOnChange(of: tab.icon) { newValue in
+            debugRecordIconStateChange(newValue)
+        }
+        .tabGeometryDebugOnChange(of: tab.iconAsset) { newValue in
+            debugRecordIconAssetStateChange(newValue)
+        }
+        .tabGeometryDebugOnChange(of: tab.isLoading) { newValue in
+            debugRecordIsLoadingStateChange(newValue)
+        }
     }
 
     /// Whether this tab renders in the compact icon-only style reserved for pinned
     /// browser surfaces (favicon only, no title or trailing affordances).
     private var isIconOnlyPinned: Bool {
         TabItemStyling.isIconOnlyPinned(isPinned: tab.isPinned, kind: tab.kind)
+    }
+
+    private func debugRecordTabFrame(_ frame: CGRect) {
+#if DEBUG
+        guard debugFrameChanged(debugLastTabFrame, frame) else { return }
+        debugLastTabFrame = frame
+#endif
+    }
+
+    private func debugRecordGeometry(which: String, frame: CGRect) {
+#if DEBUG
+        switch which {
+        case "icon":
+            guard debugFrameChanged(debugLastIconFrame, frame) else { return }
+            debugLastIconFrame = frame
+        case "title":
+            guard debugFrameChanged(debugLastTitleFrame, frame) else { return }
+            debugLastTitleFrame = frame
+        default:
+            return
+        }
+        TabGeometryDebugLog.geometry(
+            tabId: tab.id,
+            which: which,
+            frame: frame,
+            tabWidth: debugLastTabFrame?.width,
+            tab: tab,
+            isSelected: isSelected,
+            showsShortcutHint: showsShortcutHint
+        )
+#endif
+    }
+
+    private func debugRecordInitialStateSnapshot() {
+#if DEBUG
+        debugLastTitle = tab.title
+        debugLastIcon = tab.icon
+        debugLastIconAsset = tab.iconAsset
+        debugLastIsLoading = tab.isLoading
+#endif
+    }
+
+    private func debugRecordTitleStateChange(_ newValue: String) {
+#if DEBUG
+        let oldValue = debugLastTitle ?? tab.title
+        guard oldValue != newValue else { return }
+        debugLastTitle = newValue
+        debugRecordStateChange(field: "title", oldValue: oldValue, newValue: newValue)
+#endif
+    }
+
+    private func debugRecordIconStateChange(_ newValue: String?) {
+#if DEBUG
+        let oldValue = debugLastIcon
+        guard oldValue != newValue else { return }
+        debugLastIcon = newValue
+        debugRecordStateChange(
+            field: "icon",
+            oldValue: TabGeometryDebugLog.optional(oldValue),
+            newValue: TabGeometryDebugLog.optional(newValue)
+        )
+#endif
+    }
+
+    private func debugRecordIconAssetStateChange(_ newValue: String?) {
+#if DEBUG
+        let oldValue = debugLastIconAsset
+        guard oldValue != newValue else { return }
+        debugLastIconAsset = newValue
+        debugRecordStateChange(
+            field: "iconAsset",
+            oldValue: TabGeometryDebugLog.optional(oldValue),
+            newValue: TabGeometryDebugLog.optional(newValue)
+        )
+#endif
+    }
+
+    private func debugRecordIsLoadingStateChange(_ newValue: Bool) {
+#if DEBUG
+        let oldValue = debugLastIsLoading
+        guard oldValue != newValue else { return }
+        debugLastIsLoading = newValue
+        debugRecordStateChange(
+            field: "loading",
+            oldValue: TabGeometryDebugLog.optional(oldValue),
+            newValue: String(newValue)
+        )
+#endif
+    }
+
+    private func debugRecordStateChange(field: String, oldValue: String, newValue: String) {
+#if DEBUG
+        TabGeometryDebugLog.stateChange(
+            tabId: tab.id,
+            field: field,
+            oldValue: oldValue,
+            newValue: newValue,
+            tab: tab,
+            isSelected: isSelected,
+            showsShortcutHint: showsShortcutHint
+        )
+#endif
+    }
+
+    private func debugFrameChanged(_ oldFrame: CGRect?, _ newFrame: CGRect) -> Bool {
+#if DEBUG
+        guard let oldFrame else { return true }
+        return abs(oldFrame.origin.x - newFrame.origin.x) > 0.01 ||
+            abs(oldFrame.origin.y - newFrame.origin.y) > 0.01 ||
+            abs(oldFrame.width - newFrame.width) > 0.01
+#else
+        return false
+#endif
     }
 
     @ViewBuilder
@@ -341,6 +524,9 @@ struct TabItemView: View {
                             : TabBarColors.inactiveText(for: appearance)
                     )
                     .saturation(saturation)
+                    .tabGeometryDebugFrame { frame in
+                        debugRecordGeometry(which: "title", frame: frame)
+                    }
 
                 // Chrome/Safari-style audio affordance: a speaker glyph appears
                 // when the tab is producing audible audio (click to mute) or has
@@ -513,6 +699,9 @@ struct TabItemView: View {
             tx.animation = nil
         }
         .frame(width: iconSlotSize, height: iconSlotSize, alignment: .center)
+        .tabGeometryDebugFrame { frame in
+            debugRecordGeometry(which: "icon", frame: frame)
+        }
         .onAppear {
             updateRenderedFaviconImage()
             updateGlobeFallback()

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -35,18 +35,22 @@ extension View {
     @ViewBuilder
     func tabGeometryDebugFrame(_ onFrame: @escaping (CGRect) -> Void) -> some View {
 #if DEBUG
-        background(
-            GeometryReader { proxy in
-                let frame = proxy.frame(in: .global)
-                Color.clear
-                    .onAppear {
-                        onFrame(frame)
-                    }
-                    .onChange(of: frame) { _, newFrame in
-                        onFrame(newFrame)
-                    }
-            }
-        )
+        if TabGeometryDebugLog.isEnabled {
+            background(
+                GeometryReader { proxy in
+                    let frame = proxy.frame(in: .global)
+                    Color.clear
+                        .onAppear {
+                            onFrame(frame)
+                        }
+                        .onChange(of: frame) { _, newFrame in
+                            onFrame(newFrame)
+                        }
+                }
+            )
+        } else {
+            self
+        }
 #else
         self
 #endif
@@ -55,7 +59,11 @@ extension View {
     @ViewBuilder
     func tabGeometryDebugOnAppear(_ action: @escaping () -> Void) -> some View {
 #if DEBUG
-        onAppear(perform: action)
+        if TabGeometryDebugLog.isEnabled {
+            onAppear(perform: action)
+        } else {
+            self
+        }
 #else
         self
 #endif
@@ -67,8 +75,12 @@ extension View {
         perform action: @escaping (Value) -> Void
     ) -> some View {
 #if DEBUG
-        onChange(of: value) { _, newValue in
-            action(newValue)
+        if TabGeometryDebugLog.isEnabled {
+            onChange(of: value) { _, newValue in
+                action(newValue)
+            }
+        } else {
+            self
         }
 #else
         self

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -312,7 +312,8 @@ struct TabItemView: View {
             // Pinned browser tabs pin both bounds to a compact icon-only width.
             maxWidth: frameMaxWidth,
             minHeight: tabHeight,
-            maxHeight: tabHeight
+            maxHeight: tabHeight,
+            alignment: isIconOnlyPinned ? .center : .leading
         )
         // Fixed mode: size each tab to its own content and ignore the width the
         // tab strip would otherwise propose. Without this the flexible `maxWidth`

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -121,6 +121,7 @@ public final class BonsplitController {
     ///   - title: The tab title
     ///   - icon: Optional SF Symbol name for the tab icon
     ///   - iconImageData: Optional image data (PNG recommended) for the tab icon. When present, takes precedence over `icon`.
+    ///   - iconAsset: Optional asset-catalog image name for the tab icon. Resolved in the host app bundle.
     ///   - kind: Consumer-defined tab kind identifier (e.g. "terminal", "browser")
     ///   - hasCustomTitle: Whether the tab title came from a custom user override
     ///   - isDirty: Whether the tab shows a dirty indicator
@@ -136,6 +137,7 @@ public final class BonsplitController {
         hasCustomTitle: Bool = false,
         icon: String? = "doc.text",
         iconImageData: Data? = nil,
+        iconAsset: String? = nil,
         kind: String? = nil,
         isDirty: Bool = false,
         showsNotificationBadge: Bool = false,
@@ -152,6 +154,7 @@ public final class BonsplitController {
             hasCustomTitle: hasCustomTitle,
             icon: icon,
             iconImageData: iconImageData,
+            iconAsset: iconAsset,
             kind: kind,
             isDirty: isDirty,
             showsNotificationBadge: showsNotificationBadge,
@@ -191,6 +194,7 @@ public final class BonsplitController {
             hasCustomTitle: hasCustomTitle,
             icon: icon,
             iconImageData: iconImageData,
+            iconAsset: iconAsset,
             kind: kind,
             isDirty: isDirty,
             showsNotificationBadge: showsNotificationBadge,
@@ -241,6 +245,7 @@ public final class BonsplitController {
     ///   - title: New title (pass nil to keep current)
     ///   - icon: New icon (pass nil to keep current, pass .some(nil) to remove icon)
     ///   - iconImageData: New icon image data (pass nil to keep current, pass .some(nil) to remove)
+    ///   - iconAsset: New asset-catalog icon name (pass nil to keep current, pass .some(nil) to remove)
     ///   - kind: New tab kind (pass nil to keep current, pass .some(nil) to clear)
     ///   - hasCustomTitle: New custom-title state (pass nil to keep current)
     ///   - isDirty: New dirty state (pass nil to keep current)
@@ -254,6 +259,7 @@ public final class BonsplitController {
         title: String? = nil,
         icon: String?? = nil,
         iconImageData: Data?? = nil,
+        iconAsset: String?? = nil,
         kind: String?? = nil,
         hasCustomTitle: Bool? = nil,
         isDirty: Bool? = nil,
@@ -269,6 +275,7 @@ public final class BonsplitController {
             title.map { currentTab.title != $0 } ?? false ||
             icon.map { currentTab.icon != $0 } ?? false ||
             iconImageData.map { currentTab.iconImageData != $0 } ?? false ||
+            iconAsset.map { currentTab.iconAsset != $0 } ?? false ||
             kind.map { currentTab.kind != $0 } ?? false ||
             hasCustomTitle.map { currentTab.hasCustomTitle != $0 } ?? false ||
             isDirty.map { currentTab.isDirty != $0 } ?? false ||
@@ -287,6 +294,9 @@ public final class BonsplitController {
         }
         if let iconImageData = iconImageData {
             pane.tabs[tabIndex].iconImageData = iconImageData
+        }
+        if let iconAsset = iconAsset {
+            pane.tabs[tabIndex].iconAsset = iconAsset
         }
         if let kind = kind {
             pane.tabs[tabIndex].kind = kind
@@ -471,6 +481,7 @@ public final class BonsplitController {
                 hasCustomTitle: tab.hasCustomTitle,
                 icon: tab.icon,
                 iconImageData: tab.iconImageData,
+                iconAsset: tab.iconAsset,
                 kind: tab.kind,
                 isDirty: tab.isDirty,
                 showsNotificationBadge: tab.showsNotificationBadge,
@@ -537,6 +548,7 @@ public final class BonsplitController {
             hasCustomTitle: tab.hasCustomTitle,
             icon: tab.icon,
             iconImageData: tab.iconImageData,
+            iconAsset: tab.iconAsset,
             kind: tab.kind,
             isDirty: tab.isDirty,
             showsNotificationBadge: tab.showsNotificationBadge,

--- a/Sources/Bonsplit/Public/Types/Tab.swift
+++ b/Sources/Bonsplit/Public/Types/Tab.swift
@@ -8,6 +8,8 @@ public struct Tab: Identifiable, Hashable, Sendable {
     public let icon: String?
     /// Optional image data (PNG recommended) for the tab icon. When present, this takes precedence over `icon`.
     public let iconImageData: Data?
+    /// Optional asset-catalog image name for the tab icon. Resolved in the host app bundle.
+    public let iconAsset: String?
     /// Consumer-defined tab kind identifier (for example, "terminal" or "browser").
     public let kind: String?
     public let isDirty: Bool
@@ -29,6 +31,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         hasCustomTitle: Bool = false,
         icon: String? = nil,
         iconImageData: Data? = nil,
+        iconAsset: String? = nil,
         kind: String? = nil,
         isDirty: Bool = false,
         showsNotificationBadge: Bool = false,
@@ -42,6 +45,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.hasCustomTitle = hasCustomTitle
         self.icon = icon
         self.iconImageData = iconImageData
+        self.iconAsset = iconAsset
         self.kind = kind
         self.isDirty = isDirty
         self.showsNotificationBadge = showsNotificationBadge
@@ -57,6 +61,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.hasCustomTitle = tabItem.hasCustomTitle
         self.icon = tabItem.icon
         self.iconImageData = tabItem.iconImageData
+        self.iconAsset = tabItem.iconAsset
         self.kind = tabItem.kind
         self.isDirty = tabItem.isDirty
         self.showsNotificationBadge = tabItem.showsNotificationBadge

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -184,12 +184,34 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabIconAssetCreateUpdateClearRoundTrips() {
+        let controller = BonsplitController()
+        let tabId = controller.createTab(
+            title: "Agent",
+            icon: "terminal.fill",
+            iconAsset: "AgentIcons/Claude"
+        )!
+
+        XCTAssertEqual(controller.tab(tabId)?.iconAsset, "AgentIcons/Claude")
+
+        controller.updateTab(tabId, title: "Agent renamed")
+        XCTAssertEqual(controller.tab(tabId)?.iconAsset, "AgentIcons/Claude")
+
+        controller.updateTab(tabId, iconAsset: .some("AgentIcons/Codex"))
+        XCTAssertEqual(controller.tab(tabId)?.iconAsset, "AgentIcons/Codex")
+
+        controller.updateTab(tabId, iconAsset: .some(nil))
+        XCTAssertNil(controller.tab(tabId)?.iconAsset)
+    }
+
+    @MainActor
     func testNoopTabUpdateDoesNotInvalidateObservedTabMetadata() {
         let controller = BonsplitController()
         let tabId = controller.createTab(
             title: "Original",
             hasCustomTitle: true,
             icon: "doc",
+            iconAsset: "AgentIcons/Claude",
             kind: "terminal",
             isDirty: true,
             showsNotificationBadge: true,
@@ -210,6 +232,7 @@ final class BonsplitTests: XCTestCase {
             tabId,
             title: "Original",
             icon: .some("doc"),
+            iconAsset: .some("AgentIcons/Claude"),
             kind: .some("terminal"),
             hasCustomTitle: true,
             isDirty: true,


### PR DESCRIPTION
New `iconAsset` field on `TabItem`/`Tab` with keep/clear (`String??`) semantics on `createTab`/`updateTab`. Rendered between the favicon and SF-symbol branches, framed to a shared `compactMarkSize` (the optical box `terminal.fill` already uses) inside the unchanged fixed icon slot, so hosts can swap symbol and asset icons with no layout shift. `glyphSize(for:)` now uses the same helper instead of duplicating the formula. Round-trip + no-op-guard tests added (174 package tests pass).

Consumed by cmux to show the active coding agent's brand icon on terminal tabs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786086673&installation_id=133855650&pr_number=163&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F163&signature=52cc7f9bbfd08bf596036e0c544d1af7766cc48f9ea0b0271b580e7c004786c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `iconAsset` to tabs so host apps can show asset-catalog icons in the fixed tab icon slot without layout shifts. Also pin titled tab content to the leading edge to stop icon/title drift, and add DEBUG-only geometry logging gated by `CMUX_TAB_GEOMETRY_LOG`.

- **New Features**
  - Added `iconAsset` to `TabItem`, `Tab`, and `BonsplitController.createTab`/`updateTab` (`String??` keep/clear). Render order: favicon → asset icon → SF Symbol.
  - Asset icons resolve from the host bundle and use a shared `compactMarkSize` for consistent sizing; `glyphSize(for:)` now uses this helper.
  - DEBUG-only geometry logging gated by `CMUX_TAB_GEOMETRY_LOG` writes to `/tmp/cmux-tab-geometry.log` and tracks icon/title/tab frames and title/icon/iconAsset/isLoading changes. Tests cover create/update/clear and no-op updates.

- **Bug Fixes**
  - Titled tabs now align content to `.leading` to prevent icon/title drift when the tab width exceeds content; icon-only pinned tabs remain centered.

<sup>Written for commit a418483bd93ddab172f63754a51084f7cb898225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabs now support an additional, host-provided icon resolved from the app bundle/asset catalog.
  * Tab creation and updates can set, change, or clear this icon value (`iconAsset`).
* **Bug Fixes**
  * Improved leading-icon rendering: when no icon image data is available (and not loading), the view now falls back to the host-provided `iconAsset` and applies consistent compact sizing for mark-style glyphs.
* **Tests**
  * Added round-trip coverage for `iconAsset` create/update/clear.
  * Extended the no-op update test to include `iconAsset` in the identical-metadata contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->