### PR TITLE
Enforce divider range for default splits and drifted dividers

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -737,10 +737,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 let firstSubview = splitView.arrangedSubviews[0]
                 return splitState.orientation == .horizontal ? firstSubview.frame.width : firstSubview.frame.height
             }()
-            let currentNormalized = max(
-                stateBounds.lowerBound,
-                min(stateBounds.upperBound, currentDividerPixels / availableSize)
-            )
+            // Compare the RAW ratio, not a pre-clamped one: clamping the
+            // current position into stateBounds before the equality check
+            // would let a divider that physically drifted outside the
+            // configured range (window resize, range narrowed on a reused
+            // split view) satisfy the early return and stay out of range.
+            let currentNormalized = currentDividerPixels / availableSize
 
             if abs(clampedStatePosition - lastAppliedPosition) <= 0.01 &&
                 abs(currentNormalized - clampedStatePosition) <= 0.01 {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -598,13 +598,14 @@ public final class BonsplitController {
         return newPaneId
     }
 
-    private func normalizedInitialDividerPosition(_ position: CGFloat?) -> CGFloat? {
-        position.map {
-            min(
-                max($0, configuration.dividerPositionRange.lowerBound),
-                configuration.dividerPositionRange.upperBound
-            )
-        }
+    private func normalizedInitialDividerPosition(_ position: CGFloat?) -> CGFloat {
+        // A nil position must not bypass the configured range: the internal
+        // controller's 0.5 fallback can sit outside a narrowed range, so the
+        // default is clamped here exactly like an explicit position.
+        min(
+            max(position ?? 0.5, configuration.dividerPositionRange.lowerBound),
+            configuration.dividerPositionRange.upperBound
+        )
     }
 
     /// Split a pane by moving an existing tab into the new pane.

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3433,6 +3433,80 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testSyncRestoresDividerThatDriftedOutsideConfiguredRange() throws {
+        let controller = BonsplitController(configuration: BonsplitConfiguration(
+            dividerPositionRange: 0.4...0.6,
+            appearance: .init(enableAnimations: false)
+        ))
+        _ = controller.createTab(title: "Base")
+        let sourcePane = try XCTUnwrap(controller.focusedPaneId)
+        XCTAssertNotNil(controller.splitPane(
+            sourcePane,
+            orientation: .horizontal,
+            initialDividerPosition: 0.4
+        ))
+        guard case .split = controller.treeSnapshot() else {
+            XCTFail("Expected split root")
+            return
+        }
+
+        let hostingView = NSHostingView(
+            rootView: BonsplitView(controller: controller) { _, _ in
+                Color.clear
+            } emptyPane: { _ in
+                Color.clear
+            }
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try XCTUnwrap(window.contentView)
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+
+        let splitView = try XCTUnwrap(firstDescendant(ofType: NSSplitView.self, in: hostingView))
+        XCTAssertEqual(splitView.arrangedSubviews.count, 2)
+        let available = max(splitView.frame.width - splitView.dividerThickness, 1)
+
+        // Push the divider physically below the configured range without
+        // touching the model — the delegate constrain hooks enforce only the
+        // minimum pane size, mirroring an AppKit-driven (non-drag) resize.
+        // The non-drag resize path re-asserts the model position through
+        // syncPosition; that re-assert must compare the RAW pixel ratio, not a
+        // pre-clamped value that masks the out-of-range divider and
+        // early-returns.
+        splitView.setPosition(available * 0.2, ofDividerAt: 0)
+        splitView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        contentView.layoutSubtreeIfNeeded()
+        XCTAssertEqual(
+            splitView.arrangedSubviews[0].frame.width / available,
+            0.4,
+            accuracy: 0.02,
+            "Sync should restore an out-of-range divider to the model position"
+        )
+        guard case .split(let finalSplit) = controller.treeSnapshot() else {
+            XCTFail("Expected split root")
+            return
+        }
+        XCTAssertEqual(
+            finalSplit.dividerPosition,
+            0.4,
+            accuracy: 0.0001,
+            "A non-drag resize must not move the model divider position"
+        )
+    }
+
+    @MainActor
     func testTranslucentSplitWrappersStayClear() {
         let appearance = BonsplitConfiguration.Appearance(
             enableAnimations: false,

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -37,6 +37,21 @@ final class EmbeddedConfigurationTests: XCTestCase {
         XCTAssertEqual(updated.dividerPosition, 0.98, accuracy: 0.0001)
     }
 
+    func testDefaultSplitPositionRespectsConfiguredDividerRange() throws {
+        let controller = BonsplitController(configuration: BonsplitConfiguration(
+            dividerPositionRange: 0.6...0.9
+        ))
+        let rootPane = try XCTUnwrap(controller.allPaneIds.first)
+        XCTAssertNotNil(controller.splitPane(rootPane, orientation: .horizontal))
+        guard case .split(let split) = controller.treeSnapshot() else {
+            XCTFail("Expected split root")
+            return
+        }
+        // The implicit 0.5 default must be clamped into the configured range,
+        // exactly like an explicit initialDividerPosition.
+        XCTAssertEqual(split.dividerPosition, 0.6, accuracy: 0.0001)
+    }
+
     func testDisabledTabMovesRejectBothReorderAndCrossPaneMutation() throws {
         let controller = BonsplitController(configuration: BonsplitConfiguration(
             allowTabReordering: false,


### PR DESCRIPTION
Addresses the two remaining CodeRabbit findings on #167:

1. **Default (nil) divider position bypasses the configured range** — `normalizedInitialDividerPosition` now clamps the implicit 0.5 default into `dividerPositionRange` instead of passing nil through to the internal hardcoded fallback.
2. **Pre-clamped comparison masks out-of-range dividers** — `syncPosition` now compares the raw `currentDividerPixels / availableSize` ratio, so a divider that physically drifted outside the configured range (non-drag AppKit resize) is re-asserted to the model position instead of early-returning.

Both fixes verified red/green: `testDefaultSplitPositionRespectsConfiguredDividerRange` fails at 0.5 and `testSyncRestoresDividerThatDriftedOutsideConfiguredRange` fails at 0.2 without the fixes. Full suite: 184/184 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786238904&installation_id=133855650&pr_number=169&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F169&signature=632799410d574a86287274db62054120b3a6cc1ef41fa8d6d2f89041352434fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `dividerPositionRange` for default split position and restores dividers that drift outside the range after non-drag resizes. Prevents bypassing the configured range and keeps the view in sync with the model.

- **Bug Fixes**
  - Clamp the implicit 0.5 default into `dividerPositionRange` in `normalizedInitialDividerPosition`.
  - In `syncPosition`, compare the raw ratio (`currentDividerPixels / availableSize`) and re-assert the clamped model position when the divider drifts out of range.

<sup>Written for commit 4b46851cc17a6ed1a06e529dfb4e90ad238f2f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Divider positions that drift outside the configured range are now automatically restored.
  * Default divider placement now respects configured position limits, including when no initial position is provided.

* **Tests**
  * Added coverage for restoring out-of-range dividers and clamping default positions to configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->