### PR TITLE
Make the divider drag hit expansion configurable via Appearance

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -18,6 +18,20 @@ private class ThemedSplitView: NSSplitView {
         }
     }
 
+    /// Host-configured extra points on each side of the drawn divider that
+    /// still count as the divider for drag hit-testing. Cursor rects derive
+    /// from the effective divider rect, so invalidate them on change.
+    var customDividerHitExpansion: CGFloat? {
+        didSet {
+            guard oldValue != customDividerHitExpansion else { return }
+            window?.invalidateCursorRects(for: self)
+        }
+    }
+
+    var resolvedDividerHitExpansion: CGFloat {
+        max(0, customDividerHitExpansion ?? 5)
+    }
+
     override var dividerColor: NSColor {
         customDividerColor ?? super.dividerColor
     }
@@ -153,6 +167,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 #endif
         splitView.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
         splitView.customDividerThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
+        splitView.customDividerHitExpansion = appearance.dividerHitExpansion
         splitView.isVertical = splitState.orientation == .horizontal
         splitView.dividerStyle = .thin
         splitView.delegate = context.coordinator
@@ -365,6 +380,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         let resolvedThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
         let dividerThicknessChanged = (splitView as? ThemedSplitView)?.customDividerThickness != resolvedThickness
         (splitView as? ThemedSplitView)?.customDividerThickness = resolvedThickness
+        (splitView as? ThemedSplitView)?.customDividerHitExpansion = appearance.dividerHitExpansion
 
         // Update orientation if changed
         splitView.isVertical = splitState.orientation == .horizontal
@@ -842,7 +858,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             // Match the divider's expanded effective rect and treat the max edge
             // as inside so drag tracking doesn't miss when AppKit reports a point
             // exactly on the divider boundary during multi-split resizes.
-            let hitRect = dividerRect.insetBy(dx: -5, dy: -5)
+            let expansion = Self.dividerHitExpansion(for: splitView)
+            let hitRect = dividerRect.insetBy(dx: -expansion, dy: -expansion)
             if dividerHitRectContains(location, rect: hitRect) {
                 isDragging = true
 #if DEBUG
@@ -965,7 +982,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         }
 
         func splitView(_ splitView: NSSplitView, effectiveRect proposedEffectiveRect: NSRect, forDrawnRect drawnRect: NSRect, ofDividerAt dividerIndex: Int) -> NSRect {
-            let expanded = drawnRect.insetBy(dx: -5, dy: -5)
+            let expansion = Self.dividerHitExpansion(for: splitView)
+            let expanded = drawnRect.insetBy(dx: -expansion, dy: -expansion)
             return proposedEffectiveRect.union(expanded)
         }
 
@@ -987,7 +1005,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 dividerRect = NSRect(x: 0, y: y, width: splitView.bounds.width, height: thickness)
             }
 
-            return dividerRect.insetBy(dx: -5, dy: -5)
+            let expansion = Self.dividerHitExpansion(for: splitView)
+            return dividerRect.insetBy(dx: -expansion, dy: -expansion)
+        }
+
+        private static func dividerHitExpansion(for splitView: NSSplitView) -> CGFloat {
+            (splitView as? ThemedSplitView)?.resolvedDividerHitExpansion ?? 5
         }
 
         func splitView(_ splitView: NSSplitView, constrainMinCoordinate proposedMinimumPosition: CGFloat, ofSubviewAt dividerIndex: Int) -> CGFloat {

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -559,6 +559,14 @@ extension BonsplitConfiguration {
         /// Values are clamped to a sane range when applied to the split view.
         public var dividerThickness: CGFloat
 
+        /// Extra points on each side of the drawn divider that still count as
+        /// the divider for drag hit-testing (the effective divider rect).
+        ///
+        /// Defaults to `5`, matching the historical hardcoded expansion. Hosts
+        /// that show a resize cursor over a wider band must raise this to the
+        /// same value so every point that shows the cursor can start a drag.
+        public var dividerHitExpansion: CGFloat
+
         /// Whether to show split buttons in the tab bar
         public var showSplitButtons: Bool
 
@@ -637,6 +645,7 @@ extension BonsplitConfiguration {
             minimumPaneWidth: CGFloat = 100,
             minimumPaneHeight: CGFloat = 100,
             dividerThickness: CGFloat = 1,
+            dividerHitExpansion: CGFloat = 5,
             showSplitButtons: Bool = true,
             splitButtons: [SplitActionButton] = SplitActionButton.defaults,
             splitButtonsOnHover: Bool = false,
@@ -658,6 +667,7 @@ extension BonsplitConfiguration {
             self.minimumPaneWidth = minimumPaneWidth
             self.minimumPaneHeight = minimumPaneHeight
             self.dividerThickness = dividerThickness
+            self.dividerHitExpansion = dividerHitExpansion
             self.showSplitButtons = showSplitButtons
             self.splitButtons = Self.uniqueSplitButtons(splitButtons)
             self.splitButtonsOnHover = splitButtonsOnHover


### PR DESCRIPTION
cmux is widening the pane-divider resize-cursor band (hard to hit at ±5pt). Every point that shows the resize cursor must also start a drag, so the effective divider rect needs the same expansion. This adds `Appearance.dividerHitExpansion` (default 5, preserving current behavior) and threads it through `ThemedSplitView` to both `effectiveRect` delegate methods and the manual drag-start hit check.

Consumer: cmux will pass its `PortalSplitDividerRegion.dividerHitExpansion` so cursor band and drag band stay one constant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786255316&installation_id=133855650&pr_number=171&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F171&signature=ec1ecb27498fb518d0b6b0f3915bc0f409925bcdb4ada3a350b255c781d6caa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the divider drag hit area configurable so the resize cursor band and drag band stay in sync. Adds `Appearance.dividerHitExpansion` with a default of 5 to preserve current behavior.

- **New Features**
  - Introduced `Appearance.dividerHitExpansion` to control extra hit area around the divider.
  - Plumbed through `ThemedSplitView` to `effectiveRect` delegate methods and the manual drag-start check.
  - Invalidates cursor rects on change to keep cursor and drag regions aligned.

<sup>Written for commit 3d057311bf9856518229430f12e240dbd6fce738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

