### PR TITLE
Clamp the moved-tab split path default divider position

### DIFF
--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -657,12 +657,14 @@ public final class BonsplitController {
             }
         }
 
-        // Perform split with the moved tab.
+        // Perform split with the moved tab. Forward the clamped default so the
+        // moved-tab path honors dividerPositionRange like the other overloads.
         internalController.splitPaneWithTab(
             PaneID(id: targetPaneId.id),
             orientation: orientation,
             tab: tabItem,
-            insertFirst: insertFirst
+            insertFirst: insertFirst,
+            initialDividerPosition: normalizedInitialDividerPosition(nil)
         )
 
         let newPaneId = focusedPaneId!

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -52,6 +52,28 @@ final class EmbeddedConfigurationTests: XCTestCase {
         XCTAssertEqual(split.dividerPosition, 0.6, accuracy: 0.0001)
     }
 
+    func testMovingTabSplitRespectsConfiguredDividerRange() throws {
+        let controller = BonsplitController(configuration: BonsplitConfiguration(
+            dividerPositionRange: 0.6...0.9
+        ))
+        let rootPane = try XCTUnwrap(controller.allPaneIds.first)
+        let firstTab = try XCTUnwrap(controller.createTab(title: "first", inPane: rootPane))
+        _ = try XCTUnwrap(controller.createTab(title: "second", inPane: rootPane))
+        XCTAssertNotNil(controller.splitPane(
+            rootPane,
+            orientation: .horizontal,
+            movingTab: firstTab,
+            insertFirst: false
+        ))
+        guard case .split(let split) = controller.treeSnapshot() else {
+            XCTFail("Expected split root")
+            return
+        }
+        // The moved-tab split path must clamp its implicit default like the
+        // tab-creating overloads.
+        XCTAssertEqual(split.dividerPosition, 0.6, accuracy: 0.0001)
+    }
+
     func testDisabledTabMovesRejectBothReorderAndCrossPaneMutation() throws {
         let controller = BonsplitController(configuration: BonsplitConfiguration(
             allowTabReordering: false,


### PR DESCRIPTION
Addresses the remaining CodeRabbit finding on #169: the `movingTab` overload of `splitPane` bypassed the configured `dividerPositionRange` because it called `splitPaneWithTab` without an `initialDividerPosition`, hitting the internal hardcoded 0.5 default.

The clamped default is now forwarded like the tab-creating overloads. Red/green verified: `testMovingTabSplitRespectsConfiguredDividerRange` fails at 0.5 without the fix. Full suite: 185/185 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786239369&installation_id=133855650&pr_number=170&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F170&signature=3a345448f222d6badf7f98733320cb363a83cc64b09b4ea81efcaa196e7f62d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes moved-tab splits to honor `dividerPositionRange` by forwarding a clamped default divider position instead of falling back to 0.5. Adds a unit test to ensure the divider defaults to the configured lower bound when 0.5 is out of range.

- **Bug Fixes**
  - Forward the clamped default to split with a moved tab so it matches other split overloads.
  - Added test to verify a 0.6...0.9 range yields a 0.6 divider position when moving a tab.

<sup>Written for commit 660642adb2683058a70a52870d0bdffe6a961500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

