### PR TITLE
Add imposed first-extent for grid-quantized hosts

### DIFF
--- a/Sources/Bonsplit/Internal/Models/SplitState.swift
+++ b/Sources/Bonsplit/Internal/Models/SplitState.swift
@@ -25,6 +25,12 @@ final class SplitState: Identifiable {
     /// every fraction reader stays coherent. A user divider drag clears it:
     /// the gesture takes ownership and fraction semantics resume.
     var imposedFirstExtent: CGFloat?
+    /// Bumped on every explicit imposition call. The view's convergence memo
+    /// keys off this so a re-imposed target gets exactly one fresh apply
+    /// attempt even when neither the target nor the divider has moved —
+    /// AppKit may have refused the same target earlier (transient pane
+    /// minimums mid-churn) and the refusal is not permanent.
+    var imposedEpoch: Int = 0
 
     /// Animation origin for entry animation (nil = no animation needed)
     var animationOrigin: SplitAnimationOrigin?

--- a/Sources/Bonsplit/Internal/Models/SplitState.swift
+++ b/Sources/Bonsplit/Internal/Models/SplitState.swift
@@ -25,11 +25,9 @@ final class SplitState: Identifiable {
     /// every fraction reader stays coherent. A user divider drag clears it:
     /// the gesture takes ownership and fraction semantics resume.
     var imposedFirstExtent: CGFloat?
-    /// Bumped on every explicit imposition call. The view's convergence memo
-    /// keys off this so a re-imposed target gets exactly one fresh apply
-    /// attempt even when neither the target nor the divider has moved —
-    /// AppKit may have refused the same target earlier (transient pane
-    /// minimums mid-churn) and the refusal is not permanent.
+    /// Bumped when the imposed target changes. The view's convergence memo
+    /// keys off this so repeated identical plans cannot keep re-arming a
+    /// target that AppKit permanently refuses.
     var imposedEpoch: Int = 0
     /// Imperative hook the live split view's coordinator installs so an
     /// imposition applies IMMEDIATELY. Routing impositions through SwiftUI

--- a/Sources/Bonsplit/Internal/Models/SplitState.swift
+++ b/Sources/Bonsplit/Internal/Models/SplitState.swift
@@ -16,6 +16,16 @@ final class SplitState: Identifiable {
     var second: SplitNode
     var dividerPosition: CGFloat  // 0.0 to 1.0
 
+    /// Externally imposed extent, in points, for the FIRST child along the
+    /// split axis. While set, layout places the divider at exactly this many
+    /// points (clamped to pane minimums) instead of deriving pixels from
+    /// `dividerPosition` — hosts that compute exact pane sizes (terminal
+    /// grids) lose nothing to normalized-fraction rounding or drift
+    /// deadbands. `dividerPosition` is kept mirrored to the applied value so
+    /// every fraction reader stays coherent. A user divider drag clears it:
+    /// the gesture takes ownership and fraction semantics resume.
+    var imposedFirstExtent: CGFloat?
+
     /// Animation origin for entry animation (nil = no animation needed)
     var animationOrigin: SplitAnimationOrigin?
 

--- a/Sources/Bonsplit/Internal/Models/SplitState.swift
+++ b/Sources/Bonsplit/Internal/Models/SplitState.swift
@@ -29,13 +29,13 @@ final class SplitState: Identifiable {
     /// keys off this so repeated identical plans cannot keep re-arming a
     /// target that AppKit permanently refuses.
     var imposedEpoch: Int = 0
-    /// Imperative hook the live split view's coordinator installs so an
-    /// imposition applies IMMEDIATELY. Routing impositions through SwiftUI
+    /// Imperative hook the live split view's coordinator installs so divider
+    /// authority changes apply immediately. Routing them through SwiftUI
     /// observation is not reliable for representables: a split whose only
-    /// change is a re-imposed extent may never get another updateNSView,
-    /// and its divider then renders a previous layout until some unrelated
-    /// event nudges it. Weakly captured internals; safe to call when stale.
-    @ObservationIgnored var applyImposedNow: (() -> Void)?
+    /// change is an extent update may never get another updateNSView, and its
+    /// divider then renders a previous layout until some unrelated event
+    /// nudges it. Weakly captured internals; safe to call when stale.
+    @ObservationIgnored var syncDividerNow: (() -> Void)?
 
     /// Animation origin for entry animation (nil = no animation needed)
     var animationOrigin: SplitAnimationOrigin?

--- a/Sources/Bonsplit/Internal/Models/SplitState.swift
+++ b/Sources/Bonsplit/Internal/Models/SplitState.swift
@@ -31,6 +31,13 @@ final class SplitState: Identifiable {
     /// AppKit may have refused the same target earlier (transient pane
     /// minimums mid-churn) and the refusal is not permanent.
     var imposedEpoch: Int = 0
+    /// Imperative hook the live split view's coordinator installs so an
+    /// imposition applies IMMEDIATELY. Routing impositions through SwiftUI
+    /// observation is not reliable for representables: a split whose only
+    /// change is a re-imposed extent may never get another updateNSView,
+    /// and its divider then renders a previous layout until some unrelated
+    /// event nudges it. Weakly captured internals; safe to call when stale.
+    @ObservationIgnored var applyImposedNow: (() -> Void)?
 
     /// Animation origin for entry animation (nil = no animation needed)
     var animationOrigin: SplitAnimationOrigin?

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -853,7 +853,18 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 // would ever retry — panes would sit wedged at the refused
                 // layout. Bounded by explicit calls, so it cannot spin.
                 let renudged = lastImposedEpoch != splitState.imposedEpoch
-                if renudged || retargeted || (moved && abs(current - target) > 0.01) {
+                // Never apply when the divider already sits at the target:
+                // a same-position setPosition still runs a layout pass,
+                // which re-applies surface sizes, which re-imposes — a
+                // sustained once-per-turn churn loop at full CPU. Renudge
+                // and retarget only bypass the refusal memo; distance from
+                // the target is what justifies touching AppKit.
+                if abs(current - target) <= 0.01 {
+                    lastImposedTarget = target
+                    lastImposedEpoch = splitState.imposedEpoch
+                    lastImposedOutcome = current
+                    imposedRetryBudget = 0
+                } else if renudged || retargeted || moved {
                     setPositionSafely(target, in: splitView, layout: true)
                     lastImposedTarget = target
                     lastImposedEpoch = splitState.imposedEpoch

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -155,6 +155,18 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         )
     }
 
+    // A split tree is space-filling: it renders in whatever space its
+    // container gives it and has no meaningful size of its own. Without
+    // this, SwiftUI answers an unspecified proposal with AppKit's
+    // fittingSize — the sum of the current subview frames — so any
+    // container that sizes itself from its content adopts the tree's own
+    // layout as its ideal and then hands that back as the new bounds.
+    // With absolute divider positions in the tree, each round trip grows
+    // the sum, and the container inflates without bound.
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSSplitView, context: Context) -> CGSize? {
+        CGSize(width: proposal.width ?? 0, height: proposal.height ?? 0)
+    }
+
     func makeNSView(context: Context) -> NSSplitView {
 #if DEBUG
         let splitView: ThemedSplitView = {

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -439,6 +439,28 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // syncPosition — where the refused-target retry lives — never runs.
         _ = splitState.imposedFirstExtent
         _ = splitState.imposedEpoch
+        // Imperative imposition path: the controller calls this the moment
+        // an extent is imposed, so a split whose ONLY change is the imposed
+        // extent applies immediately instead of waiting for a SwiftUI
+        // update that may never come (representables are not reliably
+        // re-updated for observation-only changes).
+        splitState.applyImposedNow = { [weak coordinator = context.coordinator, weak splitView] in
+            guard let coordinator else { return }
+            // One coalesced apply on the NEXT runloop turn. Synchronous
+            // application from inside the caller's plan pass re-enters
+            // layout (impose -> layout -> geometry callback -> replan ->
+            // impose ...) and can pin the main thread; a deferred turn
+            // breaks the cycle while keeping the apply immediate enough
+            // that no settle poll ever sees a stale divider.
+            guard !coordinator.imposedApplyPending else { return }
+            coordinator.imposedApplyPending = true
+            DispatchQueue.main.async { [weak coordinator, weak splitView] in
+                guard let coordinator else { return }
+                coordinator.imposedApplyPending = false
+                guard let splitView else { return }
+                coordinator.syncPosition(coordinator.splitState.dividerPosition, in: splitView)
+            }
+        }
         let currentPosition = splitState.dividerPosition
         context.coordinator.syncPosition(currentPosition, in: splitView)
 
@@ -574,6 +596,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         var lastImposedOutcome: CGFloat?
         var lastImposedEpoch: Int?
         var imposedRetryBudget = 0
+        var imposedApplyPending = false
         weak var imposedRetrySplitView: NSSplitView?
         // Guard programmatic `setPosition` re-entrancy from resize callbacks.
         var isSyncingProgrammatically = false

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -488,9 +488,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
         // Access dividerPosition (and the imposed extent) so SwiftUI tracks
         // them as dependencies, then sync if either changed externally. The
-        // epoch must be read too: re-imposing an UNCHANGED extent bumps only
-        // the epoch, and without this read nothing invalidates the view, so
-        // syncPosition — where the refused-target retry lives — never runs.
+        // epoch must be read too so a changed target invalidates the view even
+        // when observation coalesces the extent write with adjacent updates.
         _ = splitState.imposedFirstExtent
         _ = splitState.imposedEpoch
         // Imperative imposition path: the controller calls this the moment
@@ -892,6 +891,24 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             guard splitView.arrangedSubviews.count >= 2 else { return }
             let available = splitAvailableSize(in: splitView)
             guard available > 0 else { return }
+            if let imposed = splitState.imposedFirstExtent {
+                let target = clampedDividerPosition(imposed, in: splitView)
+                setPositionSafely(target, in: splitView, layout: true)
+                lastImposedTarget = target
+                lastImposedEpoch = splitState.imposedEpoch
+                lastImposedOutcome = splitState.orientation == .horizontal
+                    ? splitView.arrangedSubviews[0].frame.width
+                    : splitView.arrangedSubviews[0].frame.height
+                mirrorImposedOutcome(lastImposedOutcome ?? target, in: splitView)
+                if abs((lastImposedOutcome ?? target) - target) > 0.01 {
+                    imposedRetryBudget = 5
+                    imposedRetrySplitView = splitView
+                    scheduleImposedRetry()
+                } else {
+                    imposedRetryBudget = 0
+                }
+                return
+            }
             let bounds = normalizedDividerBounds(in: splitView)
             let normalized = max(bounds.lowerBound, min(bounds.upperBound, splitState.dividerPosition))
             setPositionSafely(available * normalized, in: splitView, layout: true)

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -420,8 +420,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             context.coordinator.secondNodeType = secondType
         }
 
-        // Access dividerPosition to ensure SwiftUI tracks this dependency
-        // Then sync if the position changed externally
+        // Access dividerPosition (and the imposed extent) so SwiftUI tracks
+        // them as dependencies, then sync if either changed externally.
+        _ = splitState.imposedFirstExtent
         let currentPosition = splitState.dividerPosition
         context.coordinator.syncPosition(currentPosition, in: splitView)
 
@@ -549,6 +550,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         var onGeometryChange: ((_ isDragging: Bool) -> Void)?
         /// Track last applied position to detect external changes
         var lastAppliedPosition: CGFloat = 0.5
+        /// The imposed-extent memo: the last target we asked AppKit for and
+        /// the position it actually produced. Re-apply only when the target
+        /// changes or the divider moved away from that outcome — never in a
+        /// loop against a target AppKit's constraints refuse to reach.
+        var lastImposedTarget: CGFloat?
+        var lastImposedOutcome: CGFloat?
         // Guard programmatic `setPosition` re-entrancy from resize callbacks.
         var isSyncingProgrammatically = false
         /// Track if user is actively dragging the divider
@@ -596,6 +603,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 splitStateId = newState.id
                 splitState = newState
                 lastAppliedPosition = newState.dividerPosition
+                lastImposedTarget = nil
+                lastImposedOutcome = nil
                 didApplyInitialDividerPosition = false
                 initialDividerApplyAttempts = 0
                 isAnimating = false
@@ -726,6 +735,44 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             guard !isAnimating else { return }
             guard !isSyncingProgrammatically else { return }
             guard splitContainerProgrammaticSyncDepth == 0 else { return }
+
+            // An imposed extent bypasses the normalized-fraction path below
+            // entirely: the fraction comparisons use ~1% deadbands to damp
+            // pixel-rounding drift, and 1% of a large container is many
+            // points — far more than a terminal cell. Imposed layout applies
+            // exact points and mirrors the resulting fraction back into the
+            // model for readers.
+            if let imposed = splitState.imposedFirstExtent {
+                guard splitView.arrangedSubviews.count >= 2 else { return }
+                let available = splitAvailableSize(in: splitView)
+                guard available > 0 else { return }
+                let target = clampedDividerPosition(imposed, in: splitView)
+                let current = splitState.orientation == .horizontal
+                    ? splitView.arrangedSubviews[0].frame.width
+                    : splitView.arrangedSubviews[0].frame.height
+                // Convergence is memo-based, not measurement-based: apply once
+                // per distinct (target, outcome), remembering what the apply
+                // actually achieved. AppKit can refuse the exact target (its
+                // own pane-minimum constraints), and re-asserting whenever
+                // `current != target` then re-layouts on every pass — a
+                // main-thread spin. Re-apply only when the target changed or
+                // something ELSE moved the divider off our last outcome.
+                let moved = abs(current - (lastImposedOutcome ?? .infinity)) > 0.01
+                let retargeted = abs(target - (lastImposedTarget ?? .infinity)) > 0.01
+                if retargeted || (moved && abs(current - target) > 0.01) {
+                    setPositionSafely(target, in: splitView, layout: true)
+                    lastImposedTarget = target
+                    lastImposedOutcome = splitState.orientation == .horizontal
+                        ? splitView.arrangedSubviews[0].frame.width
+                        : splitView.arrangedSubviews[0].frame.height
+                }
+                let mirrored = target / available
+                if abs(splitState.dividerPosition - mirrored) > 0.000_1 {
+                    splitState.dividerPosition = mirrored
+                }
+                lastAppliedPosition = mirrored
+                return
+            }
 
             guard splitView.arrangedSubviews.count >= 2 else {
                 // Structural updates can temporarily remove an arranged subview.
@@ -974,6 +1021,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     "divider.dragUpdate split=\(splitState.id.uuidString.prefix(5)) normalized=\(String(format: "%.3f", normalizedPosition)) px=\(Int(dividerPosition.rounded())) available=\(Int(availableSize.rounded()))"
                 )
 #endif
+                self.splitState.imposedFirstExtent = nil
                 self.splitState.dividerPosition = normalizedPosition
                 self.lastAppliedPosition = normalizedPosition
                 // Notify geometry change with drag state

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -298,6 +298,22 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             context.coordinator.didApplyInitialDividerPosition = true
             context.coordinator.initialDividerApplyAttempts = 0
 
+            // A fresh view initializes from the strongest authority, same
+            // rule syncPosition applies on every pass: an imposed extent is
+            // exact points and wins over the mirrored-back fraction, which
+            // reconstructs those points only approximately (clamping and a
+            // changed available size skew it). Initializing from the
+            // fraction seeded a divider a half-cell or more off its imposed
+            // target, and every subsequent pass fought over the difference.
+            if splitState.imposedFirstExtent != nil {
+                context.coordinator.syncPosition(splitState.dividerPosition, in: splitView)
+                if animationOrigin != nil, shouldAnimate {
+                    splitView.arrangedSubviews.indices.forEach { splitView.arrangedSubviews[$0].isHidden = false }
+                    context.coordinator.isAnimating = false
+                }
+                return
+            }
+
             if animationOrigin != nil {
                 let targetDividerPosition = min(
                     max(splitState.dividerPosition, dividerPositionRange.lowerBound),
@@ -788,6 +804,20 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         }
 
         func setPositionSafely(_ position: CGFloat, in splitView: NSSplitView, layout: Bool = true) {
+#if DEBUG
+            // Wobble hunt: name every divider write while an imposition is
+            // active. The imposed target and a fraction-derived recompute
+            // disagree by ~half a cell, and two writers alternating is a
+            // divider flapping every frame at settle.
+            if splitState.imposedFirstExtent != nil {
+                let caller = Thread.callStackSymbols.dropFirst(1).prefix(3).joined(separator: " | ")
+                dlog(
+                    "split.setPosition split=\(String(splitState.id.uuidString.prefix(5)))"
+                        + " px=\(Int(position)) imposed=\(Int(splitState.imposedFirstExtent ?? -1))"
+                        + " \(caller)"
+                )
+            }
+#endif
             isSyncingProgrammatically = true
             splitContainerProgrammaticSyncDepth += 1
             defer {

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -808,6 +808,16 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             }
         }
 
+        private func mirrorImposedOutcome(_ outcome: CGFloat, in splitView: NSSplitView) {
+            let available = splitAvailableSize(in: splitView)
+            guard available > 0 else { return }
+            let mirrored = outcome / available
+            if abs(splitState.dividerPosition - mirrored) > 0.000_1 {
+                splitState.dividerPosition = mirrored
+            }
+            lastAppliedPosition = mirrored
+        }
+
         private func retryImposedIfStillShort() {
             guard imposedRetryBudget > 0,
                   let splitView = imposedRetrySplitView,
@@ -821,12 +831,14 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 : splitView.arrangedSubviews[0].frame.height
             guard abs(current - target) > 0.01 else {
                 imposedRetryBudget = 0
+                mirrorImposedOutcome(current, in: splitView)
                 return
             }
             setPositionSafely(target, in: splitView, layout: true)
             lastImposedOutcome = splitState.orientation == .horizontal
                 ? splitView.arrangedSubviews[0].frame.width
                 : splitView.arrangedSubviews[0].frame.height
+            mirrorImposedOutcome(lastImposedOutcome ?? current, in: splitView)
 #if DEBUG
             dlog(
                 "bonsplit.impose.retry split=\(String(splitState.id.uuidString.prefix(5)))"
@@ -960,11 +972,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                         imposedRetryBudget = 0
                     }
                 }
-                let mirrored = target / available
-                if abs(splitState.dividerPosition - mirrored) > 0.000_1 {
-                    splitState.dividerPosition = mirrored
-                }
-                lastAppliedPosition = mirrored
+                mirrorImposedOutcome(lastImposedOutcome ?? current, in: splitView)
                 return
             }
 

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -340,10 +340,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             // fraction seeded a divider a half-cell or more off its imposed
             // target, and every subsequent pass fought over the difference.
             if splitState.imposedFirstExtent != nil {
+                if animationOrigin != nil, shouldAnimate {
+                    context.coordinator.isAnimating = false
+                }
                 context.coordinator.syncPosition(splitState.dividerPosition, in: splitView)
                 if animationOrigin != nil, shouldAnimate {
                     splitView.arrangedSubviews.indices.forEach { splitView.arrangedSubviews[$0].isHidden = false }
-                    context.coordinator.isAnimating = false
                 }
                 return
             }

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -433,8 +433,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         }
 
         // Access dividerPosition (and the imposed extent) so SwiftUI tracks
-        // them as dependencies, then sync if either changed externally.
+        // them as dependencies, then sync if either changed externally. The
+        // epoch must be read too: re-imposing an UNCHANGED extent bumps only
+        // the epoch, and without this read nothing invalidates the view, so
+        // syncPosition — where the refused-target retry lives — never runs.
         _ = splitState.imposedFirstExtent
+        _ = splitState.imposedEpoch
         let currentPosition = splitState.dividerPosition
         context.coordinator.syncPosition(currentPosition, in: splitView)
 
@@ -568,6 +572,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         /// loop against a target AppKit's constraints refuse to reach.
         var lastImposedTarget: CGFloat?
         var lastImposedOutcome: CGFloat?
+        var lastImposedEpoch: Int?
+        var imposedRetryBudget = 0
+        weak var imposedRetrySplitView: NSSplitView?
         // Guard programmatic `setPosition` re-entrancy from resize callbacks.
         var isSyncingProgrammatically = false
         /// Track if user is actively dragging the divider
@@ -617,6 +624,8 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 lastAppliedPosition = newState.dividerPosition
                 lastImposedTarget = nil
                 lastImposedOutcome = nil
+                lastImposedEpoch = nil
+                imposedRetryBudget = 0
                 didApplyInitialDividerPosition = false
                 initialDividerApplyAttempts = 0
                 isAnimating = false
@@ -712,6 +721,49 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         }
 #endif
         /// Apply external position changes to the NSSplitView
+        /// One deferred retry per runloop turn for an imposed target AppKit
+        /// refused (see the imposed path in `syncPosition`). Deliberately
+        /// NOT measurement-driven layout-pass re-assertion — that spins the
+        /// main thread when a target is unreachable; this runs at most
+        /// `imposedRetryBudget` times per imposition and stops the moment
+        /// the outcome matches.
+        private func scheduleImposedRetry() {
+            DispatchQueue.main.async { [weak self] in
+                self?.retryImposedIfStillShort()
+            }
+        }
+
+        private func retryImposedIfStillShort() {
+            guard imposedRetryBudget > 0,
+                  let splitView = imposedRetrySplitView,
+                  let imposed = splitState.imposedFirstExtent,
+                  splitView.arrangedSubviews.count >= 2
+            else { return }
+            imposedRetryBudget -= 1
+            let target = clampedDividerPosition(imposed, in: splitView)
+            let current = splitState.orientation == .horizontal
+                ? splitView.arrangedSubviews[0].frame.width
+                : splitView.arrangedSubviews[0].frame.height
+            guard abs(current - target) > 0.01 else {
+                imposedRetryBudget = 0
+                return
+            }
+            setPositionSafely(target, in: splitView, layout: true)
+            lastImposedOutcome = splitState.orientation == .horizontal
+                ? splitView.arrangedSubviews[0].frame.width
+                : splitView.arrangedSubviews[0].frame.height
+#if DEBUG
+            dlog(
+                "bonsplit.impose.retry split=\(String(splitState.id.uuidString.prefix(5)))"
+                    + " target=\(Int(target)) outcome=\(Int(lastImposedOutcome ?? -1))"
+                    + " budget=\(imposedRetryBudget)"
+            )
+#endif
+            if abs((lastImposedOutcome ?? target) - target) > 0.01 {
+                scheduleImposedRetry()
+            }
+        }
+
         func setPositionSafely(_ position: CGFloat, in splitView: NSSplitView, layout: Bool = true) {
             isSyncingProgrammatically = true
             splitContainerProgrammaticSyncDepth += 1
@@ -771,12 +823,42 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 // something ELSE moved the divider off our last outcome.
                 let moved = abs(current - (lastImposedOutcome ?? .infinity)) > 0.01
                 let retargeted = abs(target - (lastImposedTarget ?? .infinity)) > 0.01
-                if retargeted || (moved && abs(current - target) > 0.01) {
+                // A fresh imposition call re-arms one apply attempt even for
+                // an identical target: AppKit may have refused this exact
+                // target earlier (transient pane minimums mid-churn), and
+                // with neither target nor divider moving since, nothing else
+                // would ever retry — panes would sit wedged at the refused
+                // layout. Bounded by explicit calls, so it cannot spin.
+                let renudged = lastImposedEpoch != splitState.imposedEpoch
+                if renudged || retargeted || (moved && abs(current - target) > 0.01) {
                     setPositionSafely(target, in: splitView, layout: true)
                     lastImposedTarget = target
+                    lastImposedEpoch = splitState.imposedEpoch
                     lastImposedOutcome = splitState.orientation == .horizontal
                         ? splitView.arrangedSubviews[0].frame.width
                         : splitView.arrangedSubviews[0].frame.height
+#if DEBUG
+                    dlog(
+                        "bonsplit.impose split=\(String(splitState.id.uuidString.prefix(5)))"
+                            + " target=\(Int(target)) outcome=\(Int(lastImposedOutcome ?? -1))"
+                            + " avail=\(Int(available)) renudged=\(renudged ? 1 : 0)"
+                            + " retargeted=\(retargeted ? 1 : 0) moved=\(moved ? 1 : 0)"
+                    )
+#endif
+                    // A refused apply (AppKit clamped against constraints
+                    // that are usually stale mid-churn bounds) gets a few
+                    // deferred retries, one per runloop turn: a turn later
+                    // AppKit has finished the layout pass that made the
+                    // target feasible. The budget makes it finite when the
+                    // target genuinely cannot fit; every fresh imposition
+                    // resets it.
+                    if abs((lastImposedOutcome ?? target) - target) > 0.01 {
+                        imposedRetryBudget = 5
+                        imposedRetrySplitView = splitView
+                        scheduleImposedRetry()
+                    } else {
+                        imposedRetryBudget = 0
+                    }
                 }
                 let mirrored = target / available
                 if abs(splitState.dividerPosition - mirrored) > 0.000_1 {

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -504,7 +504,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // extent applies immediately instead of waiting for a SwiftUI
         // update that may never come (representables are not reliably
         // re-updated for observation-only changes).
-        splitState.applyImposedNow = { [weak coordinator = context.coordinator, weak splitView] in
+        splitState.syncDividerNow = { [weak coordinator = context.coordinator, weak splitView] in
             guard let coordinator else { return }
             // One coalesced apply on the NEXT runloop turn. Synchronous
             // application from inside the caller's plan pass re-enters

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -383,9 +383,16 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                             duration: duration
                         ) {
                             context.coordinator.isAnimating = false
-                            // Re-assert the target ratio to prevent pixel-rounding drift.
-                            splitState.dividerPosition = targetDividerPosition
-                            context.coordinator.lastAppliedPosition = targetDividerPosition
+                            if splitState.imposedFirstExtent != nil {
+                                // An imposition requested during the entry animation
+                                // remains authoritative in the model; apply it now that
+                                // the animation guard no longer blocks synchronization.
+                                context.coordinator.syncPosition(splitState.dividerPosition, in: splitView)
+                            } else {
+                                // Re-assert the target ratio to prevent pixel-rounding drift.
+                                splitState.dividerPosition = targetDividerPosition
+                                context.coordinator.lastAppliedPosition = targetDividerPosition
+                            }
 #if DEBUG
                             dlog(
                                 "split.entry.complete split=\(splitDebugToken) orientation=\(orientationToken) " +

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -113,6 +113,15 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
             contentViewLifecycle: contentViewLifecycle
         )
         let hostingController = NonDraggableHostingController(rootView: paneView)
+        if #available(macOS 13.0, *) {
+            // Panes are space-filling: without this, the hosting controller
+            // publishes its SwiftUI content's ideal size as intrinsic-size
+            // constraints, and that pressure propagates up the fitting-size
+            // chain to whatever sizes itself from content — including a
+            // window that tracks its content's ideal. (Same reasoning as
+            // makeHostingController in SplitContainerView.)
+            hostingController.sizingOptions = []
+        }
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 
         let containerView = PaneDragContainerView()
@@ -133,6 +142,13 @@ struct SinglePaneWrapper<Content: View, EmptyContent: View>: NSViewRepresentable
         context.coordinator.hostingController = hostingController
 
         return containerView
+    }
+
+    // Space-filling, like SplitContainerView: a pane renders in whatever
+    // space its container gives it and must never answer an unspecified
+    // proposal with a content-derived size.
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSView, context: Context) -> CGSize? {
+        CGSize(width: proposal.width ?? 0, height: proposal.height ?? 0)
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -941,6 +941,7 @@ public final class BonsplitController {
                 id: splitState.id.uuidString,
                 orientation: splitState.orientation == .horizontal ? "horizontal" : "vertical",
                 dividerPosition: Double(splitState.dividerPosition),
+                imposedFirstExtent: splitState.imposedFirstExtent.map(Double.init),
                 first: buildExternalTree(from: splitState.first, containerFrame: containerFrame, bounds: firstBounds),
                 second: buildExternalTree(from: splitState.second, containerFrame: containerFrame, bounds: secondBounds)
             )
@@ -980,6 +981,30 @@ public final class BonsplitController {
             }
         }
 
+        return true
+    }
+
+    /// Imposes an exact first-child extent, in points, on a split — or
+    /// clears it with nil. While imposed, layout places the divider at
+    /// exactly this many points (clamped to pane minimums) instead of
+    /// scaling `dividerPosition`, and the mirrored fraction is kept coherent
+    /// for readers. A user divider drag clears the imposition and returns
+    /// the split to fraction semantics. Use this when pane contents are
+    /// grid-quantized (terminal cells) and a normalized fraction cannot
+    /// express the required pixel size losslessly.
+    public func setImposedFirstExtent(
+        _ extent: CGFloat?, forSplit splitId: UUID, fromExternal: Bool = false
+    ) -> Bool {
+        guard let split = internalController.findSplit(splitId) else { return false }
+        if fromExternal {
+            internalController.isExternalUpdateInProgress = true
+        }
+        split.imposedFirstExtent = extent.map { max(0, $0) }
+        if fromExternal {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.internalController.isExternalUpdateInProgress = false
+            }
+        }
         return true
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -1020,8 +1020,11 @@ public final class BonsplitController {
         if fromExternal {
             internalController.isExternalUpdateInProgress = true
         }
-        split.imposedFirstExtent = extent.map { max(0, $0) }
-        split.imposedEpoch &+= 1
+        let normalizedExtent = extent.map { max(0, $0) }
+        if split.imposedFirstExtent != normalizedExtent {
+            split.imposedFirstExtent = normalizedExtent
+            split.imposedEpoch &+= 1
+        }
         split.applyImposedNow?()
         if fromExternal {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -977,7 +977,8 @@ public final class BonsplitController {
 
     // MARK: - Geometry Update API
 
-    /// Set divider position for a split node (0.0-1.0)
+    /// Set divider position for a split node (0.0-1.0), clearing any exact
+    /// imposed extent so fraction-based callers take ownership of the divider.
     /// - Parameters:
     ///   - position: The new divider position (clamped to the configured range)
     ///   - splitId: The UUID of the split to update
@@ -993,7 +994,15 @@ public final class BonsplitController {
 
         let range = configuration.dividerPositionRange
         let clampedPosition = min(max(position, range.lowerBound), range.upperBound)
+        let clearedImposition = split.imposedFirstExtent != nil
+        if clearedImposition {
+            split.imposedFirstExtent = nil
+            split.imposedEpoch &+= 1
+        }
         split.dividerPosition = clampedPosition
+        if clearedImposition {
+            split.syncDividerNow?()
+        }
 
         if fromExternal {
             // Use a slight delay to allow the UI to update before re-enabling notifications
@@ -1027,7 +1036,7 @@ public final class BonsplitController {
             split.imposedFirstExtent = normalizedExtent
             split.imposedEpoch &+= 1
         }
-        split.applyImposedNow?()
+        split.syncDividerNow?()
         if fromExternal {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
                 self?.internalController.isExternalUpdateInProgress = false
@@ -1047,7 +1056,7 @@ public final class BonsplitController {
               split.imposedFirstExtent != nil
         else { return false }
         split.imposedEpoch &+= 1
-        split.applyImposedNow?()
+        split.syncDividerNow?()
         return true
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -1012,7 +1012,9 @@ public final class BonsplitController {
     /// for readers. A user divider drag clears the imposition and returns
     /// the split to fraction semantics. Use this when pane contents are
     /// grid-quantized (terminal cells) and a normalized fraction cannot
-    /// express the required pixel size losslessly.
+    /// express the required pixel size losslessly. Repeating the same extent
+    /// is idempotent; after an external constraint change, use
+    /// `retryImposedFirstExtent(forSplit:)` to request one fresh bounded apply.
     public func setImposedFirstExtent(
         _ extent: CGFloat?, forSplit splitId: UUID, fromExternal: Bool = false
     ) -> Bool {
@@ -1031,6 +1033,21 @@ public final class BonsplitController {
                 self?.internalController.isExternalUpdateInProgress = false
             }
         }
+        return true
+    }
+
+    /// Requests one fresh apply of a split's current imposed extent.
+    ///
+    /// Use this only after constraints that previously prevented the extent
+    /// have changed. Normal layout planning should keep calling
+    /// `setImposedFirstExtent(_:forSplit:fromExternal:)`, whose identical
+    /// updates are intentionally idempotent.
+    public func retryImposedFirstExtent(forSplit splitId: UUID) -> Bool {
+        guard let split = internalController.findSplit(splitId),
+              split.imposedFirstExtent != nil
+        else { return false }
+        split.imposedEpoch &+= 1
+        split.applyImposedNow?()
         return true
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -1000,6 +1000,7 @@ public final class BonsplitController {
             internalController.isExternalUpdateInProgress = true
         }
         split.imposedFirstExtent = extent.map { max(0, $0) }
+        split.imposedEpoch &+= 1
         if fromExternal {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
                 self?.internalController.isExternalUpdateInProgress = false

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -1001,6 +1001,7 @@ public final class BonsplitController {
         }
         split.imposedFirstExtent = extent.map { max(0, $0) }
         split.imposedEpoch &+= 1
+        split.applyImposedNow?()
         if fromExternal {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
                 self?.internalController.isExternalUpdateInProgress = false

--- a/Sources/Bonsplit/Public/Types/LayoutSnapshot.swift
+++ b/Sources/Bonsplit/Public/Types/LayoutSnapshot.swift
@@ -91,13 +91,24 @@ public struct ExternalSplitNode: Codable, Sendable, Equatable {
     public let id: String
     public let orientation: String  // "horizontal" or "vertical"
     public let dividerPosition: Double  // 0.0-1.0
+    /// The exact first-child extent imposed on this split in points, if any
+    /// (`BonsplitController.setImposedFirstExtent(_:forSplit:)`).
+    public let imposedFirstExtent: Double?
     public let first: ExternalTreeNode
     public let second: ExternalTreeNode
 
-    public init(id: String, orientation: String, dividerPosition: Double, first: ExternalTreeNode, second: ExternalTreeNode) {
+    public init(
+        id: String,
+        orientation: String,
+        dividerPosition: Double,
+        imposedFirstExtent: Double? = nil,
+        first: ExternalTreeNode,
+        second: ExternalTreeNode
+    ) {
         self.id = id
         self.orientation = orientation
         self.dividerPosition = dividerPosition
+        self.imposedFirstExtent = imposedFirstExtent
         self.first = first
         self.second = second
     }


### PR DESCRIPTION
When cmux mirrors a tmux window, every pane has to come out an exact number of terminal cells wide — a pane even one column short wraps every full-width line. Bonsplit's only way to place a divider was a ratio between 0 and 1, and the code that applies ratios ignores changes smaller than about 1% so the divider doesn't jitter. One percent of a big split is a lot of pixels: about 20 points on a 2000-point window, two or three terminal columns. So a host could compute the perfect ratio and bonsplit would quietly not apply it, and a pane came out a column short.

This adds a second way to place a divider: tell the split exactly how many points its first pane should get. `setImposedFirstExtent(_:forSplit:)` stores that number on the split, layout applies it as-is (still respecting minimum pane sizes), and the matching ratio is written back to `dividerPosition` so anything that reads the ratio still sees the right value. When the user drags the divider, the stored number is cleared and the split behaves like a normal ratio split again.

Making that reliable under churn took four follow-on rules, each from a failure a randomized live harness caught in a host application:

Impositions apply imperatively, not through SwiftUI observation. A split whose only change is a re-imposed extent may never get another `updateNSView` — representables are not reliably re-updated for observation-only changes — so the divider kept rendering a previous layout until some unrelated event nudged the view. The coordinator installs a hook the controller calls directly, coalesced to one apply on the next runloop turn so a caller's plan pass cannot re-enter layout.

A fresh split view initializes from its imposed extent, not the ratio. The written-back ratio reconstructs the imposed points only approximately (clamping and a changed available size skew it), so a recreated view started a half-cell off its target and every later pass fought over the difference.

A refused apply retries once per runloop turn, budgeted. AppKit can clamp a divider against pane minimums computed from bounds a structural update is about to replace; one turn later the target is feasible. The budget keeps an infeasible target from spinning the main thread, and every fresh imposition resets it.

An apply is skipped when the divider already sits on target. A same-position `setPosition` still runs a layout pass, which re-applies surface sizes, which can re-impose — a sustained once-per-turn churn loop at full CPU.

Split trees also stopped answering size proposals with content-derived ideals: they are space-filling, and any container that sizes itself from content would otherwise adopt the tree's own layout as its bounds and hand it back grown — with absolute divider positions, that round trip compounds without bound.

DEBUG builds log every imposed apply and retry with its outcome, and any divider write that disagrees with an active imposition, with the caller's symbol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for imposing an exact first-pane size in split layouts.
  - Added controller and snapshot APIs for setting, clearing, and preserving imposed pane sizes.
  - Imposed sizes are clamped to valid pane minimums and reflected in divider position values.

- **Bug Fixes**
  - Improved layout sizing to prevent containers and panes from expanding based on content.
  - Divider placement now reliably applies absolute sizes and recovers when the layout system temporarily rejects them.
  - User divider dragging automatically returns the layout to normal fractional positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->