### PR TITLE
Preserve tab bar leading anchor during resize

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -224,6 +224,11 @@ private final class TabBarScrollViewBridge: ObservableObject {
         let viewportWidth: CGFloat
     }
 
+    private enum AsyncCorrection {
+        case fixedTarget
+        case clampToValidRange
+    }
+
     weak var scrollView: NSScrollView?
 
     func attach(_ scrollView: NSScrollView?) {
@@ -296,7 +301,8 @@ private final class TabBarScrollViewBridge: ObservableObject {
             reason: reason,
             event: "tab.bar.clampOffset",
             asyncEvent: "tab.bar.clampOffset.async",
-            metrics: metrics
+            metrics: metrics,
+            asyncCorrection: .clampToValidRange
         )
     }
 
@@ -311,7 +317,8 @@ private final class TabBarScrollViewBridge: ObservableObject {
             reason: reason,
             event: "tab.bar.resetLeading",
             asyncEvent: "tab.bar.resetLeading.async",
-            metrics: metrics
+            metrics: metrics,
+            asyncCorrection: .fixedTarget
         )
     }
 
@@ -320,7 +327,8 @@ private final class TabBarScrollViewBridge: ObservableObject {
         reason: String,
         event: String,
         asyncEvent: String,
-        metrics: ScrollMetrics
+        metrics: ScrollMetrics,
+        asyncCorrection: AsyncCorrection
     ) {
         guard abs(targetOffset - metrics.offset) > 0.5 else { return }
         guard let scrollView else { return }
@@ -345,21 +353,33 @@ private final class TabBarScrollViewBridge: ObservableObject {
             guard let scrollView else { return }
             let clipView = scrollView.contentView
             let asyncOffset = clipView.bounds.origin.x
-            guard abs(asyncOffset - targetOffset) > 0.5 else { return }
-#if DEBUG
-            let documentWidth = max(
+            let asyncDocumentWidth = max(
                 scrollView.documentView?.frame.width ?? 0,
                 scrollView.documentView?.bounds.width ?? 0
             )
+            let asyncViewportWidth = clipView.bounds.width
+            let asyncTargetOffset: CGFloat
+
+            switch asyncCorrection {
+            case .fixedTarget:
+                asyncTargetOffset = targetOffset
+            case .clampToValidRange:
+                guard asyncViewportWidth > 0 else { return }
+                let asyncMaxOffset = max(0, asyncDocumentWidth - asyncViewportWidth)
+                asyncTargetOffset = min(max(asyncOffset, 0), asyncMaxOffset)
+            }
+
+            guard abs(asyncOffset - asyncTargetOffset) > 0.5 else { return }
+#if DEBUG
             dlog(
                 "\(asyncEvent) reason=\(reason) " +
                 "offset=\(Int(asyncOffset.rounded())) " +
-                "target=\(Int(targetOffset.rounded())) " +
-                "doc=\(Int(documentWidth.rounded())) " +
-                "viewport=\(Int(clipView.bounds.width.rounded()))"
+                "target=\(Int(asyncTargetOffset.rounded())) " +
+                "doc=\(Int(asyncDocumentWidth.rounded())) " +
+                "viewport=\(Int(asyncViewportWidth.rounded()))"
             )
 #endif
-            clipView.scroll(to: NSPoint(x: targetOffset, y: clipView.bounds.origin.y))
+            clipView.scroll(to: NSPoint(x: asyncTargetOffset, y: clipView.bounds.origin.y))
             scrollView.reflectScrolledClipView(clipView)
         }
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -291,22 +291,13 @@ private final class TabBarScrollViewBridge: ObservableObject {
 
         let maxOffset = max(0, metrics.documentWidth - metrics.viewportWidth)
         let clampedOffset = min(max(metrics.offset, 0), maxOffset)
-        guard abs(clampedOffset - metrics.offset) > 0.5 else { return }
-        guard let scrollView else { return }
-
-        #if DEBUG
-        dlog(
-            "tab.bar.clampOffset reason=\(reason) " +
-            "offset=\(Int(metrics.offset.rounded())) " +
-            "clamped=\(Int(clampedOffset.rounded())) " +
-            "doc=\(Int(metrics.documentWidth.rounded())) " +
-            "viewport=\(Int(metrics.viewportWidth.rounded()))"
+        setHorizontalOffset(
+            clampedOffset,
+            reason: reason,
+            event: "tab.bar.clampOffset",
+            asyncEvent: "tab.bar.clampOffset.async",
+            metrics: metrics
         )
-        #endif
-
-        let clipView = scrollView.contentView
-        clipView.scroll(to: NSPoint(x: clampedOffset, y: clipView.bounds.origin.y))
-        scrollView.reflectScrolledClipView(clipView)
     }
 
     func resetToLeadingEdgeIfNeeded(reason: String) {
@@ -315,40 +306,60 @@ private final class TabBarScrollViewBridge: ObservableObject {
         let currentOffset = metrics.offset
         guard abs(currentOffset) > 0.5 else { return }
 
+        setHorizontalOffset(
+            0,
+            reason: reason,
+            event: "tab.bar.resetLeading",
+            asyncEvent: "tab.bar.resetLeading.async",
+            metrics: metrics
+        )
+    }
+
+    private func setHorizontalOffset(
+        _ targetOffset: CGFloat,
+        reason: String,
+        event: String,
+        asyncEvent: String,
+        metrics: ScrollMetrics
+    ) {
+        guard abs(targetOffset - metrics.offset) > 0.5 else { return }
         guard let scrollView else { return }
-        #if DEBUG
+
+#if DEBUG
         dlog(
-            "tab.bar.resetLeading reason=\(reason) " +
-            "offset=\(Int(currentOffset.rounded())) " +
+            "\(event) reason=\(reason) " +
+            "offset=\(Int(metrics.offset.rounded())) " +
+            "target=\(Int(targetOffset.rounded())) " +
             "doc=\(Int(metrics.documentWidth.rounded())) " +
             "viewport=\(Int(metrics.viewportWidth.rounded()))"
         )
 #endif
         let clipView = scrollView.contentView
-        clipView.scroll(to: NSPoint(x: 0, y: clipView.bounds.origin.y))
+        clipView.scroll(to: NSPoint(x: targetOffset, y: clipView.bounds.origin.y))
         scrollView.reflectScrolledClipView(clipView)
 
         // SwiftUI's ScrollView can briefly restore the stale offset during the same
         // layout cycle. Re-apply the correction on the next turn to keep split-pane
-        // tab bars pinned to the leading edge once they stop overflowing.
+        // tab bars pinned or clamped once the geometry settles.
         DispatchQueue.main.async { [weak scrollView] in
             guard let scrollView else { return }
             let clipView = scrollView.contentView
             let asyncOffset = clipView.bounds.origin.x
-            guard abs(asyncOffset) > 0.5 else { return }
+            guard abs(asyncOffset - targetOffset) > 0.5 else { return }
 #if DEBUG
             let documentWidth = max(
                 scrollView.documentView?.frame.width ?? 0,
                 scrollView.documentView?.bounds.width ?? 0
             )
             dlog(
-                "tab.bar.resetLeading.async reason=\(reason) " +
+                "\(asyncEvent) reason=\(reason) " +
                 "offset=\(Int(asyncOffset.rounded())) " +
+                "target=\(Int(targetOffset.rounded())) " +
                 "doc=\(Int(documentWidth.rounded())) " +
                 "viewport=\(Int(clipView.bounds.width.rounded()))"
             )
 #endif
-            clipView.scroll(to: NSPoint(x: 0, y: clipView.bounds.origin.y))
+            clipView.scroll(to: NSPoint(x: targetOffset, y: clipView.bounds.origin.y))
             scrollView.reflectScrolledClipView(clipView)
         }
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -279,6 +279,36 @@ private final class TabBarScrollViewBridge: ObservableObject {
         resetToLeadingEdgeIfNeeded(reason: reason)
     }
 
+    func preserveCurrentOffsetAfterLayoutChange(reason: String) {
+        guard let metrics = currentMetrics(), metrics.viewportWidth > 0 else { return }
+        guard !TabBarStyling.shouldKeepLeadingAligned(
+            contentWidth: metrics.documentWidth,
+            containerWidth: metrics.viewportWidth
+        ) else {
+            resetToLeadingEdgeIfNeeded(reason: reason)
+            return
+        }
+
+        let maxOffset = max(0, metrics.documentWidth - metrics.viewportWidth)
+        let clampedOffset = min(max(metrics.offset, 0), maxOffset)
+        guard abs(clampedOffset - metrics.offset) > 0.5 else { return }
+        guard let scrollView else { return }
+
+        #if DEBUG
+        dlog(
+            "tab.bar.clampOffset reason=\(reason) " +
+            "offset=\(Int(metrics.offset.rounded())) " +
+            "clamped=\(Int(clampedOffset.rounded())) " +
+            "doc=\(Int(metrics.documentWidth.rounded())) " +
+            "viewport=\(Int(metrics.viewportWidth.rounded()))"
+        )
+        #endif
+
+        let clipView = scrollView.contentView
+        clipView.scroll(to: NSPoint(x: clampedOffset, y: clipView.bounds.origin.y))
+        scrollView.reflectScrolledClipView(clipView)
+    }
+
     func resetToLeadingEdgeIfNeeded(reason: String) {
         guard let metrics = currentMetrics() else { return }
 
@@ -1315,10 +1345,10 @@ struct TabBarView: View {
                     }
                     .onChange(of: containerGeo.size.width) { _, newWidth in
                         containerWidth = newWidth
-                        scrollToPreferredTarget(proxy, selectedTabId: pane.selectedTabId)
+                        scrollViewBridge.preserveCurrentOffsetAfterLayoutChange(reason: "containerWidth")
                     }
                     .onChange(of: contentWidth) { _, _ in
-                        scrollToPreferredTarget(proxy, selectedTabId: pane.selectedTabId)
+                        scrollViewBridge.preserveCurrentOffsetAfterLayoutChange(reason: "contentWidth")
                     }
                     .onChange(of: pane.selectedTabId) { _, newTabId in
                         scrollToPreferredTarget(proxy, selectedTabId: newTabId)

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -13,18 +13,55 @@ final class TabBarResizeAnchorTests: XCTestCase {
         )
         defer { harness.window.orderOut(nil) }
 
-        let scrollView = try XCTUnwrap(firstDescendant(ofType: NSScrollView.self, in: harness.hostingView))
+        let scrollView = try tabBarScrollView(in: harness.hostingView)
         XCTAssertEqual(scrollView.contentView.bounds.origin.x, 0, accuracy: 0.5)
 
         harness.window.setContentSize(NSSize(width: 240, height: TabBarMetrics.barHeight))
         harness.hostingView.frame = harness.window.contentView?.bounds ?? harness.hostingView.frame
-        settleLayout(in: harness.window, hostingView: harness.hostingView)
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            abs(scrollView.contentView.bounds.origin.x) <= 0.5
+        }
 
         XCTAssertEqual(
             scrollView.contentView.bounds.origin.x,
             0,
             accuracy: 0.5,
             "A pure pane/window resize must preserve the leading tab-strip anchor instead of recentering the selected tab and shifting icons."
+        )
+    }
+
+    func testViewportResizeClampsExistingOverflowOffsetToNewRange() throws {
+        let harness = try makeTabBarHarness(
+            initialSize: NSSize(width: 240, height: TabBarMetrics.barHeight),
+            tabCount: 8,
+            selectedIndex: 7
+        )
+        defer { harness.window.orderOut(nil) }
+
+        let scrollView = try tabBarScrollView(in: harness.hostingView)
+        let initialMaxOffset = maxHorizontalOffset(in: scrollView)
+        XCTAssertGreaterThan(initialMaxOffset, 0)
+
+        scrollView.contentView.scroll(to: NSPoint(x: initialMaxOffset, y: 0))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        XCTAssertEqual(scrollView.contentView.bounds.origin.x, initialMaxOffset, accuracy: 0.5)
+
+        harness.window.setContentSize(NSSize(width: 360, height: TabBarMetrics.barHeight))
+        harness.hostingView.frame = harness.window.contentView?.bounds ?? harness.hostingView.frame
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            let expectedOffset = maxHorizontalOffset(in: scrollView)
+            return expectedOffset > 0
+                && abs(scrollView.contentView.bounds.origin.x - expectedOffset) <= 0.5
+        }
+
+        let expectedOffset = maxHorizontalOffset(in: scrollView)
+        XCTAssertGreaterThan(expectedOffset, 0)
+        XCTAssertLessThan(expectedOffset, initialMaxOffset)
+        XCTAssertEqual(
+            scrollView.contentView.bounds.origin.x,
+            expectedOffset,
+            accuracy: 0.5,
+            "A resize that reduces the valid scroll range must clamp the existing offset instead of resetting or recentering the tab strip."
         )
     }
 
@@ -69,28 +106,75 @@ final class TabBarResizeAnchorTests: XCTestCase {
         contentView.addSubview(hostingView)
 
         window.makeKeyAndOrderFront(nil)
-        settleLayout(in: window, hostingView: hostingView)
+        settleLayout(in: window, hostingView: hostingView) {
+            tabBarScrollViews(in: hostingView).count == 1
+        }
 
         return TabBarHarness(window: window, hostingView: hostingView)
     }
 
-    private func settleLayout(in window: NSWindow, hostingView: NSView) {
-        window.contentView?.layoutSubtreeIfNeeded()
-        hostingView.layoutSubtreeIfNeeded()
-        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    private func settleLayout(
+        in window: NSWindow,
+        hostingView: NSView,
+        until condition: () -> Bool
+    ) {
+        for _ in 0..<20 {
+            window.contentView?.layoutSubtreeIfNeeded()
+            hostingView.layoutSubtreeIfNeeded()
+            if condition() {
+                return
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+
         window.contentView?.layoutSubtreeIfNeeded()
         hostingView.layoutSubtreeIfNeeded()
     }
 
-    private func firstDescendant<T: NSView>(ofType type: T.Type, in root: NSView) -> T? {
+    private func tabBarScrollView(
+        in root: NSView,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> NSScrollView {
+        let matches = tabBarScrollViews(in: root)
+        XCTAssertEqual(
+            matches.count,
+            1,
+            "The harness should expose exactly one tab-bar-sized scroll view.",
+            file: file,
+            line: line
+        )
+        return try XCTUnwrap(matches.first, file: file, line: line)
+    }
+
+    private func tabBarScrollViews(in root: NSView) -> [NSScrollView] {
+        descendants(ofType: NSScrollView.self, in: root).filter { scrollView in
+            let documentHeight = max(
+                scrollView.documentView?.frame.height ?? 0,
+                scrollView.documentView?.bounds.height ?? 0
+            )
+            return abs(scrollView.frame.height - TabBarMetrics.barHeight) <= 0.5
+                && abs(documentHeight - TabBarMetrics.barHeight) <= 0.5
+                && scrollView.frame.width > 0
+        }
+    }
+
+    private func maxHorizontalOffset(in scrollView: NSScrollView) -> CGFloat {
+        let documentWidth = max(
+            scrollView.documentView?.frame.width ?? 0,
+            scrollView.documentView?.bounds.width ?? 0
+        )
+        return max(0, documentWidth - scrollView.contentView.bounds.width)
+    }
+
+    private func descendants<T: NSView>(ofType type: T.Type, in root: NSView) -> [T] {
+        var matches: [T] = []
         if let match = root as? T {
-            return match
+            matches.append(match)
         }
         for subview in root.subviews {
-            if let match = firstDescendant(ofType: type, in: subview) {
-                return match
-            }
+            matches.append(contentsOf: descendants(ofType: type, in: subview))
         }
-        return nil
+        return matches
     }
 }

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -65,6 +65,50 @@ final class TabBarResizeAnchorTests: XCTestCase {
         )
     }
 
+    func testAsyncClampRetryDoesNotUndoLaterValidOffset() async throws {
+        let harness = try makeTabBarHarness(
+            initialSize: NSSize(width: 240, height: TabBarMetrics.barHeight),
+            tabCount: 8,
+            selectedIndex: 7
+        )
+        defer { harness.window.orderOut(nil) }
+
+        let scrollView = try tabBarScrollView(in: harness.hostingView)
+        let initialMaxOffset = maxHorizontalOffset(in: scrollView)
+        XCTAssertGreaterThan(initialMaxOffset, 0)
+
+        scrollView.contentView.scroll(to: NSPoint(x: initialMaxOffset, y: 0))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        var laterValidOffset: CGFloat?
+        let laterScrollApplied = expectation(description: "later valid scroll applied")
+        DispatchQueue.main.async {
+            let validOffset = self.maxHorizontalOffset(in: scrollView) / 2
+            laterValidOffset = validOffset
+            scrollView.contentView.scroll(to: NSPoint(x: validOffset, y: 0))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            laterScrollApplied.fulfill()
+        }
+
+        harness.window.setContentSize(NSSize(width: 360, height: TabBarMetrics.barHeight))
+        harness.hostingView.frame = harness.window.contentView?.bounds ?? harness.hostingView.frame
+        harness.window.contentView?.layoutSubtreeIfNeeded()
+        harness.hostingView.layoutSubtreeIfNeeded()
+
+        let queuedCorrectionsDrained = expectation(description: "queued corrections drained")
+        DispatchQueue.main.async {
+            queuedCorrectionsDrained.fulfill()
+        }
+        await fulfillment(of: [laterScrollApplied, queuedCorrectionsDrained], timeout: 1)
+        let expectedOffset = try XCTUnwrap(laterValidOffset)
+        XCTAssertEqual(
+            scrollView.contentView.bounds.origin.x,
+            expectedOffset,
+            accuracy: 0.5,
+            "The queued clamp retry must not overwrite a later scroll position that is already inside the resized tab strip's valid range."
+        )
+    }
+
     private struct TabBarHarness {
         let window: NSWindow
         let hostingView: NSView

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -1,0 +1,96 @@
+import AppKit
+@testable import Bonsplit
+import SwiftUI
+import XCTest
+
+@MainActor
+final class TabBarResizeAnchorTests: XCTestCase {
+    func testViewportResizeKeepsLeadingAnchoredWhenTabStripWasLeadingAligned() throws {
+        let harness = try makeTabBarHarness(
+            initialSize: NSSize(width: 900, height: TabBarMetrics.barHeight),
+            tabCount: 8,
+            selectedIndex: 2
+        )
+        defer { harness.window.orderOut(nil) }
+
+        let scrollView = try XCTUnwrap(firstDescendant(ofType: NSScrollView.self, in: harness.hostingView))
+        XCTAssertEqual(scrollView.contentView.bounds.origin.x, 0, accuracy: 0.5)
+
+        harness.window.setContentSize(NSSize(width: 240, height: TabBarMetrics.barHeight))
+        harness.hostingView.frame = harness.window.contentView?.bounds ?? harness.hostingView.frame
+        settleLayout(in: harness.window, hostingView: harness.hostingView)
+
+        XCTAssertEqual(
+            scrollView.contentView.bounds.origin.x,
+            0,
+            accuracy: 0.5,
+            "A pure pane/window resize must preserve the leading tab-strip anchor instead of recentering the selected tab and shifting icons."
+        )
+    }
+
+    private struct TabBarHarness {
+        let window: NSWindow
+        let hostingView: NSView
+    }
+
+    private func makeTabBarHarness(
+        initialSize: NSSize,
+        tabCount: Int,
+        selectedIndex: Int
+    ) throws -> TabBarHarness {
+        let controller = BonsplitController(configuration: BonsplitConfiguration(appearance: .default))
+        controller.tabShortcutHintsEnabled = false
+        let pane = try XCTUnwrap(controller.internalController.rootNode.allPanes.first)
+
+        let tabs = (0..<tabCount).map { index in
+            TabItem(title: "Terminal \(index + 1)", icon: "terminal.fill", kind: "terminal")
+        }
+        pane.tabs = tabs
+        pane.selectedTabId = tabs[selectedIndex].id
+
+        let hostingView = NSHostingView(
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: false)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: initialSize),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        let contentView = try XCTUnwrap(window.contentView)
+        contentView.wantsLayer = true
+        contentView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.frame = NSRect(origin: .zero, size: initialSize)
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+
+        window.makeKeyAndOrderFront(nil)
+        settleLayout(in: window, hostingView: hostingView)
+
+        return TabBarHarness(window: window, hostingView: hostingView)
+    }
+
+    private func settleLayout(in window: NSWindow, hostingView: NSView) {
+        window.contentView?.layoutSubtreeIfNeeded()
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        window.contentView?.layoutSubtreeIfNeeded()
+        hostingView.layoutSubtreeIfNeeded()
+    }
+
+    private func firstDescendant<T: NSView>(ofType type: T.Type, in root: NSView) -> T? {
+        if let match = root as? T {
+            return match
+        }
+        for subview in root.subviews {
+            if let match = firstDescendant(ofType: type, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

- Add a regression test that hosts the real `TabBarView`, resizes the viewport, and asserts the tab strip keeps its leading scroll origin.
- Preserve the current scroll offset during tab-bar viewport/content remeasurement instead of re-centering the selected tab on every resize.
- Keep existing selected-tab reveal behavior for selection changes and initial layout.

## Root cause

`TabBarView` used the same selected-tab centering path for selection changes, content measurement changes, and viewport width changes. During a pane/window resize, the horizontal `ScrollView` could briefly scroll the selected tab to center, moving the entire tab row and making the terminal icon shift right. The later leading-edge repair snapped the row back once the strip was known to fit. Resize is now treated as a layout remeasurement: preserve the current scroll origin and only reset/clamp invalid offsets.

## Tests

- `swift test --package-path vendor/bonsplit --filter TabBarResizeAnchorTests/testViewportResizeKeepsLeadingAnchoredWhenTabStripWasLeadingAligned`
  - Fails before the fix with offset `150.0` vs expected `0.0`.
  - Passes after the fix.
- `swift test --package-path vendor/bonsplit --filter BonsplitTests/testTabBarKeepsNonOverflowingTabsLeadingAligned --filter BonsplitTests/testTabBarForcesLeadingResetWhenNonOverflowingStripStaysScrolled --filter BonsplitTests/testActiveTabIndicatorTracksSelectedTabAfterHorizontalScroll --filter BonsplitTests/testActiveTabIndicatorIgnoresAnimatedSelectionTransactions`
- `swift test --package-path vendor/bonsplit`

Related cmux issue: manaflow-ai/cmux#7635

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786125897&installation_id=133855650&pr_number=164&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F164&signature=6de5c4b2ee389036a53d605e337efa47926edab24d176783a487611754384058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the tab bar’s leading edge anchored during window/pane resize so the selected tab no longer recenters and shifts icons. We preserve and clamp the current horizontal scroll offset on layout changes and ignore stale async clamp retries.

- **Bug Fixes**
  - Added `preserveCurrentOffsetAfterLayoutChange(...)` and use it on viewport/content width changes.
  - Clamp the current offset to valid bounds on resize; only reset to leading when the strip fits.
  - Prevent queued clamp retries from overwriting later valid scroll positions.
  - Expanded tests to cover leading anchoring on resize, clamping when the valid range shrinks, and not undoing a later valid offset.

<sup>Written for commit cd50d0cce04ccf949d9925f531965afd31ba3da4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab bar scrolling so the horizontal scroll position remains stable when the window or tab content width changes.
  * When resized while already scrolled, the tab strip now clamps to the new valid range instead of recentring; async layout adjustments no longer cause occasional jumps.
* **Tests**
  * Added UI test coverage for tab-strip anchor behavior during window resizing, including leading alignment, clamping to reduced scroll limits, and queued corrections not overriding later valid scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->