### PR TITLE
Add constant-time pane ownership lookups

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -6,7 +6,11 @@ import SwiftUI
 @MainActor
 final class SplitViewController {
     /// The root node of the split tree
-    var rootNode: SplitNode
+    private(set) var rootNode: SplitNode
+
+    /// Live indexes for host queries that must not walk the split tree.
+    @ObservationIgnored private var paneStatesById: [PaneID: PaneState]
+    @ObservationIgnored private var paneIdsByTabId: [UUID: PaneID]
 
     /// Currently zoomed pane. When set, rendering should only show this pane.
     var zoomedPaneId: PaneID?
@@ -63,14 +67,82 @@ final class SplitViewController {
     var onGeometryChange: (() -> Void)?
 
     init(rootNode: SplitNode? = nil) {
+        let resolvedRoot: SplitNode
+        let initialFocusedPaneId: PaneID?
         if let rootNode {
-            self.rootNode = rootNode
+            resolvedRoot = rootNode
+            initialFocusedPaneId = nil
         } else {
             // Initialize with a single pane containing a welcome tab
             let welcomeTab = TabItem(title: "Welcome", icon: "star")
             let initialPane = PaneState(tabs: [welcomeTab])
-            self.rootNode = .pane(initialPane)
-            self.focusedPaneId = initialPane.id
+            resolvedRoot = .pane(initialPane)
+            initialFocusedPaneId = initialPane.id
+        }
+
+        let indexes = Self.makeIndexes(for: resolvedRoot)
+        self.rootNode = resolvedRoot
+        self.paneStatesById = indexes.panes
+        self.paneIdsByTabId = indexes.tabOwners
+        self.focusedPaneId = initialFocusedPaneId
+    }
+
+    // MARK: - Indexed State
+
+    func paneState(for paneId: PaneID) -> PaneState? {
+        paneStatesById[paneId]
+    }
+
+    func paneId(containing tabId: UUID) -> PaneID? {
+        paneIdsByTabId[tabId]
+    }
+
+    func selectedTabId(inPane paneId: PaneID) -> UUID? {
+        paneStatesById[paneId]?.selectedTabId
+    }
+
+    var paneCount: Int {
+        paneStatesById.count
+    }
+
+    private static func makeIndexes(
+        for rootNode: SplitNode
+    ) -> (panes: [PaneID: PaneState], tabOwners: [UUID: PaneID]) {
+        var panes: [PaneID: PaneState] = [:]
+        var tabOwners: [UUID: PaneID] = [:]
+        var pendingNodes = [rootNode]
+
+        while let node = pendingNodes.popLast() {
+            switch node {
+            case .pane(let pane):
+                panes[pane.id] = pane
+                for tab in pane.tabs {
+                    tabOwners[tab.id] = pane.id
+                }
+            case .split(let split):
+                pendingNodes.append(split.second)
+                pendingNodes.append(split.first)
+            }
+        }
+
+        return (panes, tabOwners)
+    }
+
+    private func registerPane(_ pane: PaneState) {
+        if let replacedPane = paneStatesById.updateValue(pane, forKey: pane.id) {
+            for tab in replacedPane.tabs where paneIdsByTabId[tab.id] == pane.id {
+                paneIdsByTabId.removeValue(forKey: tab.id)
+            }
+        }
+        for tab in pane.tabs {
+            paneIdsByTabId[tab.id] = pane.id
+        }
+    }
+
+    private func unregisterPane(_ paneId: PaneID) {
+        guard let pane = paneStatesById.removeValue(forKey: paneId) else { return }
+        for tab in pane.tabs where paneIdsByTabId[tab.id] == paneId {
+            paneIdsByTabId.removeValue(forKey: tab.id)
         }
     }
 
@@ -78,7 +150,7 @@ final class SplitViewController {
 
     /// Set focus to a specific pane
     func focusPane(_ paneId: PaneID) {
-        guard rootNode.findPane(paneId) != nil else { return }
+        guard paneStatesById[paneId] != nil else { return }
 #if DEBUG
         dlog("focus.bonsplit pane=\(paneId.id.uuidString.prefix(5))")
 #endif
@@ -88,12 +160,12 @@ final class SplitViewController {
     /// Get the currently focused pane state
     var focusedPane: PaneState? {
         guard let focusedPaneId else { return nil }
-        return rootNode.findPane(focusedPaneId)
+        return paneStatesById[focusedPaneId]
     }
 
     var zoomedNode: SplitNode? {
-        guard let zoomedPaneId else { return nil }
-        return rootNode.findNode(containing: zoomedPaneId)
+        guard let zoomedPaneId, let pane = paneStatesById[zoomedPaneId] else { return nil }
+        return .pane(pane)
     }
 
     @discardableResult
@@ -105,7 +177,7 @@ final class SplitViewController {
 
     @discardableResult
     func togglePaneZoom(_ paneId: PaneID) -> Bool {
-        guard rootNode.findPane(paneId) != nil else { return false }
+        guard paneStatesById[paneId] != nil else { return false }
 
         if zoomedPaneId == paneId {
             zoomedPaneId = nil
@@ -113,7 +185,7 @@ final class SplitViewController {
         }
 
         // Match Ghostty behavior: a single-pane layout can't be zoomed.
-        guard rootNode.allPaneIds.count > 1 else { return false }
+        guard paneStatesById.count > 1 else { return false }
         zoomedPaneId = paneId
         focusedPaneId = paneId
         return true
@@ -128,14 +200,20 @@ final class SplitViewController {
         with newTab: TabItem? = nil,
         initialDividerPosition: CGFloat? = nil
     ) {
+        guard paneStatesById[paneId] != nil else { return }
         clearPaneZoom()
+        var createdPane: PaneState?
         rootNode = splitNodeRecursively(
             node: rootNode,
             targetPaneId: paneId,
             orientation: orientation,
             newTab: newTab,
-            initialDividerPosition: initialDividerPosition
+            initialDividerPosition: initialDividerPosition,
+            createdPane: &createdPane
         )
+        if let createdPane {
+            registerPane(createdPane)
+        }
     }
 
     private func splitNodeRecursively(
@@ -143,7 +221,8 @@ final class SplitViewController {
         targetPaneId: PaneID,
         orientation: SplitOrientation,
         newTab: TabItem?,
-        initialDividerPosition: CGFloat?
+        initialDividerPosition: CGFloat?,
+        createdPane: inout PaneState?
     ) -> SplitNode {
         switch node {
         case .pane(let paneState):
@@ -170,6 +249,7 @@ final class SplitViewController {
 
                 // Focus the new pane
                 focusedPaneId = newPane.id
+                createdPane = newPane
 
                 return .split(splitState)
             }
@@ -181,15 +261,19 @@ final class SplitViewController {
                 targetPaneId: targetPaneId,
                 orientation: orientation,
                 newTab: newTab,
-                initialDividerPosition: initialDividerPosition
+                initialDividerPosition: initialDividerPosition,
+                createdPane: &createdPane
             )
-            splitState.second = splitNodeRecursively(
-                node: splitState.second,
-                targetPaneId: targetPaneId,
-                orientation: orientation,
-                newTab: newTab,
-                initialDividerPosition: initialDividerPosition
-            )
+            if createdPane == nil {
+                splitState.second = splitNodeRecursively(
+                    node: splitState.second,
+                    targetPaneId: targetPaneId,
+                    orientation: orientation,
+                    newTab: newTab,
+                    initialDividerPosition: initialDividerPosition,
+                    createdPane: &createdPane
+                )
+            }
             return .split(splitState)
         }
     }
@@ -202,15 +286,21 @@ final class SplitViewController {
         insertFirst: Bool,
         initialDividerPosition: CGFloat? = nil
     ) {
+        guard paneStatesById[paneId] != nil else { return }
         clearPaneZoom()
+        var createdPane: PaneState?
         rootNode = splitNodeWithTabRecursively(
             node: rootNode,
             targetPaneId: paneId,
             orientation: orientation,
             tab: tab,
             insertFirst: insertFirst,
-            initialDividerPosition: initialDividerPosition
+            initialDividerPosition: initialDividerPosition,
+            createdPane: &createdPane
         )
+        if let createdPane {
+            registerPane(createdPane)
+        }
     }
 
     private func splitNodeWithTabRecursively(
@@ -219,7 +309,8 @@ final class SplitViewController {
         orientation: SplitOrientation,
         tab: TabItem,
         insertFirst: Bool,
-        initialDividerPosition: CGFloat?
+        initialDividerPosition: CGFloat?,
+        createdPane: inout PaneState?
     ) -> SplitNode {
         switch node {
         case .pane(let paneState):
@@ -251,6 +342,7 @@ final class SplitViewController {
 
                 // Focus the new pane
                 focusedPaneId = newPane.id
+                createdPane = newPane
 
                 return .split(splitState)
             }
@@ -263,16 +355,20 @@ final class SplitViewController {
                 orientation: orientation,
                 tab: tab,
                 insertFirst: insertFirst,
-                initialDividerPosition: initialDividerPosition
+                initialDividerPosition: initialDividerPosition,
+                createdPane: &createdPane
             )
-            splitState.second = splitNodeWithTabRecursively(
-                node: splitState.second,
-                targetPaneId: targetPaneId,
-                orientation: orientation,
-                tab: tab,
-                insertFirst: insertFirst,
-                initialDividerPosition: initialDividerPosition
-            )
+            if createdPane == nil {
+                splitState.second = splitNodeWithTabRecursively(
+                    node: splitState.second,
+                    targetPaneId: targetPaneId,
+                    orientation: orientation,
+                    tab: tab,
+                    insertFirst: insertFirst,
+                    initialDividerPosition: initialDividerPosition,
+                    createdPane: &createdPane
+                )
+            }
             return .split(splitState)
         }
     }
@@ -285,13 +381,14 @@ final class SplitViewController {
     /// Close a pane and collapse the split
     func closePane(_ paneId: PaneID) {
         // Don't close the last pane
-        guard rootNode.allPaneIds.count > 1 else { return }
+        guard paneStatesById.count > 1, paneStatesById[paneId] != nil else { return }
 
         let (newRoot, siblingPaneId) = closePaneRecursively(node: rootNode, targetPaneId: paneId)
 
         if let newRoot {
             rootNode = newRoot
         }
+        unregisterPane(paneId)
 
         // Focus the sibling or first available pane
         if let siblingPaneId {
@@ -300,7 +397,7 @@ final class SplitViewController {
             focusedPaneId = firstPane
         }
 
-        if let zoomedPaneId, rootNode.findPane(zoomedPaneId) == nil {
+        if let zoomedPaneId, paneStatesById[zoomedPaneId] == nil {
             self.zoomedPaneId = nil
         }
     }
@@ -352,47 +449,69 @@ final class SplitViewController {
     func addTab(_ tab: TabItem, toPane paneId: PaneID? = nil, atIndex index: Int? = nil) {
         let targetPaneId = paneId ?? focusedPaneId
         guard let targetPaneId,
-              let pane = rootNode.findPane(targetPaneId) else { return }
+              let pane = paneStatesById[targetPaneId] else { return }
 
         if let index {
             pane.insertTab(tab, at: index)
         } else {
             pane.addTab(tab)
         }
+        paneIdsByTabId[tab.id] = targetPaneId
     }
 
     /// Move a tab from one pane to another
     func moveTab(_ tab: TabItem, from sourcePaneId: PaneID, to targetPaneId: PaneID, atIndex index: Int? = nil) {
-        guard let sourcePane = rootNode.findPane(sourcePaneId),
-              let targetPane = rootNode.findPane(targetPaneId) else { return }
+        guard let sourcePane = paneStatesById[sourcePaneId],
+              let targetPane = paneStatesById[targetPaneId] else { return }
 
-        // Remove from source
-        sourcePane.removeTab(tab.id)
+        if sourcePaneId == targetPaneId {
+            guard let sourceIndex = sourcePane.tabs.firstIndex(where: { $0.id == tab.id }) else { return }
+            sourcePane.moveTab(
+                from: sourceIndex,
+                to: index.map { min(max(0, $0), sourcePane.tabs.count) } ?? sourcePane.tabs.count
+            )
+            sourcePane.selectTab(tab.id)
+            focusPane(sourcePaneId)
+            return
+        }
 
-        // Add to target
+        guard removeTab(tab.id, fromPane: sourcePaneId) != nil else { return }
+
         if let index {
             targetPane.insertTab(tab, at: index)
         } else {
             targetPane.addTab(tab)
         }
+        paneIdsByTabId[tab.id] = targetPaneId
 
         // Focus target pane
         focusPane(targetPaneId)
 
         // If source pane is now empty and not the only pane, close it
-        if sourcePane.tabs.isEmpty && rootNode.allPaneIds.count > 1 {
+        if sourcePane.tabs.isEmpty && paneStatesById.count > 1 {
             closePane(sourcePaneId)
         }
     }
 
+    /// Remove a tab while keeping its pane in the tree.
+    /// Callers that leave an empty pane decide whether to close or refill it.
+    @discardableResult
+    func removeTab(_ tabId: UUID, fromPane paneId: PaneID) -> TabItem? {
+        guard let pane = paneStatesById[paneId],
+              let removedTab = pane.removeTab(tabId) else { return nil }
+        if paneIdsByTabId[tabId] == paneId {
+            paneIdsByTabId.removeValue(forKey: tabId)
+        }
+        return removedTab
+    }
+
     /// Close a tab in a specific pane
     func closeTab(_ tabId: UUID, inPane paneId: PaneID) {
-        guard let pane = rootNode.findPane(paneId) else { return }
-
-        pane.removeTab(tabId)
+        guard let pane = paneStatesById[paneId],
+              removeTab(tabId, fromPane: paneId) != nil else { return }
 
         // If pane is now empty and not the only pane, close it
-        if pane.tabs.isEmpty && rootNode.allPaneIds.count > 1 {
+        if pane.tabs.isEmpty && paneStatesById.count > 1 {
             closePane(paneId)
         }
     }
@@ -478,7 +597,7 @@ final class SplitViewController {
         guard let pane = focusedPane else { return }
         let count = pane.tabs.count + 1
         let newTab = TabItem(title: "Untitled \(count)", icon: "doc")
-        pane.addTab(newTab)
+        addTab(newTab, toPane: pane.id)
     }
 
     /// Close the currently selected tab in the focused pane

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -183,7 +183,7 @@ public final class BonsplitController {
         switch configuration.newTabPosition {
         case .current:
             // Insert after the currently selected tab
-            if let paneState = internalController.rootNode.findPane(PaneID(id: targetPane.id)),
+            if let paneState = internalController.paneState(for: targetPane),
                let selectedTabId = paneState.selectedTabId,
                let currentIndex = paneState.tabs.firstIndex(where: { $0.id == selectedTabId }) {
                 insertIndex = currentIndex + 1
@@ -351,7 +351,7 @@ public final class BonsplitController {
     /// - Parameter tabId: The tab to close
     /// - Parameter paneId: The pane in which to close the tab
     public func closeTab(_ tabId: TabID, inPane paneId: PaneID) -> Bool {
-        guard let pane = internalController.rootNode.findPane(paneId),
+        guard let pane = internalController.paneState(for: paneId),
               let tabIndex = pane.tabs.firstIndex(where: { $0.id == tabId.id }) else {
             return false
         }
@@ -404,7 +404,7 @@ public final class BonsplitController {
     @discardableResult
     public func moveTab(_ tabId: TabID, toPane targetPaneId: PaneID, atIndex index: Int? = nil) -> Bool {
         guard let (sourcePane, sourceIndex) = findTabInternal(tabId) else { return false }
-        guard let targetPane = internalController.rootNode.findPane(PaneID(id: targetPaneId.id)) else { return false }
+        guard let targetPane = internalController.paneState(for: targetPaneId) else { return false }
 
         let tabItem = sourcePane.tabs[sourceIndex]
         let movedTab = Tab(from: tabItem)
@@ -636,6 +636,7 @@ public final class BonsplitController {
 
         // Default target to the tab's current pane to match edge-drop behavior on the source pane.
         let targetPaneId = paneId ?? sourcePane.id
+        guard internalController.paneState(for: targetPaneId) != nil else { return nil }
 
         // Check with delegate
         if delegate?.splitTabBar(self, shouldSplitPane: targetPaneId, orientation: orientation) == false {
@@ -643,15 +644,20 @@ public final class BonsplitController {
         }
 
         // Remove from source first.
-        sourcePane.removeTab(tabItem.id)
+        guard internalController.removeTab(tabItem.id, fromPane: sourcePane.id) != nil else {
+            return nil
+        }
 
         if sourcePane.tabs.isEmpty {
             if sourcePane.id == targetPaneId {
                 // Keep a placeholder tab so the original pane isn't left "tabless".
                 // This makes the empty side closable via tab close, and avoids apps
                 // needing to special-case empty panes.
-                sourcePane.addTab(TabItem(title: "Empty", icon: nil), select: true)
-            } else if internalController.rootNode.allPaneIds.count > 1 {
+                internalController.addTab(
+                    TabItem(title: "Empty", icon: nil),
+                    toPane: sourcePane.id
+                )
+            } else if internalController.paneCount > 1 {
                 // If the source pane is now empty, close it (unless it's also the split target).
                 internalController.closePane(sourcePane.id)
             }
@@ -683,7 +689,7 @@ public final class BonsplitController {
     @discardableResult
     public func closePane(_ paneId: PaneID) -> Bool {
         // Don't close if it's the last pane and not allowed
-        if !configuration.allowCloseLastPane && internalController.rootNode.allPaneIds.count <= 1 {
+        if !configuration.allowCloseLastPane && internalController.paneCount <= 1 {
             return false
         }
 
@@ -783,7 +789,7 @@ public final class BonsplitController {
     /// - Returns: `true` when the pane exists and was updated; otherwise `false`.
     @discardableResult
     public func setFullWidthTabMode(_ enabled: Bool, inPane pane: PaneID) -> Bool {
-        guard let paneState = internalController.rootNode.findPane(pane) else { return false }
+        guard let paneState = internalController.paneState(for: pane) else { return false }
         paneState.isFullWidthTabMode = enabled
         return true
     }
@@ -792,7 +798,7 @@ public final class BonsplitController {
     ///
     /// Unknown panes are treated as off and return `false`.
     public func isFullWidthTabMode(inPane pane: PaneID) -> Bool {
-        internalController.rootNode.findPane(pane)?.isFullWidthTabMode ?? false
+        internalController.paneState(for: pane)?.isFullWidthTabMode ?? false
     }
 
     /// Toggle full-width-tab mode for a pane.
@@ -801,7 +807,7 @@ public final class BonsplitController {
     /// - Returns: The new mode state when the pane exists. Returns `false` without mutating state when the pane is unknown.
     @discardableResult
     public func toggleFullWidthTabMode(inPane pane: PaneID) -> Bool {
-        guard let paneState = internalController.rootNode.findPane(pane) else { return false }
+        guard let paneState = internalController.paneState(for: pane) else { return false }
         paneState.isFullWidthTabMode.toggle()
         return paneState.isFullWidthTabMode
     }
@@ -849,15 +855,29 @@ public final class BonsplitController {
 
     /// Get tabs in a specific pane
     public func tabs(inPane paneId: PaneID) -> [Tab] {
-        guard let pane = internalController.rootNode.findPane(PaneID(id: paneId.id)) else {
+        guard let pane = internalController.paneState(for: paneId) else {
             return []
         }
         return pane.tabs.map { Tab(from: $0) }
     }
 
+    /// Get the pane that currently owns a tab.
+    ///
+    /// This lookup is constant time and does not walk the split tree.
+    public func paneId(containing tabId: TabID) -> PaneID? {
+        internalController.paneId(containing: tabId.id)
+    }
+
+    /// Get the selected tab ID in a pane.
+    ///
+    /// This lookup is constant time and does not scan the pane's tabs.
+    public func selectedTabId(inPane paneId: PaneID) -> TabID? {
+        internalController.selectedTabId(inPane: paneId).map(TabID.init(id:))
+    }
+
     /// Get selected tab in a pane
     public func selectedTab(inPane paneId: PaneID) -> Tab? {
-        guard let pane = internalController.rootNode.findPane(PaneID(id: paneId.id)),
+        guard let pane = internalController.paneState(for: paneId),
               let selected = pane.selectedTab else {
             return nil
         }
@@ -872,7 +892,7 @@ public final class BonsplitController {
         let paneBounds = internalController.rootNode.computePaneBounds()
 
         let paneGeometries = paneBounds.map { bounds -> PaneGeometry in
-            let pane = internalController.rootNode.findPane(bounds.paneId)
+            let pane = internalController.paneState(for: bounds.paneId)
             let pixelFrame = PixelRect(
                 x: Double(bounds.bounds.minX * containerFrame.width + containerFrame.origin.x),
                 y: Double(bounds.bounds.minY * containerFrame.height + containerFrame.origin.y),
@@ -1014,12 +1034,10 @@ public final class BonsplitController {
     // MARK: - Private Helpers
 
     private func findTabInternal(_ tabId: TabID) -> (PaneState, Int)? {
-        for pane in internalController.rootNode.allPanes {
-            if let index = pane.tabs.firstIndex(where: { $0.id == tabId.id }) {
-                return (pane, index)
-            }
-        }
-        return nil
+        guard let paneId = internalController.paneId(containing: tabId.id),
+              let pane = internalController.paneState(for: paneId),
+              let index = pane.tabs.firstIndex(where: { $0.id == tabId.id }) else { return nil }
+        return (pane, index)
     }
 
     private func notifyTabSelection() {

--- a/Tests/BonsplitTests/PaneOwnershipIndexTests.swift
+++ b/Tests/BonsplitTests/PaneOwnershipIndexTests.swift
@@ -8,6 +8,7 @@ final class PaneOwnershipIndexTests: XCTestCase {
             configuration: BonsplitConfiguration(newTabPosition: .end)
         )
         let paneId = try! XCTUnwrap(controller.focusedPaneId)
+        let welcomeTabId = try! XCTUnwrap(controller.tabs(inPane: paneId).only?.id)
         let firstTabId = try! XCTUnwrap(controller.createTab(title: "First"))
         let secondTabId = try! XCTUnwrap(controller.createTab(title: "Second"))
 
@@ -21,6 +22,60 @@ final class PaneOwnershipIndexTests: XCTestCase {
 
         XCTAssertEqual(controller.selectedTabId(inPane: paneId), firstTabId)
         XCTAssertEqual(controller.selectedTab(inPane: paneId)?.id, firstTabId)
+
+        XCTAssertTrue(controller.moveTab(firstTabId, toPane: paneId, atIndex: 3))
+        XCTAssertEqual(
+            paneState.tabs.map(\.id),
+            [welcomeTabId.uuid, secondTabId.uuid, firstTabId.uuid]
+        )
+        XCTAssertEqual(controller.paneId(containing: firstTabId), paneId)
+        XCTAssertEqual(controller.selectedTabId(inPane: paneId), firstTabId)
+
+        let firstTabItem = try! XCTUnwrap(paneState.tabs.first { $0.id == firstTabId.uuid })
+        controller.internalController.moveTab(
+            firstTabItem,
+            from: paneId,
+            to: paneId,
+            atIndex: 0
+        )
+        XCTAssertEqual(
+            paneState.tabs.map(\.id),
+            [firstTabId.uuid, welcomeTabId.uuid, secondTabId.uuid]
+        )
+        XCTAssertEqual(controller.paneId(containing: firstTabId), paneId)
+        XCTAssertEqual(controller.selectedTabId(inPane: paneId), firstTabId)
+
+        XCTAssertTrue(controller.closeTab(firstTabId))
+        XCTAssertNil(controller.paneId(containing: firstTabId))
+        XCTAssertEqual(controller.selectedTabId(inPane: paneId), welcomeTabId)
+    }
+
+    @MainActor
+    func testSplitVariantsIndexEmptyAndInsertedPanes() {
+        let controller = BonsplitController()
+        let originalPaneId = try! XCTUnwrap(controller.focusedPaneId)
+
+        let emptyPaneId = try! XCTUnwrap(
+            controller.splitPane(originalPaneId, orientation: .vertical)
+        )
+        XCTAssertNil(controller.selectedTabId(inPane: emptyPaneId))
+
+        let emptyPaneTabId = try! XCTUnwrap(
+            controller.createTab(title: "Empty pane tab", inPane: emptyPaneId)
+        )
+        XCTAssertEqual(controller.paneId(containing: emptyPaneTabId), emptyPaneId)
+
+        let insertedTab = Tab(title: "Inserted first")
+        let insertedPaneId = try! XCTUnwrap(
+            controller.splitPane(
+                originalPaneId,
+                orientation: .horizontal,
+                withTab: insertedTab,
+                insertFirst: true
+            )
+        )
+        XCTAssertEqual(controller.paneId(containing: insertedTab.id), insertedPaneId)
+        XCTAssertEqual(controller.selectedTabId(inPane: insertedPaneId), insertedTab.id)
     }
 
     @MainActor
@@ -102,7 +157,7 @@ final class PaneOwnershipIndexTests: XCTestCase {
     }
 
     @MainActor
-    func testReplacingRestoredTreeRebuildsIndexesAndRepairsFocusAndZoom() {
+    func testRestoredTreeBootstrapsIndexesAndRejectsInvalidFocus() {
         let leftTab = TabItem(title: "Left")
         let rightTab = TabItem(title: "Right")
         let leftPane = PaneState(tabs: [leftTab])
@@ -120,15 +175,15 @@ final class PaneOwnershipIndexTests: XCTestCase {
         XCTAssertEqual(controller.paneId(containing: rightTab.id), rightPane.id)
         controller.focusPane(rightPane.id)
         XCTAssertTrue(controller.togglePaneZoom(rightPane.id))
+        controller.focusPane(PaneID())
 
-        let replacementTab = TabItem(title: "Replacement")
-        let replacementPane = PaneState(tabs: [replacementTab])
-        controller.replaceRootNode(.pane(replacementPane))
+        XCTAssertEqual(controller.focusedPaneId, rightPane.id)
+        XCTAssertEqual(controller.zoomedPaneId, rightPane.id)
 
-        XCTAssertNil(controller.paneId(containing: leftTab.id))
+        controller.closePane(rightPane.id)
         XCTAssertNil(controller.paneId(containing: rightTab.id))
-        XCTAssertEqual(controller.paneId(containing: replacementTab.id), replacementPane.id)
-        XCTAssertEqual(controller.focusedPaneId, replacementPane.id)
+        XCTAssertEqual(controller.paneId(containing: leftTab.id), leftPane.id)
+        XCTAssertEqual(controller.focusedPaneId, leftPane.id)
         XCTAssertNil(controller.zoomedPaneId)
     }
 }

--- a/Tests/BonsplitTests/PaneOwnershipIndexTests.swift
+++ b/Tests/BonsplitTests/PaneOwnershipIndexTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import Bonsplit
+
+final class PaneOwnershipIndexTests: XCTestCase {
+    @MainActor
+    func testOwnershipIndexBootstrapsAndTracksDirectPaneSelection() {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let paneId = try! XCTUnwrap(controller.focusedPaneId)
+        let firstTabId = try! XCTUnwrap(controller.createTab(title: "First"))
+        let secondTabId = try! XCTUnwrap(controller.createTab(title: "Second"))
+
+        XCTAssertEqual(controller.paneId(containing: firstTabId), paneId)
+        XCTAssertEqual(controller.paneId(containing: secondTabId), paneId)
+
+        // TabBarView selects through PaneState directly. The indexed query must
+        // reflect that UI path without requiring a controller rescan or callback.
+        let paneState = try! XCTUnwrap(controller.internalController.paneState(for: paneId))
+        paneState.selectTab(firstTabId.uuid)
+
+        XCTAssertEqual(controller.selectedTabId(inPane: paneId), firstTabId)
+        XCTAssertEqual(controller.selectedTab(inPane: paneId)?.id, firstTabId)
+    }
+
+    @MainActor
+    func testCrossPaneMovesTrackOwnerSourceSuccessorAndAutomaticPaneClose() {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let sourcePaneId = try! XCTUnwrap(controller.focusedPaneId)
+        let movedTabId = try! XCTUnwrap(controller.createTab(title: "Moved"))
+        let successorTabId = try! XCTUnwrap(controller.createTab(title: "Successor"))
+        let targetTab = Tab(title: "Target")
+        let targetPaneId = try! XCTUnwrap(
+            controller.splitPane(sourcePaneId, orientation: .horizontal, withTab: targetTab)
+        )
+
+        controller.selectTab(movedTabId)
+        XCTAssertTrue(controller.moveTab(movedTabId, toPane: targetPaneId))
+
+        XCTAssertEqual(controller.paneId(containing: movedTabId), targetPaneId)
+        XCTAssertEqual(controller.selectedTabId(inPane: sourcePaneId), successorTabId)
+
+        let soleTab = Tab(title: "Sole")
+        let soleTabPaneId = try! XCTUnwrap(
+            controller.splitPane(targetPaneId, orientation: .vertical, withTab: soleTab)
+        )
+        XCTAssertTrue(controller.moveTab(soleTab.id, toPane: targetPaneId))
+
+        XCTAssertEqual(controller.paneId(containing: soleTab.id), targetPaneId)
+        XCTAssertFalse(controller.allPaneIds.contains(soleTabPaneId))
+        XCTAssertNil(controller.selectedTabId(inPane: soleTabPaneId))
+    }
+
+    @MainActor
+    func testMovingSoleTabIntoSplitIndexesPlaceholderAndDestination() {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let sourcePaneId = try! XCTUnwrap(controller.focusedPaneId)
+        let welcomeTabId = try! XCTUnwrap(controller.tabs(inPane: sourcePaneId).first?.id)
+        XCTAssertTrue(controller.closeTab(welcomeTabId))
+        let movedTabId = try! XCTUnwrap(controller.createTab(title: "Moved"))
+
+        let newPaneId = try! XCTUnwrap(
+            controller.splitPane(
+                sourcePaneId,
+                orientation: .horizontal,
+                movingTab: movedTabId,
+                insertFirst: true
+            )
+        )
+
+        let placeholder = try! XCTUnwrap(controller.tabs(inPane: sourcePaneId).only)
+        XCTAssertEqual(placeholder.title, "Empty")
+        XCTAssertEqual(controller.paneId(containing: placeholder.id), sourcePaneId)
+        XCTAssertEqual(controller.selectedTabId(inPane: sourcePaneId), placeholder.id)
+        XCTAssertEqual(controller.paneId(containing: movedTabId), newPaneId)
+        XCTAssertEqual(controller.selectedTabId(inPane: newPaneId), movedTabId)
+    }
+
+    @MainActor
+    func testClosingZoomedPaneRemovesOwnershipAndFocusesSibling() {
+        let controller = BonsplitController()
+        let originalPaneId = try! XCTUnwrap(controller.focusedPaneId)
+        let closingTab = Tab(title: "Closing")
+        let closingPaneId = try! XCTUnwrap(
+            controller.splitPane(originalPaneId, orientation: .horizontal, withTab: closingTab)
+        )
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: closingPaneId))
+        XCTAssertTrue(controller.closePane(closingPaneId))
+
+        XCTAssertNil(controller.paneId(containing: closingTab.id))
+        XCTAssertNil(controller.selectedTabId(inPane: closingPaneId))
+        XCTAssertEqual(controller.focusedPaneId, originalPaneId)
+        XCTAssertNil(controller.zoomedPaneId)
+
+        controller.focusPane(PaneID())
+        XCTAssertEqual(controller.focusedPaneId, originalPaneId)
+    }
+
+    @MainActor
+    func testReplacingRestoredTreeRebuildsIndexesAndRepairsFocusAndZoom() {
+        let leftTab = TabItem(title: "Left")
+        let rightTab = TabItem(title: "Right")
+        let leftPane = PaneState(tabs: [leftTab])
+        let rightPane = PaneState(tabs: [rightTab])
+        let restoredRoot = SplitNode.split(
+            SplitState(
+                orientation: .horizontal,
+                first: .pane(leftPane),
+                second: .pane(rightPane)
+            )
+        )
+        let controller = SplitViewController(rootNode: restoredRoot)
+
+        XCTAssertEqual(controller.paneId(containing: leftTab.id), leftPane.id)
+        XCTAssertEqual(controller.paneId(containing: rightTab.id), rightPane.id)
+        controller.focusPane(rightPane.id)
+        XCTAssertTrue(controller.togglePaneZoom(rightPane.id))
+
+        let replacementTab = TabItem(title: "Replacement")
+        let replacementPane = PaneState(tabs: [replacementTab])
+        controller.replaceRootNode(.pane(replacementPane))
+
+        XCTAssertNil(controller.paneId(containing: leftTab.id))
+        XCTAssertNil(controller.paneId(containing: rightTab.id))
+        XCTAssertEqual(controller.paneId(containing: replacementTab.id), replacementPane.id)
+        XCTAssertEqual(controller.focusedPaneId, replacementPane.id)
+        XCTAssertNil(controller.zoomedPaneId)
+    }
+}
+
+private extension Collection {
+    var only: Element? {
+        count == 1 ? first : nil
+    }
+}


### PR DESCRIPTION
## Summary
- maintain controller-owned pane and tab-owner indexes across initialization, create, select, close, same/cross-pane move, split, pane close, focus, and zoom transitions
- expose constant-time `paneId(containing:)` and `selectedTabId(inPane:)` APIs while routing existing pane queries and layout snapshots through the pane index
- keep lookup dictionaries outside SwiftUI observation; direct tab-strip selection remains observable through `PaneState.selectedTabId`

## Correctness coverage
- restored-tree bootstrap and invalid focus
- direct UI-shaped selection and exact same-pane reorder order
- selected close with successor selection
- cross-pane move with source successor and empty-pane auto-close
- empty, inserted-side, and moving-tab split variants, including the placeholder tab
- pane close, sibling focus, and zoom cleanup

## Testing
- `xcodebuildmcp swift-package build --package-path <worktree> --target-name Bonsplit --configuration debug`: pass
- GitHub Actions `swift test`: 191 tests, 0 failures: https://github.com/manaflow-ai/bonsplit/actions/runs/29108682071
- CodeRabbit incremental review: clean
- Greptile review: 5/5, safe to merge, no blocking issues
- test-first API contract commit: expected compile failure before implementation: https://github.com/manaflow-ai/bonsplit/actions/runs/29107913582

A deterministic red test for the old recursive lookup complexity is not practical without a timing assertion, source-shape test, or production instrumentation. The behavior suite instead verifies every ownership-changing mutation and the direct selection path.