### PR TITLE
Apply pane zoom by collapsing splits in place instead of swapping the rendered node

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -9,7 +9,37 @@ final class SplitViewController {
     var rootNode: SplitNode
 
     /// Currently zoomed pane. When set, rendering should only show this pane.
-    var zoomedPaneId: PaneID?
+    var zoomedPaneId: PaneID? {
+        didSet {
+            guard oldValue != zoomedPaneId else { return }
+            notifyZoomCollapseAppliers()
+        }
+    }
+
+    /// Registered zoom-collapse appliers, one per live SplitContainerView
+    /// coordinator. Zoom is applied to the AppKit split hierarchy synchronously
+    /// when `zoomedPaneId` changes, in the same runloop turn as the toggle;
+    /// waiting for the SwiftUI update to thread the new value through every
+    /// nested NSHostingController adds several display-cycle-paced passes
+    /// (~200ms on deep trees). The SwiftUI pass still runs afterwards as an
+    /// idempotent backstop for views created mid-zoom.
+    @ObservationIgnored
+    private var zoomCollapseAppliers: [ObjectIdentifier: (PaneID?) -> Void] = [:]
+
+    func registerZoomCollapseApplier(key: ObjectIdentifier, _ applier: @escaping (PaneID?) -> Void) {
+        zoomCollapseAppliers[key] = applier
+    }
+
+    func unregisterZoomCollapseApplier(key: ObjectIdentifier) {
+        zoomCollapseAppliers.removeValue(forKey: key)
+    }
+
+    private func notifyZoomCollapseAppliers() {
+        let zoomed = zoomedPaneId
+        for applier in zoomCollapseAppliers.values {
+            applier(zoomed)
+        }
+    }
 
     /// Currently focused pane ID
     var focusedPaneId: PaneID?

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -479,10 +479,15 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         }
         context.coordinator.applyZoomCollapse(zoomHiddenIndex, in: splitView)
 
-        // Access dividerPosition to ensure SwiftUI tracks this dependency
-        // Then sync if the position changed externally
-        let currentPosition = splitState.dividerPosition
-        context.coordinator.syncPosition(currentPosition, in: splitView)
+        // Divider position deliberately NOT read here: reading it would make
+        // SwiftUI invalidate this representable on every model divider change
+        // (external resize commands, restored layouts, equalize), which cascades
+        // through updateHostedContent's rootView reassignment into a full
+        // pane-subtree diff (tab bars and all) per divider tick. Model divider
+        // changes are applied straight to the NSSplitView by the coordinator's
+        // Observation-based watcher instead; SwiftUI stays responsible only for
+        // structural updates.
+        context.coordinator.armDividerModelObservation(in: splitView)
 
         // A pure divider-thickness change doesn't move the model divider
         // position, so `syncPosition` early-returns and AppKit keeps the cached
@@ -772,6 +777,43 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             }
         }
 
+        /// Superseded-arm guard for the divider model watcher below.
+        private var dividerObservationGeneration: UInt64 = 0
+
+        /// Watch the model's dividerPosition with Observation and apply changes
+        /// straight to the NSSplitView, outside SwiftUI. Reading dividerPosition
+        /// during updateNSView would re-invalidate the representable per divider
+        /// tick and cascade a full pane-subtree diff through the hosted
+        /// rootViews; this path keeps divider syncing O(one setPosition).
+        ///
+        /// Arming is deferred one runloop turn so the tracked read is not
+        /// captured by SwiftUI's own observation scope around updateNSView.
+        func armDividerModelObservation(in splitView: NSSplitView) {
+            dividerObservationGeneration &+= 1
+            let generation = dividerObservationGeneration
+            DispatchQueue.main.async { [weak self, weak splitView] in
+                guard let self, let splitView else { return }
+                guard generation == self.dividerObservationGeneration else { return }
+                self.syncPosition(self.splitState.dividerPosition, in: splitView)
+                self.observeDividerModel(generation: generation, in: splitView)
+            }
+        }
+
+        private func observeDividerModel(generation: UInt64, in splitView: NSSplitView) {
+            guard generation == dividerObservationGeneration else { return }
+            let observedState = splitState
+            withObservationTracking {
+                _ = observedState.dividerPosition
+            } onChange: { [weak self, weak splitView] in
+                Task { @MainActor [weak self, weak splitView] in
+                    guard let self, let splitView else { return }
+                    guard generation == self.dividerObservationGeneration else { return }
+                    self.syncPosition(self.splitState.dividerPosition, in: splitView)
+                    self.observeDividerModel(generation: generation, in: splitView)
+                }
+            }
+        }
+
         /// Collapse or restore one side of the split for pane zoom.
         ///
         /// Hiding an arranged subview removes it from NSSplitView tiling, so the
@@ -889,7 +931,14 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             }
 
             let pixelPosition = availableSize * clampedStatePosition
-            setPositionSafely(pixelPosition, in: splitView, layout: true)
+            // No forced layoutSubtreeIfNeeded here: setPosition updates the
+            // arranged-subview frames immediately and marks descendant layout
+            // dirty; AppKit coalesces the recursive pass into the current
+            // display cycle. Forcing a synchronous full-subtree flush per sync
+            // cost ~30% of the main thread under an external resize storm
+            // (socket resize-pane at high rate on nested splits), because every
+            // divider tick re-laid-out the whole hosting-view subtree.
+            setPositionSafely(pixelPosition, in: splitView, layout: false)
             lastAppliedPosition = clampedStatePosition
         }
 

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -132,6 +132,10 @@ private final class DebugSplitView: ThemedSplitView {
 struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentable {
     @Bindable var splitState: SplitState
     let controller: SplitViewController
+    /// Currently zoomed pane, threaded down from SplitViewContainer as a plain
+    /// value so every split on the zoom path deterministically re-runs
+    /// updateNSView when zoom toggles.
+    var zoomedPaneId: PaneID?
     let appearance: BonsplitConfiguration.Appearance
     let dividerPositionRange: ClosedRange<CGFloat>
     let contentBuilder: (TabItem, PaneID) -> Content
@@ -202,6 +206,23 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
         context.coordinator.splitView = splitView
 
+        // Apply zoom collapse synchronously when the controller's zoom state
+        // changes, without waiting for SwiftUI to re-thread zoomedPaneId through
+        // every nested hosting controller (each nesting level costs a
+        // display-paced update pass). updateNSView re-applies the same state
+        // idempotently as a backstop.
+        context.coordinator.zoomRegistrationController = controller
+        let coordinatorKey = ObjectIdentifier(context.coordinator)
+        controller.registerZoomCollapseApplier(key: coordinatorKey) { [weak coordinator = context.coordinator, weak splitView] zoomedPaneId in
+            guard let coordinator, let splitView else { return }
+            let hiddenIndex: Int? = zoomedPaneId.flatMap { zoomId in
+                if coordinator.splitState.first.findPane(zoomId) != nil { return 1 }
+                if coordinator.splitState.second.findPane(zoomId) != nil { return 0 }
+                return nil
+            }
+            coordinator.applyZoomCollapse(hiddenIndex, in: splitView)
+        }
+
         // Capture animation origin before it gets cleared
         let animationOrigin = splitState.animationOrigin
 #if DEBUG
@@ -239,6 +260,18 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // Apply the initial divider position once after initial layout scheduling.
         func applyInitialDividerPosition() {
             if context.coordinator.didApplyInitialDividerPosition {
+                return
+            }
+
+            // A split materialized while pane zoom is collapsing this view keeps
+            // its collapsed layout; the zoom-restore pass re-applies the model
+            // ratio, so don't fight it here.
+            if context.coordinator.zoomHiddenIndex != nil {
+                context.coordinator.didApplyInitialDividerPosition = true
+                if splitState.animationOrigin != nil {
+                    splitState.animationOrigin = nil
+                    context.coordinator.isAnimating = false
+                }
                 return
             }
 
@@ -356,6 +389,13 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         return splitView
     }
 
+    static func dismantleNSView(_ nsView: NSSplitView, coordinator: Coordinator) {
+        coordinator.zoomRegistrationController?.unregisterZoomCollapseApplier(
+            key: ObjectIdentifier(coordinator)
+        )
+        coordinator.zoomRegistrationController = nil
+    }
+
     func updateNSView(_ splitView: NSSplitView, context: Context) {
         // SwiftUI may reuse the same NSSplitView/Coordinator instance while the underlying SplitState
         // object changes (e.g., during split tree restructuring). Keep the coordinator pointed at
@@ -419,6 +459,25 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             )
             context.coordinator.secondNodeType = secondType
         }
+
+        // Zoom: collapse the side of this split that does not contain the
+        // zoomed pane. Hidden arranged subviews are excluded from NSSplitView
+        // tiling, so the zoom-path side expands to the full container while
+        // every pane keeps its live AppKit hierarchy (no teardown/rebuild).
+        //
+        // Read the live controller state, not the threaded `zoomedPaneId`
+        // property: updateNSView can run with a stale value view after the
+        // synchronous zoom-collapse applier already ran (the threaded property
+        // only exists to guarantee an update pass reaches every nested split).
+        // Acting on the stale value would briefly restore and re-collapse the
+        // split, flashing the old layout and resizing terminals twice.
+        let liveZoomedPaneId = controller.zoomedPaneId
+        let zoomHiddenIndex: Int? = liveZoomedPaneId.flatMap { zoomId in
+            if splitState.first.findPane(zoomId) != nil { return 1 }
+            if splitState.second.findPane(zoomId) != nil { return 0 }
+            return nil
+        }
+        context.coordinator.applyZoomCollapse(zoomHiddenIndex, in: splitView)
 
         // Access dividerPosition to ensure SwiftUI tracks this dependency
         // Then sync if the position changed externally
@@ -518,6 +577,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             SplitContainerView(
                 splitState: nestedSplitState,
                 controller: controller,
+                zoomedPaneId: zoomedPaneId,
                 appearance: appearance,
                 dividerPositionRange: dividerPositionRange,
                 contentBuilder: contentBuilder,
@@ -556,6 +616,13 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         /// Track child node types to detect structural changes
         var firstNodeType: SplitNode.NodeType
         var secondNodeType: SplitNode.NodeType
+        /// Arranged-subview index currently collapsed for pane zoom (nil = not zoomed
+        /// through this split). While set, divider syncing/persistence is suspended so
+        /// the temporary full-size layout never overwrites the model's divider ratio.
+        var zoomHiddenIndex: Int?
+        /// Controller this coordinator registered its zoom-collapse applier with,
+        /// kept so dismantleNSView can unregister.
+        weak var zoomRegistrationController: SplitViewController?
         /// Retain hosting controllers so SwiftUI content stays alive
         var firstHostingController: NonDraggableHostingController<AnyView>?
         var secondHostingController: NonDraggableHostingController<AnyView>?
@@ -705,6 +772,58 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             }
         }
 
+        /// Collapse or restore one side of the split for pane zoom.
+        ///
+        /// Hiding an arranged subview removes it from NSSplitView tiling, so the
+        /// remaining side takes the full container. Both sides stay in the view
+        /// hierarchy: pane content (hosting controllers, portal-hosted terminal
+        /// placeholders) is preserved, making zoom toggles O(1) instead of a full
+        /// subtree teardown/rebuild that scales with pane count.
+        func applyZoomCollapse(_ hiddenIndex: Int?, in splitView: NSSplitView) {
+            guard zoomHiddenIndex != hiddenIndex else { return }
+            let arranged = splitView.arrangedSubviews
+            guard arranged.count >= 2 else { return }
+            zoomHiddenIndex = hiddenIndex
+
+            isSyncingProgrammatically = true
+            splitContainerProgrammaticSyncDepth += 1
+            defer {
+                isSyncingProgrammatically = false
+                splitContainerProgrammaticSyncDepth = max(0, splitContainerProgrammaticSyncDepth - 1)
+            }
+
+            // Note: no layoutSubtreeIfNeeded here. adjustSubviews()/setPosition()
+            // update arranged-subview frames directly; forcing a full recursive
+            // layout per split multiplies into one full-depth pass per split on
+            // the zoom path (hundreds of ms on deep trees). AppKit coalesces the
+            // remaining work into the next layout pass.
+            if let hiddenIndex {
+                arranged[hiddenIndex].isHidden = true
+                arranged[1 - hiddenIndex].isHidden = false
+                splitView.adjustSubviews()
+#if DEBUG
+                dlog("split.zoomCollapse split=\(splitState.id.uuidString.prefix(5)) hidden=\(hiddenIndex) view=\(Unmanaged.passUnretained(splitView).toOpaque()) window=\(splitView.window?.windowNumber ?? -1)")
+#endif
+            } else {
+                arranged[0].isHidden = false
+                arranged[1].isHidden = false
+                splitView.adjustSubviews()
+                // Restore the model's divider ratio; the collapse pass left the
+                // visible side at full size.
+                let available = splitAvailableSize(in: splitView)
+                if available > 0 {
+                    let bounds = normalizedDividerBounds(in: splitView)
+                    let normalized = max(bounds.lowerBound, min(bounds.upperBound, splitState.dividerPosition))
+                    let clamped = clampedDividerPosition(available * normalized, in: splitView)
+                    splitView.setPosition(clamped, ofDividerAt: 0)
+                    lastAppliedPosition = normalized
+                }
+#if DEBUG
+                dlog("split.zoomRestore split=\(splitState.id.uuidString.prefix(5)) ratio=\(String(format: "%.3f", splitState.dividerPosition)) view=\(Unmanaged.passUnretained(splitView).toOpaque()) window=\(splitView.window?.windowNumber ?? -1)")
+#endif
+            }
+        }
+
         /// Re-divide the split using the model's current fractional position so a
         /// runtime change to `dividerThickness` takes effect immediately.
         ///
@@ -713,6 +832,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         /// the stored fraction preserves the user's split ratio while widening
         /// (or narrowing) the gap to match the new thickness.
         func reapplyDividerForThicknessChange(in splitView: NSSplitView) {
+            guard zoomHiddenIndex == nil else { return }
             guard splitView.arrangedSubviews.count >= 2 else { return }
             let available = splitAvailableSize(in: splitView)
             guard available > 0 else { return }
@@ -726,6 +846,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             guard !isAnimating else { return }
             guard !isSyncingProgrammatically else { return }
             guard splitContainerProgrammaticSyncDepth == 0 else { return }
+            // While zoom-collapsed, the visible side intentionally fills the
+            // container; don't fight it by re-applying the model ratio.
+            guard zoomHiddenIndex == nil else { return }
 
             guard splitView.arrangedSubviews.count >= 2 else {
                 // Structural updates can temporarily remove an arranged subview.
@@ -892,6 +1015,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             dlog("split.didResize split=\(splitState.id.uuidString.prefix(5)) orient=\(splitState.orientation == .horizontal ? "H" : "V") container=\(Int(splitView.frame.width))x\(Int(splitView.frame.height)) subs=[\(subframes)] anim=\(isAnimating ? 1 : 0) sync=\(isSyncingProgrammatically ? 1 : 0)")
 #endif
             if isSyncingProgrammatically || splitContainerProgrammaticSyncDepth > 0 {
+                return
+            }
+            // Zoom-collapsed layouts are transient full-size states; never persist
+            // them into the model's divider ratio (and never re-assert the model
+            // ratio against them).
+            if zoomHiddenIndex != nil {
                 return
             }
             // Prevent stale drag state from persisting through programmatic/async resizes.

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -6,6 +6,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
     @Environment(SplitViewController.self) private var controller
 
     let node: SplitNode
+    var zoomedPaneId: PaneID?
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
@@ -34,6 +35,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
             SplitContainerView(
                 splitState: splitState,
                 controller: controller,
+                zoomedPaneId: zoomedPaneId,
                 appearance: appearance,
                 dividerPositionRange: dividerPositionRange,
                 contentBuilder: contentBuilder,

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -40,9 +40,15 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var splitNodeContent: some View {
-        let nodeToRender = controller.zoomedNode ?? controller.rootNode
+        // Always render the full tree. Zoom is applied by collapsing the
+        // non-zoomed side of each split on the zoom path (see
+        // SplitContainerView), never by swapping the rendered node: swapping
+        // changes SwiftUI structural identity and tears down / rebuilds the
+        // entire AppKit split hierarchy (one NSHostingController per pane),
+        // which made maximize/minimize scale with pane count.
         SplitNodeView(
-            node: nodeToRender,
+            node: controller.rootNode,
+            zoomedPaneId: controller.zoomedPaneId,
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
             appearance: appearance,

--- a/Tests/BonsplitTests/ZoomTogglePerformanceTests.swift
+++ b/Tests/BonsplitTests/ZoomTogglePerformanceTests.swift
@@ -1,0 +1,214 @@
+import XCTest
+@testable import Bonsplit
+import AppKit
+import SwiftUI
+
+/// Benchmarks the wall-clock cost of toggling pane zoom (maximize/minimize) with
+/// multiple panes open, hosted in a real NSWindow like the app does.
+///
+/// Run with:
+///   swift test --filter ZoomTogglePerformanceTests
+///
+/// The benchmark reports, per toggle direction:
+///   - settle latency: time from togglePaneZoom() until the AppKit hierarchy
+///     reflects the final layout (zoomed pane fills the container, or all panes
+///     are back at their split frames)
+///   - AppKit content-view churn: how many pane content NSViews were created
+///     during the toggle (teardown/rebuild cost that portals/terminals pay)
+final class ZoomTogglePerformanceTests: XCTestCase {
+
+    /// NSView whose lifecycle we can count, standing in for expensive pane content
+    /// (Metal-backed terminals in cmux).
+    @MainActor
+    private final class BenchContentNSView: NSView {
+        static var instancesCreated = 0
+        let tag2: Int
+
+        init(tag2: Int) {
+            self.tag2 = tag2
+            super.init(frame: .zero)
+            Self.instancesCreated += 1
+            wantsLayer = true
+        }
+
+        required init?(coder: NSCoder) { fatalError("unsupported") }
+    }
+
+    private struct BenchContent: NSViewRepresentable {
+        let index: Int
+
+        func makeNSView(context: Context) -> NSView {
+            BenchContentNSView(tag2: index)
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {}
+    }
+
+    @MainActor
+    private func collectBenchViews(in root: NSView) -> [BenchContentNSView] {
+        var result: [BenchContentNSView] = []
+        var queue: [NSView] = [root]
+        while let view = queue.popLast() {
+            if let bench = view as? BenchContentNSView {
+                result.append(bench)
+            }
+            queue.append(contentsOf: view.subviews)
+        }
+        return result
+    }
+
+    @MainActor
+    private func pump(_ seconds: TimeInterval = 0.001) {
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    }
+
+    @MainActor
+    private func pumpUntil(
+        timeout: TimeInterval,
+        window: NSWindow,
+        _ condition: () -> Bool
+    ) -> TimeInterval? {
+        _ = window
+        let start = CFAbsoluteTimeGetCurrent()
+        while CFAbsoluteTimeGetCurrent() - start < timeout {
+            if condition() {
+                return CFAbsoluteTimeGetCurrent() - start
+            }
+            pump()
+        }
+        return condition() ? CFAbsoluteTimeGetCurrent() - start : nil
+    }
+
+    /// True when the view is attached to a window and not hidden anywhere in its chain.
+    @MainActor
+    private func isEffectivelyVisible(_ view: NSView) -> Bool {
+        guard view.window != nil else { return false }
+        return !view.isHiddenOrHasHiddenAncestor
+    }
+
+    @MainActor
+    func testZoomToggleLatencyWithEightPanes() throws {
+        let paneCount = 8
+        let cycles = 12
+
+        let appearance = BonsplitConfiguration.Appearance(enableAnimations: false)
+        let configuration = BonsplitConfiguration(appearance: appearance)
+        let controller = BonsplitController(configuration: configuration)
+
+        _ = controller.createTab(title: "pane-0")
+        guard var currentPane = controller.focusedPaneId else {
+            XCTFail("Expected focused pane")
+            return
+        }
+
+        // Build an 8-pane layout alternating split orientation, like a busy
+        // real-world workspace.
+        for index in 1..<paneCount {
+            let orientation: SplitOrientation = index % 2 == 0 ? .vertical : .horizontal
+            guard let newPane = controller.splitPane(currentPane, orientation: orientation) else {
+                XCTFail("Expected splitPane to create pane \(index)")
+                return
+            }
+            _ = controller.createTab(title: "pane-\(index)", inPane: newPane)
+            currentPane = newPane
+        }
+        XCTAssertEqual(controller.allPaneIds.count, paneCount)
+
+        let hostingView = NSHostingView(
+            rootView: BonsplitView(controller: controller) { tab, _ in
+                BenchContent(index: abs(tab.title.hashValue))
+            } emptyPane: { _ in
+                Color.clear
+            }
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1400, height: 900),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        hostingView.frame = contentView.bounds
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+
+        // Let the initial 8-pane layout settle fully.
+        let initialSettle = pumpUntil(timeout: 5.0, window: window) {
+            collectBenchViews(in: hostingView).filter { isEffectivelyVisible($0) }.count == paneCount
+        }
+        XCTAssertNotNil(initialSettle, "Initial \(paneCount)-pane layout never settled")
+        pump(0.1)
+
+        guard let zoomPane = controller.focusedPaneId else {
+            XCTFail("Expected focused pane to zoom")
+            return
+        }
+
+        var zoomInTimes: [Double] = []
+        var zoomOutTimes: [Double] = []
+        var zoomInChurn: [Int] = []
+        var zoomOutChurn: [Int] = []
+
+        for cycle in 0..<(cycles + 1) {
+            // --- Zoom in (maximize) ---
+            let createdBeforeIn = BenchContentNSView.instancesCreated
+            let zoomInStart = CFAbsoluteTimeGetCurrent()
+            XCTAssertTrue(controller.togglePaneZoom(inPane: zoomPane))
+            let zoomInSettle = pumpUntil(timeout: 5.0, window: window) {
+                let visible = collectBenchViews(in: hostingView).filter { isEffectivelyVisible($0) }
+                guard visible.count == 1, let only = visible.first else { return false }
+                // Zoomed pane content should span (nearly) the full container width.
+                return only.frame.width >= hostingView.bounds.width - 4
+            }
+            let zoomInElapsed = CFAbsoluteTimeGetCurrent() - zoomInStart
+            XCTAssertNotNil(zoomInSettle, "Zoom-in never settled on cycle \(cycle)")
+            let inChurn = BenchContentNSView.instancesCreated - createdBeforeIn
+            pump(0.05)
+
+            // --- Zoom out (minimize) ---
+            let createdBeforeOut = BenchContentNSView.instancesCreated
+            let zoomOutStart = CFAbsoluteTimeGetCurrent()
+            XCTAssertTrue(controller.togglePaneZoom(inPane: zoomPane))
+            let zoomOutSettle = pumpUntil(timeout: 5.0, window: window) {
+                let visible = collectBenchViews(in: hostingView).filter { isEffectivelyVisible($0) }
+                guard visible.count == paneCount else { return false }
+                // Every pane must have a real, laid-out frame again.
+                return visible.allSatisfy { $0.frame.width > 1 && $0.frame.height > 1 }
+            }
+            let zoomOutElapsed = CFAbsoluteTimeGetCurrent() - zoomOutStart
+            XCTAssertNotNil(zoomOutSettle, "Zoom-out never settled on cycle \(cycle)")
+            let outChurn = BenchContentNSView.instancesCreated - createdBeforeOut
+            pump(0.05)
+
+            // Skip the first cycle as warmup.
+            if cycle > 0 {
+                zoomInTimes.append(zoomInElapsed * 1000)
+                zoomOutTimes.append(zoomOutElapsed * 1000)
+                zoomInChurn.append(inChurn)
+                zoomOutChurn.append(outChurn)
+            }
+        }
+
+        func stats(_ values: [Double]) -> String {
+            let sorted = values.sorted()
+            let median = sorted[sorted.count / 2]
+            let mean = values.reduce(0, +) / Double(values.count)
+            return String(
+                format: "median=%.1fms mean=%.1fms min=%.1fms max=%.1fms",
+                median, mean, sorted.first ?? 0, sorted.last ?? 0
+            )
+        }
+
+        print("[ZOOM-BENCH] panes=\(paneCount) cycles=\(cycles)")
+        print("[ZOOM-BENCH] zoom-in  (maximize): \(stats(zoomInTimes))")
+        print("[ZOOM-BENCH] zoom-out (minimize): \(stats(zoomOutTimes))")
+        print("[ZOOM-BENCH] content-view churn per zoom-in:  \(zoomInChurn)")
+        print("[ZOOM-BENCH] content-view churn per zoom-out: \(zoomOutChurn)")
+    }
+}


### PR DESCRIPTION
## Problem

Toggling pane zoom rendered `zoomedNode ?? rootNode`, which changes SwiftUI structural identity — the entire AppKit split hierarchy (every `NSSplitView` plus one `NSHostingController` per pane) was torn down on maximize and fully rebuilt on minimize. Cost scales with pane count: with 8 panes, maximize took 443.8 ms and minimize 1303.4 ms median (debug), and minimize recreated all 8 pane content views. In cmux this shows up as a very laggy `cmd+shift+enter` with multiple panes open.

## Fix

Zoom keeps the tree mounted and collapses the side of each split that does not contain the zoomed pane (hidden arranged subviews are excluded from NSSplitView tiling, so the zoom path expands to the full container).

- **Synchronous apply:** split coordinators register a collapse applier with `SplitViewController`; the AppKit collapse runs in the same runloop turn as `togglePaneZoom()` instead of waiting for SwiftUI to re-thread state through every nested hosting controller (display-paced, hundreds of ms on deep trees).
- **Idempotent backstop:** `updateNSView` re-applies the same state reading **live** controller state, so stale SwiftUI passes cannot flash the pre-toggle layout (restore-then-recollapse flap).
- **Model protection:** divider sync/persistence and entry-animation placement are suspended while a split is zoom-collapsed, so the temporary full-size layout never overwrites the stored divider ratio.

## Results

New window-hosted benchmark `Tests/BonsplitTests/ZoomTogglePerformanceTests.swift` (8 panes, 12 cycles, `swift test --filter ZoomTogglePerformanceTests`):

| metric (median) | before | after |
|---|---|---|
| maximize settle | 443.8 ms | ~170 ms* |
| minimize settle | 1303.4 ms | 3.3 ms |
| pane content NSViews recreated per maximize | 1 | 0 |
| pane content NSViews recreated per minimize | 8 | 0 |

\* residual is offscreen-window SwiftUI update scheduling in the headless harness; a probe confirms AppKit frames are final within the toggle call. In cmux (11 panes, real key events) end-to-end settle went from 315→115 ms (maximize) and 825→130 ms (minimize), with terminal-portal detach/attach per minimize going from 18–20 to 0.

Full benchmark report: https://polite-sandal-rgcv.here.now/

All 186 package tests pass.

Note for cmux integration: cmux's `WorkspaceContentView` re-keyed the Bonsplit subtree with `.id(zoomState)` (workaround for stale pane chrome above browser portals under the old node-swap rendering). That re-key must be removed together with this change, and pane content visibility made zoom-aware, since collapsed panes now stay mounted; the cmux-side commit is prepared to land with the submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786318378&installation_id=133855650&pr_number=175&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F175&signature=16c6b9747497d0ffd0447d1574ff868c49659bcdf64bea77fe80cede6dc2f173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply pane zoom by collapsing the non-zoomed side of each split in place, and move divider syncing out of SwiftUI. Keeps the AppKit split tree mounted, makes zoom toggles much faster, and cuts CPU during resize storms.

- **Refactors**
  - Always render the full tree; hide the side that doesn’t contain the zoomed pane in each split.
  - Synchronous collapse: `SplitViewController` notifies registered split coordinators on `zoomedPaneId` change in the same runloop turn.
  - Idempotent backstop: `updateNSView` re-applies collapse using live controller state to avoid layout flashes.
  - Divider syncing: observe the model’s `dividerPosition` and apply changes directly to `NSSplitView` (no `updateNSView` dependency, no `layoutSubtreeIfNeeded` on ticks); reduces main-thread work under heavy resizes (cmux: app CPU ~93% → ~50–60%).
  - Suspend divider syncing/persistence and entry animations while zoomed; restore the model ratio on unzoom.
  - `SplitViewContainer` passes `zoomedPaneId` down; appliers are registered in `makeNSView` and unregistered in `dismantleNSView`.
  - Added `ZoomTogglePerformanceTests.swift` (8 panes): minimize 1303.4 ms → 3.3 ms; maximize 443.8 ms → ~170 ms; pane content NSView churn → 0.

- **Migration**
  - In cmux, remove `.id(zoomState)` from `WorkspaceContentView` and make pane content visibility zoom-aware, since collapsed panes now remain mounted.

<sup>Written for commit 806285404d2c30708789234c4d9ebdf3abaf34c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane zooming/restoration across nested split layouts by collapsing the non-zoomed side and reliably restoring the previous layout.
  * Reduced visual flicker and eliminated unnecessary split hierarchy rebuilding when toggling zoom.
  * Kept divider behavior consistent during zoom by suspending/safeguarding divider syncing and position persistence.
* **New Features**
  * Enabled more accurate zoom-aware propagation so nested split containers respond correctly to the current zoomed pane.
* **Tests**
  * Added performance benchmarks for zoom toggle latency and view churn in an 8-pane window scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->