### PR TITLE
Enforce embedded cross-pane move policy for edge splits

### DIFF
--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -411,6 +411,9 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 
         let hasTabTransfer = info.hasItemsConforming(to: [.tabTransfer])
         let hasFileURL = info.hasItemsConforming(to: [.fileURL])
+        if hasTabTransfer, !bonsplitController.configuration.allowCrossPaneTabMove {
+            return false
+        }
 
         // Read from non-observable drag state. @Observable writes from createItemProvider
         // may not have propagated yet when performDrop runs.
@@ -554,6 +557,9 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         let hasTabTransfer = info.hasItemsConforming(to: [.tabTransfer])
         let hasFileURL = info.hasItemsConforming(to: [.fileURL])
         guard hasTabTransfer || hasFileURL else { return false }
+        if hasTabTransfer, !bonsplitController.configuration.allowCrossPaneTabMove {
+            return false
+        }
 
         if Self.isFileDropOnly(hasTabTransfer: hasTabTransfer, hasFileURL: hasFileURL) {
             guard Self.acceptsFileDrop(

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -411,9 +411,23 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 
         let hasTabTransfer = info.hasItemsConforming(to: [.tabTransfer])
         let hasFileURL = info.hasItemsConforming(to: [.fileURL])
-        if hasTabTransfer, !bonsplitController.configuration.allowCrossPaneTabMove {
-            return false
+        let tabTransferPermitted = permitsTabTransfer(
+            hasTabTransfer: hasTabTransfer,
+            zone: zone
+        )
+        if Self.shouldHandleFileDrop(
+            hasTabTransfer: hasTabTransfer,
+            hasFileURL: hasFileURL,
+            permitsTabTransfer: tabTransferPermitted
+        ) {
+            let handled = performFileDrop(info: info, zone: zone)
+            if handled {
+                dropLifecycle = .idle
+                activeDropZone = nil
+            }
+            return handled
         }
+        guard !hasTabTransfer || tabTransferPermitted else { return false }
 
         // Read from non-observable drag state. @Observable writes from createItemProvider
         // may not have propagated yet when performDrop runs.
@@ -527,9 +541,10 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             return DropProposal(operation: dropOperation(for: info))
         }
         let zone = effectiveZone(for: info)
+        let shouldHandleFileDrop = shouldHandleFileDrop(info, zone: zone)
         guard let acceptedZone = Self.acceptedDropZone(
             zone,
-            isFileDropOnly: isFileDropOnly(info),
+            isFileDropOnly: shouldHandleFileDrop,
             hasExternalFileDropHandler: bonsplitController.onExternalFileDrop != nil,
             hasLegacyFileDropHandler: controller.onFileDrop != nil
         ) else {
@@ -557,18 +572,26 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         let hasTabTransfer = info.hasItemsConforming(to: [.tabTransfer])
         let hasFileURL = info.hasItemsConforming(to: [.fileURL])
         guard hasTabTransfer || hasFileURL else { return false }
-        if hasTabTransfer, !bonsplitController.configuration.allowCrossPaneTabMove {
-            return false
-        }
+        let zone = effectiveZone(for: info)
+        let tabTransferPermitted = permitsTabTransfer(
+            hasTabTransfer: hasTabTransfer,
+            zone: zone
+        )
 
-        if Self.isFileDropOnly(hasTabTransfer: hasTabTransfer, hasFileURL: hasFileURL) {
+        if Self.shouldHandleFileDrop(
+            hasTabTransfer: hasTabTransfer,
+            hasFileURL: hasFileURL,
+            permitsTabTransfer: tabTransferPermitted
+        ) {
             guard Self.acceptsFileDrop(
-                zone: effectiveZone(for: info),
+                zone: zone,
                 hasExternalFileDropHandler: bonsplitController.onExternalFileDrop != nil,
                 hasLegacyFileDropHandler: controller.onFileDrop != nil
             ), Self.hasReadableFileURLs() else {
                 return false
             }
+        } else if !tabTransferPermitted {
+            return false
         } else if controller.activeDragTab != nil || controller.draggingTab != nil {
             // Local tab drags use in-memory state and are always same-process.
             return true
@@ -623,20 +646,42 @@ struct UnifiedPaneDropDelegate: DropDelegate {
     }
 
     private func dropOperation(for info: DropInfo) -> DropOperation {
-        isFileDropOnly(info)
+        shouldHandleFileDrop(info, zone: effectiveZone(for: info))
             ? .copy
             : .move
     }
 
-    private func isFileDropOnly(_ info: DropInfo) -> Bool {
-        Self.isFileDropOnly(
-            hasTabTransfer: info.hasItemsConforming(to: [.tabTransfer]),
-            hasFileURL: info.hasItemsConforming(to: [.fileURL])
+    private func shouldHandleFileDrop(_ info: DropInfo, zone: DropZone) -> Bool {
+        let hasTabTransfer = info.hasItemsConforming(to: [.tabTransfer])
+        return Self.shouldHandleFileDrop(
+            hasTabTransfer: hasTabTransfer,
+            hasFileURL: info.hasItemsConforming(to: [.fileURL]),
+            permitsTabTransfer: permitsTabTransfer(
+                hasTabTransfer: hasTabTransfer,
+                zone: zone
+            )
         )
     }
 
     static func isFileDropOnly(hasTabTransfer: Bool, hasFileURL: Bool) -> Bool {
         hasFileURL && !hasTabTransfer
+    }
+
+    static func shouldHandleFileDrop(
+        hasTabTransfer: Bool,
+        hasFileURL: Bool,
+        permitsTabTransfer: Bool
+    ) -> Bool {
+        hasFileURL && (!hasTabTransfer || !permitsTabTransfer)
+    }
+
+    private func permitsTabTransfer(hasTabTransfer: Bool, zone: DropZone) -> Bool {
+        guard hasTabTransfer else { return false }
+        let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId
+        if zone == .center, sourcePaneId == pane.id {
+            return true
+        }
+        return bonsplitController.configuration.allowCrossPaneTabMove
     }
 
     static func shouldUseLocalTabDrag(

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -353,7 +353,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 
     private func effectiveZone(for info: DropInfo) -> DropZone {
         let defaultZone = zoneForLocation(info.location)
-        guard !isFileDropOnly(info) else {
+        guard !shouldHandleFileDrop(info, zone: defaultZone) else {
             return defaultZone
         }
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -626,7 +626,8 @@ public final class BonsplitController {
         movingTab tabId: TabID,
         insertFirst: Bool
     ) -> PaneID? {
-        guard configuration.allowSplits else { return nil }
+        guard configuration.allowSplits,
+              configuration.allowCrossPaneTabMove else { return nil }
 
         // Find the existing tab and its source pane.
         guard let (sourcePane, tabIndex) = findTabInternal(tabId) else { return nil }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2849,6 +2849,30 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
+    func testMixedFileDropFallsBackWhenTabTransferIsNotPermitted() {
+        XCTAssertTrue(
+            UnifiedPaneDropDelegate.shouldHandleFileDrop(
+                hasTabTransfer: true,
+                hasFileURL: true,
+                permitsTabTransfer: false
+            )
+        )
+        XCTAssertFalse(
+            UnifiedPaneDropDelegate.shouldHandleFileDrop(
+                hasTabTransfer: true,
+                hasFileURL: true,
+                permitsTabTransfer: true
+            )
+        )
+        XCTAssertTrue(
+            UnifiedPaneDropDelegate.shouldHandleFileDrop(
+                hasTabTransfer: false,
+                hasFileURL: true,
+                permitsTabTransfer: false
+            )
+        )
+    }
+
     func testSelectedTabNeverShowsHoverBackground() {
         XCTAssertFalse(
             TabItemStyling.shouldShowHoverBackground(isHovered: true, isSelected: true)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2871,6 +2871,13 @@ final class BonsplitTests: XCTestCase {
                 permitsTabTransfer: false
             )
         )
+        XCTAssertFalse(
+            UnifiedPaneDropDelegate.shouldHandleFileDrop(
+                hasTabTransfer: true,
+                hasFileURL: false,
+                permitsTabTransfer: false
+            )
+        )
     }
 
     func testSelectedTabNeverShowsHoverBackground() {

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -52,5 +52,14 @@ final class EmbeddedConfigurationTests: XCTestCase {
         XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
         XCTAssertFalse(controller.moveTab(firstTab, toPane: secondPane))
         XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
+        let paneCountBefore = controller.allPaneIds.count
+        XCTAssertNil(controller.splitPane(
+            rootPane,
+            orientation: .vertical,
+            movingTab: firstTab,
+            insertFirst: false
+        ))
+        XCTAssertEqual(controller.allPaneIds.count, paneCountBefore)
+        XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
     }
 }


### PR DESCRIPTION
Follow-up to #167.

The shared moving-tab split API and pane-content drop surface now honor `allowCrossPaneTabMove` before any source mutation. Adds behavioral coverage for the edge-split path.

Required by manaflow-ai/cmux#7406 structured review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786233943&installation_id=133855650&pr_number=168&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F168&signature=0f7a1c3a24c4e6fee34f01704fd75bd622910f027c16032941ee6ded10fe73f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the `allowCrossPaneTabMove` policy for edge splits and pane drop targets, and classifies mixed tab+file drags before zone routing so file copies still work when tab moves are blocked. Cross‑pane tab moves are blocked in embedded mode before any state changes; adds coverage for mixed‑payload fallback and edge‑split paths.

- **Bug Fixes**
  - `splitPane(..., movingTab:)` and cross‑pane `.tabTransfer` drops now check the policy upfront; tab‑only cross‑pane drops are rejected with no pane/tab mutations.
  - Mixed payloads fall back to file copy; pure file drops still work; same‑pane center drops remain allowed.

<sup>Written for commit e250d04966d67a15d77b8aaa4f58b0e95b1be1a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

