### PR TITLE
Expose managed split view identity for external drag coordination

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -5,6 +5,10 @@ import SwiftUI
 @Observable
 @MainActor
 final class SplitViewController {
+    /// The public wrapper that owns this controller, for identity lookups
+    /// from managed AppKit views (see `BonsplitManagedSplitView`).
+    weak var publicController: BonsplitController?
+
     /// The root node of the split tree
     var rootNode: SplitNode
 

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -3,8 +3,15 @@ import AppKit
 
 private var splitContainerProgrammaticSyncDepth = 0
 
-private class ThemedSplitView: NSSplitView {
+private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
     var customDividerColor: NSColor?
+
+    /// Identity for external drag coordination (see BonsplitManagedSplitView).
+    weak var stampedInternalController: SplitViewController?
+    var stampedSplitId: UUID?
+
+    var bonsplitController: BonsplitController? { stampedInternalController?.publicController }
+    var bonsplitSplitId: UUID? { stampedSplitId }
 
     /// Host-configured divider thickness in points. When `nil` the split view
     /// uses AppKit's default thickness for its `dividerStyle`.
@@ -168,6 +175,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
         splitView.customDividerThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
         splitView.customDividerHitExpansion = appearance.dividerHitExpansion
+        splitView.stampedInternalController = controller
+        splitView.stampedSplitId = splitState.id
         splitView.isVertical = splitState.orientation == .horizontal
         splitView.dividerStyle = .thin
         splitView.delegate = context.coordinator
@@ -381,6 +390,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         let dividerThicknessChanged = (splitView as? ThemedSplitView)?.customDividerThickness != resolvedThickness
         (splitView as? ThemedSplitView)?.customDividerThickness = resolvedThickness
         (splitView as? ThemedSplitView)?.customDividerHitExpansion = appearance.dividerHitExpansion
+        (splitView as? ThemedSplitView)?.stampedInternalController = controller
+        (splitView as? ThemedSplitView)?.stampedSplitId = splitState.id
 
         // Update orientation if changed
         splitView.isVertical = splitState.orientation == .horizontal

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -118,6 +118,7 @@ public final class BonsplitController {
     public init(configuration: BonsplitConfiguration = .default) {
         self.configuration = configuration
         self.internalController = SplitViewController()
+        internalController.publicController = self
     }
 
     // MARK: - Tab Operations

--- a/Sources/Bonsplit/Public/BonsplitManagedSplitView.swift
+++ b/Sources/Bonsplit/Public/BonsplitManagedSplitView.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+/// Identity of an `NSSplitView` managed by a Bonsplit split container.
+///
+/// Hosts that coordinate external divider drags (e.g. a two-axis corner drag
+/// that moves two split views at once) resolve the owning controller and
+/// split id from the AppKit view, then write positions through
+/// `BonsplitController.setDividerPosition(_:forSplit:)` so the model stays
+/// the source of truth and never snaps the view back.
+public protocol BonsplitManagedSplitView: AnyObject {
+    var bonsplitController: BonsplitController? { get }
+    var bonsplitSplitId: UUID? { get }
+}


### PR DESCRIPTION
cmux's two-axis corner drag (manaflow-ai/cmux#7839) drives two split views at once. The coordinator's pointer-based drag latch can't arm for the axis whose split view the pointer is outside of (e.g. dragging a corner from the far side of the other divider), so that coordinator reasserts the model and freezes the axis.

Adds a public `BonsplitManagedSplitView` protocol (controller + split id resolved from the `NSSplitView`, stamped by the split container) so hosts can write drag positions through `setDividerPosition(_:forSplit:)`, keeping the model authoritative instead of fighting the latch. Additive only; no behavior change for existing consumers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786308622&installation_id=133855650&pr_number=174&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F174&signature=6b41c73688450290ded75d0b7e852790a924e79a5a4ed46d90e4de2d66327e52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes managed split view identity so hosts can coordinate external divider drags (e.g., corner drags) without fighting the drag latch. Hosts resolve the owning `BonsplitController` and split id from the `NSSplitView` and write positions via `setDividerPosition(_:forSplit:)` to keep the model authoritative.

- **New Features**
  - Added `BonsplitManagedSplitView` with `bonsplitController` and `bonsplitSplitId`.
  - `ThemedSplitView` conforms and is stamped by `SplitContainerView` with the internal controller and split id.
  - Wired `publicController` on `SplitViewController` for lookups; additive only with no behavior change for existing consumers.

<sup>Written for commit cdbc6ee14ee098765e6f2d8a0a717ec2f560e2ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for coordinating external split-view divider drags.
  * Split views can now identify their owning controller and split, enabling divider position updates through the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->