### PR TITLE
Add embedded split interaction policy

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -279,7 +279,7 @@ final class SplitViewController {
 
     private func normalizedInitialDividerPosition(_ position: CGFloat?) -> CGFloat {
         guard let position else { return 0.5 }
-        return min(max(position, 0.1), 0.9)
+        return min(max(position, 0), 1)
     }
 
     /// Close a pane and collapse the split

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -119,6 +119,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
     @Bindable var splitState: SplitState
     let controller: SplitViewController
     let appearance: BonsplitConfiguration.Appearance
+    let dividerPositionRange: ClosedRange<CGFloat>
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true
@@ -135,6 +136,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             splitState: splitState,
             minimumPaneWidth: appearance.minimumPaneWidth,
             minimumPaneHeight: appearance.minimumPaneHeight,
+            dividerPositionRange: dividerPositionRange,
             onGeometryChange: onGeometryChange
         )
     }
@@ -270,7 +272,10 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             context.coordinator.initialDividerApplyAttempts = 0
 
             if animationOrigin != nil {
-                let targetDividerPosition = min(max(splitState.dividerPosition, 0.1), 0.9)
+                let targetDividerPosition = min(
+                    max(splitState.dividerPosition, dividerPositionRange.lowerBound),
+                    dividerPositionRange.upperBound
+                )
                 let targetPosition = availableSize * targetDividerPosition
                 splitState.dividerPosition = targetDividerPosition
 
@@ -344,6 +349,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             splitState: splitState,
             minimumPaneWidth: appearance.minimumPaneWidth,
             minimumPaneHeight: appearance.minimumPaneHeight,
+            dividerPositionRange: dividerPositionRange,
             onGeometryChange: onGeometryChange
         )
 
@@ -497,6 +503,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 splitState: nestedSplitState,
                 controller: controller,
                 appearance: appearance,
+                dividerPositionRange: dividerPositionRange,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,
@@ -516,6 +523,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         private var splitStateId: UUID
         private var minimumPaneWidth: CGFloat
         private var minimumPaneHeight: CGFloat
+        private var dividerPositionRange: ClosedRange<CGFloat>
         weak var splitView: NSSplitView?
         var isAnimating = false
         var didApplyInitialDividerPosition = false
@@ -540,12 +548,14 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             splitState: SplitState,
             minimumPaneWidth: CGFloat,
             minimumPaneHeight: CGFloat,
+            dividerPositionRange: ClosedRange<CGFloat>,
             onGeometryChange: ((_ isDragging: Bool) -> Void)?
         ) {
             self.splitState = splitState
             self.splitStateId = splitState.id
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
+            self.dividerPositionRange = dividerPositionRange
             self.onGeometryChange = onGeometryChange
             self.lastAppliedPosition = splitState.dividerPosition
             self.firstNodeType = splitState.first.nodeType
@@ -556,11 +566,13 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             splitState newState: SplitState,
             minimumPaneWidth: CGFloat,
             minimumPaneHeight: CGFloat,
+            dividerPositionRange: ClosedRange<CGFloat>,
             onGeometryChange: ((_ isDragging: Bool) -> Void)?
         ) {
             self.onGeometryChange = onGeometryChange
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
+            self.dividerPositionRange = dividerPositionRange
 
             // If SwiftUI reused this representable for a different split node,
             // reset our cached sync state so we don't "pin" the divider to an edge.
@@ -610,15 +622,21 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             let available = splitAvailableSize(in: splitView)
             guard available > 0 else { return 0...1 }
             let minNormalized = min(0.5, effectiveMinimumPaneSize(in: splitView) / available)
-            return minNormalized...(1 - minNormalized)
+            let lower = max(minNormalized, dividerPositionRange.lowerBound)
+            let upper = min(1 - minNormalized, dividerPositionRange.upperBound)
+            if lower <= upper { return lower...upper }
+            let midpoint = min(max(0.5, dividerPositionRange.lowerBound), dividerPositionRange.upperBound)
+            return midpoint...midpoint
         }
 
         private func clampedDividerPosition(_ position: CGFloat, in splitView: NSSplitView) -> CGFloat {
             let available = splitAvailableSize(in: splitView)
             guard available > 0 else { return 0 }
-            let minPaneSize = effectiveMinimumPaneSize(in: splitView)
-            let maxPosition = max(minPaneSize, available - minPaneSize)
-            return min(max(position, minPaneSize), maxPosition)
+            let bounds = normalizedDividerBounds(in: splitView)
+            return min(
+                max(position, available * bounds.lowerBound),
+                available * bounds.upperBound
+            )
         }
 
         private func dividerHitRectContains(_ point: NSPoint, rect: NSRect) -> Bool {

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -9,6 +9,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
+    let dividerPositionRange: ClosedRange<CGFloat>
     var showSplitButtons: Bool = true
     var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
@@ -34,6 +35,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
                 splitState: splitState,
                 controller: controller,
                 appearance: appearance,
+                dividerPositionRange: dividerPositionRange,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -7,6 +7,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
+    let dividerPositionRange: ClosedRange<CGFloat>
     var showSplitButtons: Bool = true
     var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
@@ -45,6 +46,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
             appearance: appearance,
+            dividerPositionRange: dividerPositionRange,
             showSplitButtons: showSplitButtons,
             tabBarVisibility: tabBarVisibility,
             contentViewLifecycle: contentViewLifecycle,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1439,16 +1439,18 @@ struct TabBarView: View {
         .overlay(
             TabBarHoverTrackingView { updateTabBarHover($0) }
         )
-        .overlay(
-            TabBarManualReorderTrackingView(
-                pane: pane,
-                bonsplitController: controller,
-                splitViewController: splitViewController,
-                tabFrames: tabFramesInBar,
-                dropTargetIndex: $dropTargetIndex,
-                dropLifecycle: $dropLifecycle
-            )
-        )
+        .overlay {
+            if controller.configuration.allowTabReordering {
+                TabBarManualReorderTrackingView(
+                    pane: pane,
+                    bonsplitController: controller,
+                    splitViewController: splitViewController,
+                    tabFrames: tabFramesInBar,
+                    dropTargetIndex: $dropTargetIndex,
+                    dropLifecycle: $dropLifecycle
+                )
+            }
+        }
         .background {
             if splitViewController.tabShortcutHintsEnabled {
                 TabBarHostWindowReader { window in
@@ -3589,6 +3591,7 @@ struct TabDropDelegate: DropDelegate {
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
             if let transfer = decodeTransfer(from: info),
                transfer.isFromCurrentProcess {
+                guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
                 let request = BonsplitController.ExternalTabDropRequest(
                     tabId: TabID(id: transfer.tab.id),
                     sourcePaneId: PaneID(id: transfer.sourcePaneId),
@@ -3602,6 +3605,12 @@ struct TabDropDelegate: DropDelegate {
             }
 
             return performFileDrop(info: info)
+        }
+
+        if sourcePaneId == pane.id {
+            guard bonsplitController.configuration.allowTabReordering else { return false }
+        } else {
+            guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
         }
 
         // Execute synchronously when possible so the dragged tab disappears immediately.
@@ -3727,7 +3736,11 @@ struct TabDropDelegate: DropDelegate {
 
         // Local drags use in-memory state and are always same-process.
         if controller.activeDragTab != nil || controller.draggingTab != nil {
-            return true
+            let sourcePaneID = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId
+            if sourcePaneID == pane.id {
+                return bonsplitController.configuration.allowTabReordering
+            }
+            return bonsplitController.configuration.allowCrossPaneTabMove
         }
 
         // External drags (another Bonsplit controller) must include a payload from this process.
@@ -3735,6 +3748,7 @@ struct TabDropDelegate: DropDelegate {
               transfer.isFromCurrentProcess else {
             return false
         }
+        guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
 #if DEBUG
         let hasDrag = controller.draggingTab != nil
         let hasActive = controller.activeDragTab != nil

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1449,12 +1449,14 @@ struct TabBarView: View {
                 dropLifecycle: $dropLifecycle
             )
         )
-        .background(
-            TabBarHostWindowReader { window in
-                controlKeyMonitor.setHostWindow(window)
+        .background {
+            if splitViewController.tabShortcutHintsEnabled {
+                TabBarHostWindowReader { window in
+                    controlKeyMonitor.setHostWindow(window)
+                }
+                .frame(width: 0, height: 0)
             }
-            .frame(width: 0, height: 0)
-        )
+        }
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
         .onChange(of: splitViewController.draggingTab) { _, newValue in
 #if DEBUG
@@ -1470,7 +1472,16 @@ struct TabBarView: View {
             }
         }
         .onAppear {
-            controlKeyMonitor.start()
+            if splitViewController.tabShortcutHintsEnabled {
+                controlKeyMonitor.start()
+            }
+        }
+        .onChange(of: splitViewController.tabShortcutHintsEnabled) { _, enabled in
+            if enabled {
+                controlKeyMonitor.start()
+            } else {
+                controlKeyMonitor.stop()
+            }
         }
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
             withTransaction(Transaction(animation: nil)) {
@@ -1515,6 +1526,7 @@ struct TabBarView: View {
             showsControlShortcutHint: showsControlShortcutHints,
             shortcutModifierSymbol: controlKeyMonitor.shortcutModifierSymbol,
             allowsClose: controller.configuration.allowCloseTabs,
+            allowsContextMenu: controller.configuration.allowsTabContextMenu,
             contextMenuState: contextMenuState,
             moveDestinationsProvider: {
                 controller.tabContextMoveDestinationsProvider?(TabID(id: tab.id), pane.id) ?? []

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -282,6 +282,7 @@ struct TabItemView: View {
     let showsControlShortcutHint: Bool
     let shortcutModifierSymbol: String
     let allowsClose: Bool
+    let allowsContextMenu: Bool
     let contextMenuState: TabContextMenuState
     let moveDestinationsProvider: () -> [TabContextMoveDestination]
     let forkConversationOpenAvailabilityProvider: () -> Bool?
@@ -343,16 +344,20 @@ struct TabItemView: View {
             guard allowsClose, !tab.isPinned else { return }
             onClose(.middleClick)
         }))
-        .background(TabContextMenuPresenter(
-            snapshot: TabContextMenuSnapshot(
-                tabId: tab.id,
-                state: contextMenuState,
-                moveDestinationsProvider: moveDestinationsProvider,
-                forkConversationOpenAvailabilityProvider: forkConversationOpenAvailabilityProvider
-            ),
-            onContextAction: onContextAction,
-            onMoveDestination: onMoveDestination
-        ))
+        .background {
+            if allowsContextMenu {
+                TabContextMenuPresenter(
+                    snapshot: TabContextMenuSnapshot(
+                        tabId: tab.id,
+                        state: contextMenuState,
+                        moveDestinationsProvider: moveDestinationsProvider,
+                        forkConversationOpenAvailabilityProvider: forkConversationOpenAvailabilityProvider
+                    ),
+                    onContextAction: onContextAction,
+                    onMoveDestination: onMoveDestination
+                )
+            }
+        }
         .onTapGesture {
             onSelect()
         }

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -62,6 +62,9 @@ public struct BonsplitConfiguration: Sendable {
     /// Whether to allow moving tabs between panes
     public var allowCrossPaneTabMove: Bool
 
+    /// Whether tabs install and present their standard context menu.
+    public var allowsTabContextMenu: Bool
+
     /// Whether to automatically close empty panes
     public var autoCloseEmptyPanes: Bool
 
@@ -73,6 +76,13 @@ public struct BonsplitConfiguration: Sendable {
 
     /// Controls when pane tab bars are shown
     public var tabBarVisibility: TabBarVisibility
+
+    /// Normalized range allowed for split divider positions.
+    public var dividerPositionRange: ClosedRange<CGFloat> {
+        didSet {
+            dividerPositionRange = Self.normalizedDividerPositionRange(dividerPositionRange)
+        }
+    }
 
     // MARK: - Appearance
 
@@ -103,10 +113,12 @@ public struct BonsplitConfiguration: Sendable {
         allowCloseLastPane: Bool = false,
         allowTabReordering: Bool = true,
         allowCrossPaneTabMove: Bool = true,
+        allowsTabContextMenu: Bool = true,
         autoCloseEmptyPanes: Bool = true,
         contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch,
         newTabPosition: NewTabPosition = .current,
         tabBarVisibility: TabBarVisibility = .always,
+        dividerPositionRange: ClosedRange<CGFloat> = 0.1...0.9,
         appearance: Appearance = .default
     ) {
         self.allowSplits = allowSplits
@@ -114,11 +126,21 @@ public struct BonsplitConfiguration: Sendable {
         self.allowCloseLastPane = allowCloseLastPane
         self.allowTabReordering = allowTabReordering
         self.allowCrossPaneTabMove = allowCrossPaneTabMove
+        self.allowsTabContextMenu = allowsTabContextMenu
         self.autoCloseEmptyPanes = autoCloseEmptyPanes
         self.contentViewLifecycle = contentViewLifecycle
         self.newTabPosition = newTabPosition
         self.tabBarVisibility = tabBarVisibility
+        self.dividerPositionRange = Self.normalizedDividerPositionRange(dividerPositionRange)
         self.appearance = appearance
+    }
+
+    private static func normalizedDividerPositionRange(
+        _ range: ClosedRange<CGFloat>
+    ) -> ClosedRange<CGFloat> {
+        let lower = min(max(range.lowerBound, 0), 1)
+        let upper = min(max(range.upperBound, lower), 1)
+        return lower...upper
     }
 }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -939,7 +939,7 @@ public final class BonsplitController {
 
     /// Set divider position for a split node (0.0-1.0)
     /// - Parameters:
-    ///   - position: The new divider position (clamped to 0.1-0.9)
+    ///   - position: The new divider position (clamped to the configured range)
     ///   - splitId: The UUID of the split to update
     ///   - fromExternal: Set to true to suppress outgoing notifications (prevents loops)
     /// - Returns: true if the split was found and updated
@@ -951,8 +951,8 @@ public final class BonsplitController {
             internalController.isExternalUpdateInProgress = true
         }
 
-        // Clamp position to valid range
-        let clampedPosition = min(max(position, 0.1), 0.9)
+        let range = configuration.dividerPositionRange
+        let clampedPosition = min(max(position, range.lowerBound), range.upperBound)
         split.dividerPosition = clampedPosition
 
         if fromExternal {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -411,6 +411,7 @@ public final class BonsplitController {
         let sourcePaneId = sourcePane.id
 
         if sourcePaneId == targetPane.id {
+            guard configuration.allowTabReordering else { return false }
             // Reorder within same pane.
             let destinationIndex: Int = {
                 if let index { return max(0, min(index, sourcePane.tabs.count)) }
@@ -424,6 +425,7 @@ public final class BonsplitController {
             return true
         }
 
+        guard configuration.allowCrossPaneTabMove else { return false }
         internalController.moveTab(tabItem, from: sourcePaneId, to: targetPane.id, atIndex: index)
         delegate?.splitTabBar(self, didMoveTab: movedTab, fromPane: sourcePaneId, toPane: targetPane.id)
         notifyGeometryChange()
@@ -437,6 +439,7 @@ public final class BonsplitController {
     /// - Returns: true if reordered.
     @discardableResult
     public func reorderTab(_ tabId: TabID, toIndex: Int) -> Bool {
+        guard configuration.allowTabReordering else { return false }
         guard let (pane, sourceIndex) = findTabInternal(tabId) else { return false }
         let destinationIndex = max(0, min(toIndex, pane.tabs.count))
         pane.moveTab(from: sourceIndex, to: destinationIndex)

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -513,11 +513,12 @@ public final class BonsplitController {
         }
 
         // Perform split
+        let dividerPosition = normalizedInitialDividerPosition(initialDividerPosition)
         internalController.splitPane(
             PaneID(id: targetPaneId.id),
             orientation: orientation,
             with: internalTab,
-            initialDividerPosition: initialDividerPosition
+            initialDividerPosition: dividerPosition
         )
 
         // Find new pane (will be focused after split)
@@ -578,12 +579,13 @@ public final class BonsplitController {
         )
 
         // Perform split with insertion side.
+        let dividerPosition = normalizedInitialDividerPosition(initialDividerPosition)
         internalController.splitPaneWithTab(
             PaneID(id: targetPaneId.id),
             orientation: orientation,
             tab: internalTab,
             insertFirst: insertFirst,
-            initialDividerPosition: initialDividerPosition
+            initialDividerPosition: dividerPosition
         )
 
         let newPaneId = focusedPaneId!
@@ -594,6 +596,15 @@ public final class BonsplitController {
         notifyGeometryChange()
 
         return newPaneId
+    }
+
+    private func normalizedInitialDividerPosition(_ position: CGFloat?) -> CGFloat? {
+        position.map {
+            min(
+                max($0, configuration.dividerPositionRange.lowerBound),
+                configuration.dividerPositionRange.upperBound
+            )
+        }
     }
 
     /// Split a pane by moving an existing tab into the new pane.

--- a/Sources/Bonsplit/Public/BonsplitView.swift
+++ b/Sources/Bonsplit/Public/BonsplitView.swift
@@ -46,6 +46,7 @@ public struct BonsplitView<Content: View, EmptyContent: View>: View {
                 emptyPaneBuilder(PaneID(id: internalPaneId.id))
             },
             appearance: controller.configuration.appearance,
+            dividerPositionRange: controller.configuration.dividerPositionRange,
             showSplitButtons: controller.configuration.allowSplits && controller.configuration.appearance.showSplitButtons,
             tabBarVisibility: controller.configuration.tabBarVisibility,
             contentViewLifecycle: controller.configuration.contentViewLifecycle,

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -31,4 +31,21 @@ final class EmbeddedConfigurationTests: XCTestCase {
         }
         XCTAssertEqual(updated.dividerPosition, 0.02, accuracy: 0.0001)
     }
+
+    func testDisabledTabMovesRejectBothReorderAndCrossPaneMutation() throws {
+        let controller = BonsplitController(configuration: BonsplitConfiguration(
+            allowTabReordering: false,
+            allowCrossPaneTabMove: false
+        ))
+        let rootPane = try XCTUnwrap(controller.allPaneIds.first)
+        let firstTab = try XCTUnwrap(controller.createTab(title: "first", inPane: rootPane))
+        _ = try XCTUnwrap(controller.createTab(title: "second", inPane: rootPane))
+        let secondPane = try XCTUnwrap(controller.splitPane(rootPane, orientation: .horizontal))
+        let orderBefore = controller.tabs(inPane: rootPane).map(\.id)
+
+        XCTAssertFalse(controller.reorderTab(firstTab, toIndex: 1))
+        XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
+        XCTAssertFalse(controller.moveTab(firstTab, toPane: secondPane))
+        XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
+    }
 }

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Bonsplit
+
+@MainActor
+final class EmbeddedConfigurationTests: XCTestCase {
+    func testEmbeddedBehaviorControlsAreOptIn() {
+        let configuration = BonsplitConfiguration()
+
+        XCTAssertTrue(configuration.allowsTabContextMenu)
+        XCTAssertEqual(configuration.dividerPositionRange, 0.1...0.9)
+    }
+
+    func testConfiguredDividerRangeAllowsNarrowProgrammaticLayouts() throws {
+        let configuration = BonsplitConfiguration(
+            allowsTabContextMenu: false,
+            dividerPositionRange: 0...1
+        )
+        let controller = BonsplitController(configuration: configuration)
+        let rootPane = try XCTUnwrap(controller.allPaneIds.first)
+        XCTAssertNotNil(controller.splitPane(rootPane, orientation: .horizontal))
+        guard case .split(let split) = controller.treeSnapshot() else {
+            XCTFail("Expected split root")
+            return
+        }
+        let splitID = try XCTUnwrap(UUID(uuidString: split.id))
+
+        XCTAssertTrue(controller.setDividerPosition(0.02, forSplit: splitID))
+        guard case .split(let updated) = controller.treeSnapshot() else {
+            XCTFail("Expected split root")
+            return
+        }
+        XCTAssertEqual(updated.dividerPosition, 0.02, accuracy: 0.0001)
+    }
+}

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -17,19 +17,24 @@ final class EmbeddedConfigurationTests: XCTestCase {
         )
         let controller = BonsplitController(configuration: configuration)
         let rootPane = try XCTUnwrap(controller.allPaneIds.first)
-        XCTAssertNotNil(controller.splitPane(rootPane, orientation: .horizontal))
+        XCTAssertNotNil(controller.splitPane(
+            rootPane,
+            orientation: .horizontal,
+            initialDividerPosition: 0.02
+        ))
         guard case .split(let split) = controller.treeSnapshot() else {
             XCTFail("Expected split root")
             return
         }
+        XCTAssertEqual(split.dividerPosition, 0.02, accuracy: 0.0001)
         let splitID = try XCTUnwrap(UUID(uuidString: split.id))
 
-        XCTAssertTrue(controller.setDividerPosition(0.02, forSplit: splitID))
+        XCTAssertTrue(controller.setDividerPosition(0.98, forSplit: splitID))
         guard case .split(let updated) = controller.treeSnapshot() else {
             XCTFail("Expected split root")
             return
         }
-        XCTAssertEqual(updated.dividerPosition, 0.02, accuracy: 0.0001)
+        XCTAssertEqual(updated.dividerPosition, 0.98, accuracy: 0.0001)
     }
 
     func testDisabledTabMovesRejectBothReorderAndCrossPaneMutation() throws {


### PR DESCRIPTION
Supports embedded split trees that need native pane chrome without outer-window-only interaction surfaces.

- make tab context menus configurable
- gate shortcut monitor lifecycle when hints are disabled
- make divider position bounds configurable
- preserve existing defaults for current hosts

Required by manaflow-ai/cmux#7406.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232491&installation_id=133855650&pr_number=167&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F167&signature=244ddab795697047b2bec35efce4dd719ff6621da183b6fdd3cf87279db244a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an embedded split interaction policy with opt-in tab context menus, divider bounds, and shortcut hints, enforces tab-move rules across drag/drop and APIs, and clamps initial split positions to the configured range. Defaults are unchanged; required by manaflow-ai/cmux#7406.

- **New Features**
  - `BonsplitConfiguration.allowsTabContextMenu` to enable/disable tab context menus (default: true).
  - `BonsplitConfiguration.dividerPositionRange` to constrain divider positions (normalized, default: 0.1...0.9). Clamping now honors this plus minimum pane size; initial split positions are clamped to this range.
  - Shortcut hint monitor only attaches/starts when shortcut hints are enabled; stops when disabled.
  - Tests cover defaults and allow programmatic narrow layouts (e.g., `0...1`).

- **Bug Fixes**
  - Honor `allowTabReordering` and `allowCrossPaneTabMove` in drag/drop validation, drops, and programmatic moves (`reorderTab`, `moveTab`). Manual reorder overlay is gated by `allowTabReordering`. Added tests to confirm behavior.

<sup>Written for commit 68158bd1b433263564c9f9499bf687251247886c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable divider positioning ranges, including support for the full split range.
  * Added a setting to enable or disable tab context menus.
  * Improved controls for tab reordering and moving tabs between panes.

* **Bug Fixes**
  * Divider positions now consistently respect configured limits.
  * Tab drag-and-drop actions now correctly honor reordering and cross-pane movement settings.
  * Shortcut monitoring and reordering indicators only appear when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->