### PR TITLE
Add ChromeColors.splitDividerHex: dedicated split-divider color

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -263,6 +263,15 @@ enum TabBarColors {
         return tone.withAlphaComponent(alpha)
     }
 
+    static func nsColorSplitDivider(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        if let splitDividerHex = appearance.chromeColors.splitDividerHex,
+           let explicit = NSColor(bonsplitHex: splitDividerHex) {
+            return explicit
+        }
+
+        return nsColorSeparator(for: appearance)
+    }
+
     static var dropIndicator: Color {
         Color.accentColor
     }

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -149,7 +149,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 #else
         let splitView = ThemedSplitView()
 #endif
-        splitView.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
+        splitView.customDividerColor = TabBarColors.nsColorSplitDivider(for: appearance)
         splitView.customDividerThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
         splitView.isVertical = splitState.orientation == .horizontal
         splitView.dividerStyle = .thin
@@ -355,7 +355,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.wantsLayer = true
         splitView.layer?.backgroundColor = NSColor.clear.cgColor
         splitView.layer?.isOpaque = false
-        (splitView as? ThemedSplitView)?.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
+        (splitView as? ThemedSplitView)?.customDividerColor = TabBarColors.nsColorSplitDivider(for: appearance)
         let resolvedThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
         let dividerThicknessChanged = (splitView as? ThemedSplitView)?.customDividerThickness != resolvedThickness
         (splitView as? ThemedSplitView)?.customDividerThickness = resolvedThickness

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -467,18 +467,24 @@ extension BonsplitConfiguration {
             /// When unset, Bonsplit derives separators from the chrome background.
             public var borderHex: String?
 
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for split dividers.
+            /// When unset, Bonsplit uses the derived separator color.
+            public var splitDividerHex: String?
+
             public init(
                 backgroundHex: String? = nil,
                 tabBarBackgroundHex: String? = nil,
                 splitButtonBackdropHex: String? = nil,
                 paneBackgroundHex: String? = nil,
-                borderHex: String? = nil
+                borderHex: String? = nil,
+                splitDividerHex: String? = nil
             ) {
                 self.backgroundHex = backgroundHex
                 self.tabBarBackgroundHex = tabBarBackgroundHex
                 self.splitButtonBackdropHex = splitButtonBackdropHex
                 self.paneBackgroundHex = paneBackgroundHex
                 self.borderHex = borderHex
+                self.splitDividerHex = splitDividerHex
             }
         }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1332,6 +1332,48 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(Int(round(alpha * 255)), 255)
     }
 
+    func testNilSplitDividerHexUsesSeparatorColor() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#272822", borderHex: "#112233")
+        )
+
+        let splitDivider = TabBarColors.nsColorSplitDivider(for: appearance).usingColorSpace(.sRGB)!
+        let separator = TabBarColors.nsColorSeparator(for: appearance).usingColorSpace(.sRGB)!
+
+        XCTAssertEqual(splitDivider, separator)
+    }
+
+    func testTransparentSplitDividerHexParsesForSplitDividerColor() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(backgroundHex: "#272822", splitDividerHex: "#00000000")
+        )
+        let color = TabBarColors.nsColorSplitDivider(for: appearance).usingColorSpace(.sRGB)!
+
+        XCTAssertEqual(Int(round(color.alphaComponent * 255)), 0)
+    }
+
+    func testSplitDividerHexOverridesBorderHexForSplitDividerColor() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(
+                backgroundHex: "#272822",
+                borderHex: "#112233",
+                splitDividerHex: "#445566"
+            )
+        )
+        let color = TabBarColors.nsColorSplitDivider(for: appearance).usingColorSpace(.sRGB)!
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(Int(round(red * 255)), 68)
+        XCTAssertEqual(Int(round(green * 255)), 85)
+        XCTAssertEqual(Int(round(blue * 255)), 102)
+        XCTAssertEqual(Int(round(alpha * 255)), 255)
+    }
+
     func testInvalidChromeBackgroundHexFallsBackToPaneDefaultColor() {
         let appearance = BonsplitConfiguration.Appearance(
             chromeColors: .init(backgroundHex: "#ZZZZZZ")


### PR DESCRIPTION
Split dividers previously shared `borderHex` with tab-bar separators, so a host could not hide or recolor the pane divider without also changing tab-bar hairlines (bottom hairline, per-tab right separators, split-button separator fade).

`splitDividerHex` overrides only the `NSSplitView` divider color in `SplitContainerView`. When nil or unparsable it falls back to `nsColorSeparator(for:)`, keeping default rendering byte-identical. Divider thickness and hit-testing are untouched, so drag-resize behavior is unchanged even with a fully transparent divider.

Motivation: cmux wants invisible split dividers by default while keeping the documented `paneBorderColor` setting as a split-divider-only override (cmux-side PR follows, based on the currently pinned `cd50d0c`).

Tests: three new BonsplitTests cases (nil fallback, transparent, explicit override with borderHex also set); `swift test` green, 179 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786146424&installation_id=133855650&pr_number=166&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F166&signature=2da6c08cd062962f2595d9ec7af2418dde38bd889643205f73de451d5c5b9cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated split-divider color so hosts can style or hide the pane divider without changing tab-bar separators. Defaults to the derived separator color, so existing apps look and behave the same.

- **New Features**
  - Added `splitDividerHex` to `BonsplitConfiguration.Appearance.ChromeColors` (`#RRGGBB` or `#RRGGBBAA`).
  - Introduced `TabBarColors.nsColorSplitDivider(for:)` and wired it into `SplitContainerView` for `customDividerColor`.
  - Falls back to `nsColorSeparator(for:)` when unset or invalid; divider thickness and hit-testing are unchanged.

<sup>Written for commit 82260c92a9ca4025f7c288036a6bcb685e67c11d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the split-pane divider color in appearance settings.
  * Split divider styling now uses the configured divider color when provided, with a fallback to the default separator color.

* **Bug Fixes**
  * Improved color precedence so the split divider uses its dedicated setting instead of reusing border styling.
  * Transparent divider values are now respected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->