### PR TITLE
Migrate off ObservableObject to @Observable and Task-based delays

### DIFF
--- a/Example/BonsplitExample/AppState.swift
+++ b/Example/BonsplitExample/AppState.swift
@@ -8,10 +8,11 @@ struct TabContent {
 
 /// Application state managing tabs and their content
 @MainActor
-class AppState: ObservableObject {
+@Observable
+class AppState {
     let controller: BonsplitController
 
-    @Published var tabContents: [TabID: TabContent] = [:]
+    var tabContents: [TabID: TabContent] = [:]
 
     /// Reference to debug state for geometry notifications
     weak var debugState: DebugState?

--- a/Example/BonsplitExample/BonsplitExampleApp.swift
+++ b/Example/BonsplitExample/BonsplitExampleApp.swift
@@ -3,7 +3,7 @@ import Bonsplit
 
 @main
 struct BonsplitExampleApp: App {
-    @StateObject private var debugState = DebugState()
+    @State private var debugState = DebugState()
 
     var body: some Scene {
         WindowGroup {

--- a/Example/BonsplitExample/ContentView.swift
+++ b/Example/BonsplitExample/ContentView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import Bonsplit
 
 struct ContentView: View {
-    @StateObject private var appState = AppState()
-    @ObservedObject var debugState: DebugState
+    @State private var appState = AppState()
+    let debugState: DebugState
 
     var body: some View {
         BonsplitView(controller: appState.controller) { tab, paneId in
@@ -28,7 +28,7 @@ struct ContentView: View {
 struct TabContentView: View {
     let tab: Bonsplit.Tab
     let paneId: PaneID
-    @ObservedObject var appState: AppState
+    let appState: AppState
     @FocusState private var isEditorFocused: Bool
 
     var body: some View {
@@ -69,7 +69,7 @@ struct TabContentView: View {
 /// Custom view for empty panes - developer can fully customize this
 struct EmptyPaneView: View {
     let paneId: PaneID
-    @ObservedObject var appState: AppState
+    let appState: AppState
 
     var body: some View {
         VStack(spacing: 20) {

--- a/Example/BonsplitExample/DebugState.swift
+++ b/Example/BonsplitExample/DebugState.swift
@@ -3,10 +3,11 @@ import Bonsplit
 
 /// Observable state for the geometry debug panel
 @MainActor
-class DebugState: ObservableObject {
-    @Published var logs: [String] = []
-    @Published var currentSnapshot: LayoutSnapshot?
-    @Published var currentTree: ExternalTreeNode?
+@Observable
+class DebugState {
+    var logs: [String] = []
+    var currentSnapshot: LayoutSnapshot?
+    var currentTree: ExternalTreeNode?
 
     weak var controller: BonsplitController?
 

--- a/Example/BonsplitExample/DebugWindowView.swift
+++ b/Example/BonsplitExample/DebugWindowView.swift
@@ -3,7 +3,7 @@ import AppKit
 import Bonsplit
 
 struct DebugWindowView: View {
-    @ObservedObject var debugState: DebugState
+    let debugState: DebugState
 
     var body: some View {
         VStack(spacing: 0) {
@@ -29,7 +29,7 @@ struct DebugWindowView: View {
 
 struct GeometrySection: View {
     let snapshot: LayoutSnapshot
-    @ObservedObject var debugState: DebugState
+    let debugState: DebugState
 
     var body: some View {
         ScrollView {
@@ -83,7 +83,7 @@ struct GeometrySection: View {
 
 struct SplitControlsView: View {
     let node: ExternalTreeNode
-    @ObservedObject var debugState: DebugState
+    let debugState: DebugState
 
     var body: some View {
         switch node {
@@ -101,7 +101,7 @@ struct SplitControlsView: View {
 
 struct DividerSlider: View {
     let split: ExternalSplitNode
-    @ObservedObject var debugState: DebugState
+    let debugState: DebugState
     @State private var position: Double
 
     init(split: ExternalSplitNode, debugState: DebugState) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -217,7 +217,7 @@ private struct SplitButtonLaneWidthReader: View {
 }
 
 @MainActor
-private final class TabBarScrollViewBridge: ObservableObject {
+private final class TabBarScrollViewBridge {
     private struct ScrollMetrics {
         let offset: CGFloat
         let documentWidth: CGFloat
@@ -1034,8 +1034,8 @@ struct TabBarView: View {
     @State private var splitButtonScrollOffset: CGFloat = 0
     @State private var splitButtonContentWidth: CGFloat = 0
     @State private var splitButtonViewportWidth: CGFloat = 0
-    @StateObject private var controlKeyMonitor = TabControlShortcutKeyMonitor()
-    @StateObject private var scrollViewBridge = TabBarScrollViewBridge()
+    @State private var controlKeyMonitor = TabControlShortcutKeyMonitor()
+    @State private var scrollViewBridge = TabBarScrollViewBridge()
 
     private var canScrollLeft: Bool {
         scrollOffset > 1
@@ -3294,18 +3294,19 @@ private struct TabBarHostWindowReader: NSViewRepresentable {
 }
 
 @MainActor
-private final class TabControlShortcutKeyMonitor: ObservableObject {
-    @Published private(set) var isShortcutHintVisible = false
-    @Published private(set) var shortcutModifierSymbol = TabControlShortcutHintPolicy.configuredShortcutModifierSymbol()
+@Observable
+private final class TabControlShortcutKeyMonitor {
+    private(set) var isShortcutHintVisible = false
+    private(set) var shortcutModifierSymbol = TabControlShortcutHintPolicy.configuredShortcutModifierSymbol()
 
-    private weak var hostWindow: NSWindow?
-    private var hostWindowDidBecomeKeyObserver: NSObjectProtocol?
-    private var hostWindowDidResignKeyObserver: NSObjectProtocol?
-    private var flagsMonitor: Any?
-    private var keyDownMonitor: Any?
-    private var resignObserver: NSObjectProtocol?
-    private var pendingShowWorkItem: DispatchWorkItem?
-    private var pendingModifier: TabControlShortcutModifier?
+    @ObservationIgnored private weak var hostWindow: NSWindow?
+    @ObservationIgnored private var hostWindowDidBecomeKeyObserver: NSObjectProtocol?
+    @ObservationIgnored private var hostWindowDidResignKeyObserver: NSObjectProtocol?
+    @ObservationIgnored private var flagsMonitor: Any?
+    @ObservationIgnored private var keyDownMonitor: Any?
+    @ObservationIgnored private var resignObserver: NSObjectProtocol?
+    @ObservationIgnored private var pendingShowTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingModifier: TabControlShortcutModifier?
 
     func setHostWindow(_ window: NSWindow?) {
         guard hostWindow !== window else { return }
@@ -3421,15 +3422,17 @@ private final class TabControlShortcutKeyMonitor: ObservableObject {
     }
 
     private func queueHintShow(for modifier: TabControlShortcutModifier) {
-        if pendingModifier == modifier, pendingShowWorkItem != nil {
+        if pendingModifier == modifier, pendingShowTask != nil {
             return
         }
 
-        pendingShowWorkItem?.cancel()
+        pendingShowTask?.cancel()
 
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            self.pendingShowWorkItem = nil
+        pendingModifier = modifier
+        pendingShowTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(TabControlShortcutHintPolicy.intentionalHoldDelay))
+            guard !Task.isCancelled, let self else { return }
+            self.pendingShowTask = nil
             self.pendingModifier = nil
             guard TabControlShortcutHintPolicy.shouldShowHints(
                 for: NSEvent.modifierFlags,
@@ -3444,15 +3447,11 @@ private final class TabControlShortcutKeyMonitor: ObservableObject {
                 self.isShortcutHintVisible = true
             }
         }
-
-        pendingModifier = modifier
-        pendingShowWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + TabControlShortcutHintPolicy.intentionalHoldDelay, execute: workItem)
     }
 
     private func cancelPendingHintShow(resetVisible: Bool) {
-        pendingShowWorkItem?.cancel()
-        pendingShowWorkItem = nil
+        pendingShowTask?.cancel()
+        pendingShowTask = nil
         pendingModifier = nil
         if resetVisible {
             shortcutModifierSymbol = TabControlShortcutHintPolicy.configuredShortcutModifierSymbol()

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -5,6 +5,12 @@ import Observation
 import QuartzCore
 import SwiftUI
 
+@MainActor
+@Observable
+private final class DropZoneModel {
+    var zone: DropZone?
+}
+
 final class BonsplitTests: XCTestCase {
     @MainActor
     private final class FakeTabBarHitRegionView: NSView {
@@ -88,13 +94,8 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    private final class DropZoneModel: ObservableObject {
-        @Published var zone: DropZone?
-    }
-
-    @MainActor
     private struct PaneDropInteractionHarness: View {
-        @ObservedObject var model: DropZoneModel
+        let model: DropZoneModel
         let probeView: LayoutProbeView
 
         var body: some View {


### PR DESCRIPTION
Companion to https://github.com/manaflow-ai/cmux/pull/7606 (cmux-wide ObservableObject removal). Library: TabBarScrollViewBridge loses a stateless ObservableObject conformance and is owned by @State; TabControlShortcutKeyMonitor becomes @Observable and its hold-to-show hint delay moves from DispatchWorkItem/asyncAfter to a cancellable Task.sleep (same 300ms policy, cancellation preserved). Example app + test mock migrate mechanically. rg for ObservableObject/@Published/@StateObject/@ObservedObject/@EnvironmentObject/objectWillChange over Sources/Tests/Example is zero. swift build clean; 173/173 tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786139704&installation_id=133855650&pr_number=165&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F165&signature=d9f83a7f0acefb933f155fea5c6cbb8555551a8e990a51d1544c8df1c628ef2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate to Swift Observation by replacing ObservableObject/@Published with @Observable and switch the tab shortcut hint delay to a cancellable Task-based approach. Behavior is unchanged (300ms hold-to-show; cancellation preserved).

- **Refactors**
  - TabBarScrollViewBridge drops ObservableObject and is stored with @State.
  - TabControlShortcutKeyMonitor becomes @Observable; non-observed fields use @ObservationIgnored; delay uses Task.sleep.
  - Example app and tests migrate to @Observable: AppState, DebugState, and DropZoneModel; views replace @StateObject/@ObservedObject with @State or plain lets.
  - Removed remaining ObservableObject/@Published/@StateObject/@ObservedObject/@EnvironmentObject/objectWillChange references; all tests pass (173/173).

<sup>Written for commit 5dc80005bf8c40b39d8aeab5c709e15be8f63c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated app state handling across the UI to use a newer observation approach, improving consistency and simplifying state ownership.
  * Adjusted tab bar and debug UI state management for smoother updates and more reliable behavior.

* **Bug Fixes**
  * Improved shortcut hint timing and cancellation so hints appear and disappear more predictably.
  * Refined drag-and-drop handling in tests to better match real app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->