### PR TITLE
Host-injectable divider cursors for split cursor rects

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -47,6 +47,31 @@ private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
         customDividerThickness ?? super.dividerThickness
     }
 
+    /// When the host injects divider cursors, replace AppKit's built-in
+    /// divider cursor rects (added by super) with the custom cursor over
+    /// each divider's expanded effective rect.
+    override func resetCursorRects() {
+        let custom = isVertical ? BonsplitDividerCursors.vertical : BonsplitDividerCursors.horizontal
+        guard let custom else {
+            super.resetCursorRects()
+            return
+        }
+        let expansion = resolvedDividerHitExpansion
+        let thickness = dividerThickness
+        for index in 0..<max(0, arrangedSubviews.count - 1) {
+            let first = arrangedSubviews[index].frame
+            var rect = isVertical
+                ? NSRect(x: max(0, first.maxX), y: 0, width: thickness, height: bounds.height)
+                : NSRect(x: 0, y: max(0, first.maxY), width: bounds.width, height: thickness)
+            rect = rect.insetBy(
+                dx: isVertical ? -expansion : 0,
+                dy: isVertical ? 0 : -expansion
+            ).intersection(bounds)
+            guard !rect.isNull, rect.width > 0, rect.height > 0 else { continue }
+            addCursorRect(rect, cursor: custom)
+        }
+    }
+
     // Paint the full reserved divider rect with the resolved color so a
     // thicker-than-hairline divider renders as a solid bar. AppKit's `.thin`
     // style otherwise draws a 1pt line regardless of the reserved thickness.

--- a/Sources/Bonsplit/Public/BonsplitDividerCursors.swift
+++ b/Sources/Bonsplit/Public/BonsplitDividerCursors.swift
@@ -1,0 +1,14 @@
+import AppKit
+
+/// Host-injectable cursors for split divider cursor rects.
+///
+/// When set, managed split views register these over their divider effective
+/// rects instead of AppKit's built-in system resize cursors, so a host that
+/// draws its own resize-cursor family (e.g. to match a custom four-way corner
+/// cursor) keeps one visual set. Unset (the default) preserves AppKit's
+/// native divider cursors.
+@MainActor
+public enum BonsplitDividerCursors {
+    public static var vertical: NSCursor?
+    public static var horizontal: NSCursor?
+}


### PR DESCRIPTION
cmux draws its own resize-cursor family (manaflow-ai/cmux#7839: custom four-way corner cursor, matching single-axis variants). NSSplitView's built-in divider cursor rects still register the system cursors, and with overlapping cursor rects AppKit's winner is undefined — so the old system glyphs intermittently show through. When `BonsplitDividerCursors.vertical/horizontal` are set, `ThemedSplitView.resetCursorRects` registers the injected cursor over each divider's expanded effective rect instead of AppKit's defaults; unset keeps native behavior. Additive, default unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786438130&installation_id=133855650&pr_number=177&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F177&signature=922bdd3623cb22739cfa0ee08231a1deb6bbc777c8e662229777376a066814d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let hosts inject custom divider cursors into managed split views so custom resize cursors always win over AppKit’s defaults. Defaults remain unchanged when unset.

- **New Features**
  - Added `BonsplitDividerCursors.vertical` and `.horizontal` for optional `NSCursor` injection.
  - `ThemedSplitView.resetCursorRects` now registers the injected cursor over each divider’s expanded effective rect, replacing AppKit’s cursor rects to avoid overlap conflicts.

- **Migration**
  - Optional: Set `BonsplitDividerCursors.vertical`/`.horizontal` to your `NSCursor` instances; leave `nil` to keep native behavior.

<sup>Written for commit 63dba21b2ca652779efd0c710bf1ec7d11127e2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

