### PR TITLE
Suppress duplicate geometry callbacks

### DIFF
--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -36,7 +36,13 @@ public final class BonsplitController {
     // MARK: - Delegate
 
     /// Delegate for receiving callbacks about tab bar events
-    public weak var delegate: BonsplitDelegate?
+    public weak var delegate: BonsplitDelegate? {
+        didSet {
+            if oldValue !== delegate {
+                lastDeliveredGeometrySnapshot = nil
+            }
+        }
+    }
 
     // MARK: - Configuration
 
@@ -111,6 +117,7 @@ public final class BonsplitController {
     // MARK: - Internal State
 
     internal var internalController: SplitViewController
+    @ObservationIgnored private var lastDeliveredGeometrySnapshot: LayoutSnapshot?
 
     // MARK: - Initialization
 
@@ -1007,8 +1014,11 @@ public final class BonsplitController {
             internalController.lastGeometryNotificationTime = now
         }
 
+        guard let delegate else { return }
         let snapshot = layoutSnapshot()
-        delegate?.splitTabBar(self, didChangeGeometry: snapshot)
+        guard lastDeliveredGeometrySnapshot?.hasSameLayout(as: snapshot) != true else { return }
+        lastDeliveredGeometrySnapshot = snapshot
+        delegate.splitTabBar(self, didChangeGeometry: snapshot)
     }
 
     // MARK: - Private Helpers

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -39,7 +39,7 @@ public final class BonsplitController {
     public weak var delegate: BonsplitDelegate? {
         didSet {
             if oldValue !== delegate {
-                lastDeliveredGeometrySnapshot = nil
+                lastDeliveredGeometryState = nil
             }
         }
     }
@@ -117,7 +117,24 @@ public final class BonsplitController {
     // MARK: - Internal State
 
     internal var internalController: SplitViewController
-    @ObservationIgnored private var lastDeliveredGeometrySnapshot: LayoutSnapshot?
+
+    private struct GeometryDeliveryState {
+        let snapshot: LayoutSnapshot
+        let zoomedPaneId: PaneID?
+        let tabBarVisibility: TabBarVisibility
+        let tabBarHeight: CGFloat
+        let dividerThickness: CGFloat
+
+        func hasSameGeometry(as other: GeometryDeliveryState) -> Bool {
+            snapshot.hasSameLayout(as: other.snapshot) &&
+                zoomedPaneId == other.zoomedPaneId &&
+                tabBarVisibility == other.tabBarVisibility &&
+                tabBarHeight == other.tabBarHeight &&
+                dividerThickness == other.dividerThickness
+        }
+    }
+
+    @ObservationIgnored private var lastDeliveredGeometryState: GeometryDeliveryState?
 
     // MARK: - Initialization
 
@@ -1017,8 +1034,15 @@ public final class BonsplitController {
 
         guard let delegate else { return }
         let snapshot = layoutSnapshot()
-        guard lastDeliveredGeometrySnapshot?.hasSameLayout(as: snapshot) != true else { return }
-        lastDeliveredGeometrySnapshot = snapshot
+        let deliveryState = GeometryDeliveryState(
+            snapshot: snapshot,
+            zoomedPaneId: zoomedPaneId,
+            tabBarVisibility: configuration.tabBarVisibility,
+            tabBarHeight: configuration.appearance.tabBarHeight,
+            dividerThickness: configuration.appearance.dividerThickness
+        )
+        guard lastDeliveredGeometryState?.hasSameGeometry(as: deliveryState) != true else { return }
+        lastDeliveredGeometryState = deliveryState
         delegate.splitTabBar(self, didChangeGeometry: snapshot)
     }
 

--- a/Sources/Bonsplit/Public/Types/LayoutSnapshot.swift
+++ b/Sources/Bonsplit/Public/Types/LayoutSnapshot.swift
@@ -56,6 +56,17 @@ public struct LayoutSnapshot: Codable, Sendable, Equatable {
         self.focusedPaneId = focusedPaneId
         self.timestamp = timestamp
     }
+
+    /// Returns whether two snapshots describe the same rendered layout.
+    ///
+    /// `timestamp` records when a snapshot was captured, not a layout input, so
+    /// it is intentionally excluded. The existing `Equatable` conformance stays
+    /// timestamp-sensitive for callers comparing complete captured snapshots.
+    public func hasSameLayout(as other: LayoutSnapshot) -> Bool {
+        containerFrame == other.containerFrame &&
+            panes == other.panes &&
+            focusedPaneId == other.focusedPaneId
+    }
 }
 
 // MARK: - External Tree Representation

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -200,6 +200,140 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
+    func testLayoutEquivalenceCoversEveryOverlayInput() {
+        let containerFrame = PixelRect(x: 10, y: 20, width: 800, height: 600)
+        let firstPane = PaneGeometry(
+            paneId: "pane-a",
+            frame: PixelRect(x: 10, y: 20, width: 400, height: 600),
+            selectedTabId: "tab-a",
+            tabIds: ["tab-a", "tab-b"]
+        )
+        let secondPane = PaneGeometry(
+            paneId: "pane-b",
+            frame: PixelRect(x: 410, y: 20, width: 400, height: 600),
+            selectedTabId: "tab-c",
+            tabIds: ["tab-c"]
+        )
+        let base = LayoutSnapshot(
+            containerFrame: containerFrame,
+            panes: [firstPane, secondPane],
+            focusedPaneId: "pane-a",
+            timestamp: 100
+        )
+        let timestampOnlyChange = LayoutSnapshot(
+            containerFrame: containerFrame,
+            panes: [firstPane, secondPane],
+            focusedPaneId: "pane-a",
+            timestamp: 200
+        )
+
+        XCTAssertTrue(base.hasSameLayout(as: timestampOnlyChange))
+        XCTAssertNotEqual(base, timestampOnlyChange, "Equatable must remain timestamp-sensitive")
+
+        let changedFirstPaneId = PaneGeometry(
+            paneId: "pane-z",
+            frame: firstPane.frame,
+            selectedTabId: firstPane.selectedTabId,
+            tabIds: firstPane.tabIds
+        )
+        let changedFirstPaneFrame = PaneGeometry(
+            paneId: firstPane.paneId,
+            frame: PixelRect(x: 10, y: 20, width: 450, height: 600),
+            selectedTabId: firstPane.selectedTabId,
+            tabIds: firstPane.tabIds
+        )
+        let changedFirstPaneSelection = PaneGeometry(
+            paneId: firstPane.paneId,
+            frame: firstPane.frame,
+            selectedTabId: "tab-b",
+            tabIds: firstPane.tabIds
+        )
+        let changedFirstPaneTabOrder = PaneGeometry(
+            paneId: firstPane.paneId,
+            frame: firstPane.frame,
+            selectedTabId: firstPane.selectedTabId,
+            tabIds: ["tab-b", "tab-a"]
+        )
+        let variants: [(String, LayoutSnapshot)] = [
+            (
+                "container frame",
+                LayoutSnapshot(
+                    containerFrame: PixelRect(x: 10, y: 20, width: 900, height: 600),
+                    panes: [firstPane, secondPane],
+                    focusedPaneId: "pane-a",
+                    timestamp: 100
+                )
+            ),
+            (
+                "pane id",
+                LayoutSnapshot(
+                    containerFrame: containerFrame,
+                    panes: [changedFirstPaneId, secondPane],
+                    focusedPaneId: "pane-a",
+                    timestamp: 100
+                )
+            ),
+            (
+                "pane frame",
+                LayoutSnapshot(
+                    containerFrame: containerFrame,
+                    panes: [changedFirstPaneFrame, secondPane],
+                    focusedPaneId: "pane-a",
+                    timestamp: 100
+                )
+            ),
+            (
+                "selected tab",
+                LayoutSnapshot(
+                    containerFrame: containerFrame,
+                    panes: [changedFirstPaneSelection, secondPane],
+                    focusedPaneId: "pane-a",
+                    timestamp: 100
+                )
+            ),
+            (
+                "tab order",
+                LayoutSnapshot(
+                    containerFrame: containerFrame,
+                    panes: [changedFirstPaneTabOrder, secondPane],
+                    focusedPaneId: "pane-a",
+                    timestamp: 100
+                )
+            ),
+            (
+                "pane order",
+                LayoutSnapshot(
+                    containerFrame: containerFrame,
+                    panes: [secondPane, firstPane],
+                    focusedPaneId: "pane-a",
+                    timestamp: 100
+                )
+            ),
+            (
+                "pane membership",
+                LayoutSnapshot(
+                    containerFrame: containerFrame,
+                    panes: [firstPane],
+                    focusedPaneId: "pane-a",
+                    timestamp: 100
+                )
+            ),
+            (
+                "focused pane",
+                LayoutSnapshot(
+                    containerFrame: containerFrame,
+                    panes: [firstPane, secondPane],
+                    focusedPaneId: "pane-b",
+                    timestamp: 100
+                )
+            ),
+        ]
+
+        for (label, variant) in variants {
+            XCTAssertFalse(base.hasSameLayout(as: variant), label)
+        }
+    }
+
     @MainActor
     func testGeometryDedupCacheResetsForNewDelegate() {
         let controller = BonsplitController()

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -146,6 +146,19 @@ final class BonsplitTests: XCTestCase {
         }
     }
 
+    @MainActor
+    private final class GeometryDelegateSpy: BonsplitDelegate {
+        var snapshots: [LayoutSnapshot] = []
+        var reenterOnFirstGeometryChange = false
+
+        func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {
+            snapshots.append(snapshot)
+            if reenterOnFirstGeometryChange, snapshots.count == 1 {
+                controller.notifyGeometryChange()
+            }
+        }
+    }
+
     private final class ObservationInvalidationFlag: @unchecked Sendable {
         var didInvalidate = false
     }
@@ -154,6 +167,76 @@ final class BonsplitTests: XCTestCase {
     func testControllerCreation() {
         let controller = BonsplitController()
         XCTAssertNotNil(controller.focusedPaneId)
+    }
+
+    @MainActor
+    func testNotifyGeometryChangeSuppressesTimestampOnlyDuplicate() {
+        let controller = BonsplitController()
+        let delegate = GeometryDelegateSpy()
+        controller.delegate = delegate
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+
+        controller.notifyGeometryChange()
+        controller.notifyGeometryChange()
+
+        XCTAssertEqual(delegate.snapshots.count, 1)
+    }
+
+    @MainActor
+    func testNotifyGeometryChangeDeliversContainerFrameChange() throws {
+        let controller = BonsplitController()
+        let delegate = GeometryDelegateSpy()
+        controller.delegate = delegate
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+
+        controller.notifyGeometryChange()
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 900, height: 600))
+        controller.notifyGeometryChange()
+
+        XCTAssertEqual(delegate.snapshots.count, 2)
+        XCTAssertEqual(
+            try XCTUnwrap(delegate.snapshots.last?.containerFrame),
+            PixelRect(x: 10, y: 20, width: 900, height: 600)
+        )
+    }
+
+    @MainActor
+    func testGeometryDedupCacheResetsForNewDelegate() {
+        let controller = BonsplitController()
+        let firstDelegate = GeometryDelegateSpy()
+        let secondDelegate = GeometryDelegateSpy()
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+
+        controller.delegate = firstDelegate
+        controller.notifyGeometryChange()
+        controller.delegate = firstDelegate
+        controller.notifyGeometryChange()
+        XCTAssertEqual(
+            firstDelegate.snapshots.count,
+            1,
+            "Reassigning the same delegate must preserve deduplication"
+        )
+
+        controller.delegate = nil
+        controller.notifyGeometryChange()
+        controller.delegate = secondDelegate
+        controller.notifyGeometryChange()
+
+        XCTAssertEqual(firstDelegate.snapshots.count, 1)
+        XCTAssertEqual(secondDelegate.snapshots.count, 1)
+    }
+
+    @MainActor
+    func testGeometryDedupCachesBeforeReentrantDelegateCallback() {
+        let controller = BonsplitController()
+        let delegate = GeometryDelegateSpy()
+        delegate.reenterOnFirstGeometryChange = true
+        controller.delegate = delegate
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+
+        controller.notifyGeometryChange()
+
+        XCTAssertEqual(delegate.snapshots.count, 1)
     }
 
     @MainActor

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -374,6 +374,55 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testGeometryDedupDeliversZoomStateChange() throws {
+        let controller = BonsplitController()
+        let delegate = GeometryDelegateSpy()
+        controller.delegate = delegate
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+        let zoomedPane = try XCTUnwrap(
+            controller.splitPane(orientation: .horizontal)
+        )
+        let deliveryCountBeforeZoom = delegate.snapshots.count
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: zoomedPane))
+        controller.notifyGeometryChange()
+
+        XCTAssertEqual(delegate.snapshots.count, deliveryCountBeforeZoom + 1)
+    }
+
+    @MainActor
+    func testGeometryDedupDeliversTabBarVisibilityChange() {
+        let controller = BonsplitController()
+        let delegate = GeometryDelegateSpy()
+        controller.delegate = delegate
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+        controller.notifyGeometryChange()
+        let deliveryCountBeforeVisibilityChange = delegate.snapshots.count
+
+        controller.configuration.tabBarVisibility = .multipleTabs
+        controller.notifyGeometryChange()
+        controller.notifyGeometryChange()
+
+        XCTAssertEqual(delegate.snapshots.count, deliveryCountBeforeVisibilityChange + 1)
+    }
+
+    @MainActor
+    func testGeometryDedupDeliversDividerThicknessChange() {
+        let controller = BonsplitController()
+        let delegate = GeometryDelegateSpy()
+        controller.delegate = delegate
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+        controller.notifyGeometryChange()
+        let deliveryCountBeforeThicknessChange = delegate.snapshots.count
+
+        controller.configuration.appearance.dividerThickness = 4
+        controller.notifyGeometryChange()
+        controller.notifyGeometryChange()
+
+        XCTAssertEqual(delegate.snapshots.count, deliveryCountBeforeThicknessChange + 1)
+    }
+
+    @MainActor
     func testTabCreation() {
         let controller = BonsplitController()
         let tabId = controller.createTab(title: "Test Tab", icon: "doc")


### PR DESCRIPTION
Geometry callbacks previously delivered a fresh timestamped LayoutSnapshot even when every rendered field was unchanged. cmux republishes that snapshot and invalidates mounted workspace layout.

This caches the last delivered semantic layout, excludes capture timestamp from the dedup key, resets on delegate replacement, and caches before callback reentry. Real container, pane, selection, tab-order, and focus changes still deliver.

Proof:
- Regression commit 6d81025 compiles and fails 3 focused behavior tests on the old implementation.
- Fix commit fba2e5f passes all 190 package tests.
- Independent audit found no timestamp-heartbeat consumer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786275419&installation_id=133855650&pr_number=172&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F172&signature=3e70c38ef1f05606d54f652a94f46cdde6d758da5e42154995f560bf7ca4ab70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress duplicate geometry callbacks by deduping the full rendered geometry (layout, zoom state, tab bar, divider), ignoring timestamp-only changes. This cuts redundant workspace invalidations and improves performance.

- **Bug Fixes**
  - Cache last delivered geometry state in `BonsplitController` (snapshot + zoomed pane + tab bar visibility/height + divider thickness) and skip duplicates.
  - Add `LayoutSnapshot.hasSameLayout(...)` that ignores `timestamp`; still notify on any real layout or geometry change.
  - Reset state when the `delegate` changes and cache before invoking the delegate to handle reentrancy; tests cover zoom, tab bar and divider changes, container frame changes, delegate swaps, and timestamp-only heartbeats.

<sup>Written for commit 35bc42972522a3b18b802fa8c7e313ef406fb4c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate geometry updates by deduplicating geometry-change notifications when only non-layout details (such as capture time) change.
  * Continued delivering geometry updates when relevant layout-affecting details change, including container size, pane arrangement, focus, zoom, tab bar visibility, or divider thickness.
  * Reset geometry deduplication when the active delegate is cleared or replaced to ensure the next update is delivered.
  * Improved robustness for re-entrant geometry update scenarios initiated during delegate callbacks.
* **New Features**
  * Added a public layout-comparison helper to check whether two layout snapshots match while ignoring capture time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->