### PR TITLE
Fix tab bar layout feedback at scale (#7975)

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -273,7 +273,11 @@ enum TabBarColors {
     }
 
     static func activeIndicator(saturation: Double) -> Color {
-        return Color(nsColor: NSColor.controlAccentColor.bonsplitSaturating(by: saturation))
+        Color(nsColor: nsColorActiveIndicator(saturation: saturation))
+    }
+
+    static func nsColorActiveIndicator(saturation: Double) -> NSColor {
+        NSColor.controlAccentColor.bonsplitSaturating(by: saturation)
     }
 
     static var focusRing: Color {

--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -1,0 +1,202 @@
+import AppKit
+import SwiftUI
+
+/// AppKit-owned geometry for the tab strip.
+///
+/// Tab frames stay in the platform view hierarchy and are queried only by
+/// platform consumers. They never become SwiftUI state, so measuring or
+/// scrolling the strip cannot invalidate the graph that produced the frames.
+@MainActor
+final class TabBarItemGeometryRegistry {
+    private let itemViews = NSMapTable<NSUUID, NSView>.strongToWeakObjects()
+    private let observers = NSHashTable<NSView>.weakObjects()
+    private weak var scrollView: NSScrollView?
+    private var scrollBoundsObservation: NSKeyValueObservation?
+
+    func register(_ view: NSView, for tabId: UUID) {
+        itemViews.setObject(view, forKey: tabId as NSUUID)
+        invalidateObservers()
+    }
+
+    func unregister(_ view: NSView, for tabId: UUID) {
+        guard itemViews.object(forKey: tabId as NSUUID) === view else { return }
+        itemViews.removeObject(forKey: tabId as NSUUID)
+        invalidateObservers()
+    }
+
+    func registerObserver(_ view: NSView) {
+        observers.add(view)
+        view.needsDisplay = true
+    }
+
+    func unregisterObserver(_ view: NSView) {
+        observers.remove(view)
+    }
+
+    func attachScrollView(_ scrollView: NSScrollView?) {
+        guard self.scrollView !== scrollView else { return }
+        scrollBoundsObservation = nil
+        self.scrollView = scrollView
+        guard let clipView = scrollView?.contentView else {
+            invalidateObservers()
+            return
+        }
+
+        // NSClipView exposes scroll movement through KVO; keeping that signal in
+        // AppKit lets chrome redraw without publishing geometry into SwiftUI.
+        scrollBoundsObservation = clipView.observe(\.bounds, options: [.new]) { [weak self] _, _ in
+            MainActor.assumeIsolated {
+                self?.invalidateObservers()
+            }
+        }
+        invalidateObservers()
+    }
+
+    func frame(for tabId: UUID, in targetView: NSView) -> CGRect? {
+        guard let itemView = itemViews.object(forKey: tabId as NSUUID),
+              itemView.window === targetView.window,
+              isVisibleInHierarchy(itemView) else {
+            return nil
+        }
+        return itemView.convert(itemView.bounds, to: targetView)
+    }
+
+    func frames(for tabIds: [UUID], in targetView: NSView) -> [UUID: CGRect] {
+        var frames: [UUID: CGRect] = [:]
+        frames.reserveCapacity(tabIds.count)
+        for tabId in tabIds {
+            if let frame = frame(for: tabId, in: targetView) {
+                frames[tabId] = frame
+            }
+        }
+        return frames
+    }
+
+    func geometryDidChange() {
+        invalidateObservers()
+    }
+
+    private func invalidateObservers() {
+        for observer in observers.allObjects {
+            observer.needsDisplay = true
+            observer.needsLayout = true
+        }
+    }
+
+    private func isVisibleInHierarchy(_ view: NSView) -> Bool {
+        var current: NSView? = view
+        while let candidate = current {
+            guard !candidate.isHidden, candidate.alphaValue > 0 else { return false }
+            current = candidate.superview
+        }
+        return true
+    }
+}
+
+struct TabItemHitRegionView: NSViewRepresentable {
+    let tabId: UUID
+    let geometryRegistry: TabBarItemGeometryRegistry
+
+    func makeNSView(context: Context) -> RegionNSView {
+        let view = RegionNSView()
+        view.configure(tabId: tabId, geometryRegistry: geometryRegistry)
+        return view
+    }
+
+    func updateNSView(_ nsView: RegionNSView, context: Context) {
+        nsView.configure(tabId: tabId, geometryRegistry: geometryRegistry)
+    }
+
+    final class RegionNSView: NSView, BonsplitTabItemHitRegionProviding {
+        nonisolated(unsafe) private var hitBounds: NSRect = .zero
+        private var tabId: UUID?
+        private weak var geometryRegistry: TabBarItemGeometryRegistry?
+
+        override var mouseDownCanMoveWindow: Bool { false }
+
+        deinit {
+            unregisterGeometry()
+            BonsplitTabItemHitRegionRegistry.unregister(self)
+        }
+
+        func configure(tabId: UUID, geometryRegistry: TabBarItemGeometryRegistry) {
+            if self.tabId != tabId || self.geometryRegistry !== geometryRegistry {
+                unregisterGeometry()
+                self.tabId = tabId
+                self.geometryRegistry = geometryRegistry
+            }
+            registerGeometryIfVisible()
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            syncHitBounds()
+            BonsplitTabItemHitRegionRegistry.unregister(self)
+            if window != nil {
+                BonsplitTabItemHitRegionRegistry.register(self)
+            }
+            registerGeometryIfVisible()
+        }
+
+        override func viewDidMoveToSuperview() {
+            super.viewDidMoveToSuperview()
+            if superview == nil {
+                unregisterGeometry()
+                BonsplitTabItemHitRegionRegistry.unregister(self)
+            } else {
+                registerGeometryIfVisible()
+            }
+        }
+
+        override func layout() {
+            super.layout()
+            syncHitBounds()
+            geometryRegistry?.geometryDidChange()
+        }
+
+        override func setFrameSize(_ newSize: NSSize) {
+            super.setFrameSize(newSize)
+            syncHitBounds()
+            geometryRegistry?.geometryDidChange()
+        }
+
+        override func setBoundsSize(_ newSize: NSSize) {
+            super.setBoundsSize(newSize)
+            syncHitBounds()
+            geometryRegistry?.geometryDidChange()
+        }
+
+        override func setBoundsOrigin(_ newOrigin: NSPoint) {
+            super.setBoundsOrigin(newOrigin)
+            syncHitBounds()
+            geometryRegistry?.geometryDidChange()
+        }
+
+        nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
+            hitBounds
+                .insetBy(
+                    dx: -BonsplitTabItemHitTesting.horizontalSlop,
+                    dy: -BonsplitTabItemHitTesting.verticalSlop
+                )
+                .contains(localPoint)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+
+        private func registerGeometryIfVisible() {
+            guard window != nil, superview != nil, let tabId else { return }
+            geometryRegistry?.register(self, for: tabId)
+        }
+
+        private func unregisterGeometry() {
+            guard let tabId else { return }
+            geometryRegistry?.unregister(self, for: tabId)
+        }
+
+        private func syncHitBounds() {
+            hitBounds = bounds
+        }
+    }
+}

--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -1,6 +1,11 @@
 import AppKit
 import SwiftUI
 
+@MainActor
+protocol TabBarItemGeometryObserving: AnyObject {
+    func tabBarItemGeometryDidChange()
+}
+
 /// AppKit-owned geometry for the tab strip.
 ///
 /// Tab frames stay in the platform view hierarchy and are queried only by
@@ -9,9 +14,15 @@ import SwiftUI
 @MainActor
 final class TabBarItemGeometryRegistry {
     private let itemViews = NSMapTable<NSUUID, NSView>.strongToWeakObjects()
-    private let observers = NSHashTable<NSView>.weakObjects()
+    private let observers = NSHashTable<AnyObject>.weakObjects()
     private weak var scrollView: NSScrollView?
-    private var scrollBoundsObservation: NSKeyValueObservation?
+    private var scrollBoundsObserver: NSObjectProtocol?
+
+    deinit {
+        if let scrollBoundsObserver {
+            NotificationCenter.default.removeObserver(scrollBoundsObserver)
+        }
+    }
 
     func register(_ view: NSView, for tabId: UUID) {
         itemViews.setObject(view, forKey: tabId as NSUUID)
@@ -24,27 +35,35 @@ final class TabBarItemGeometryRegistry {
         invalidateObservers()
     }
 
-    func registerObserver(_ view: NSView) {
-        observers.add(view)
-        view.needsDisplay = true
+    func registerObserver(_ observer: TabBarItemGeometryObserving) {
+        observers.add(observer)
+        observer.tabBarItemGeometryDidChange()
     }
 
-    func unregisterObserver(_ view: NSView) {
-        observers.remove(view)
+    func unregisterObserver(_ observer: TabBarItemGeometryObserving) {
+        observers.remove(observer)
     }
 
     func attachScrollView(_ scrollView: NSScrollView?) {
         guard self.scrollView !== scrollView else { return }
-        scrollBoundsObservation = nil
+        if let scrollBoundsObserver {
+            NotificationCenter.default.removeObserver(scrollBoundsObserver)
+            self.scrollBoundsObserver = nil
+        }
         self.scrollView = scrollView
         guard let clipView = scrollView?.contentView else {
             invalidateObservers()
             return
         }
 
-        // NSClipView exposes scroll movement through KVO; keeping that signal in
-        // AppKit lets chrome redraw without publishing geometry into SwiftUI.
-        scrollBoundsObservation = clipView.observe(\.bounds, options: [.new]) { [weak self] _, _ in
+        // Keep the documented AppKit scroll signal outside SwiftUI so chrome
+        // redraws do not publish geometry into the view graph.
+        clipView.postsBoundsChangedNotifications = true
+        scrollBoundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: clipView,
+            queue: .main
+        ) { [weak self] _ in
             MainActor.assumeIsolated {
                 self?.invalidateObservers()
             }
@@ -77,9 +96,8 @@ final class TabBarItemGeometryRegistry {
     }
 
     private func invalidateObservers() {
-        for observer in observers.allObjects {
-            observer.needsDisplay = true
-            observer.needsLayout = true
+        for case let observer as TabBarItemGeometryObserving in observers.allObjects {
+            observer.tabBarItemGeometryDidChange()
         }
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
@@ -5,7 +5,9 @@ struct TabBarSelectionChromeMask: Equatable {
     let leftFadeWidth: CGFloat
     let rightFadeWidth: CGFloat
     let rightOcclusionWidth: CGFloat
-    let actionLaneSeparatorWidth: CGFloat
+    let actionLaneSeparatorFadeWidth: CGFloat
+    let actionLaneSeparatorSolidWidth: CGFloat
+    let actionLaneSeparatorFadeRampStartFraction: CGFloat
 }
 
 struct TabBarSelectionChromeView: NSViewRepresentable {
@@ -49,7 +51,9 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
             leftFadeWidth: 0,
             rightFadeWidth: 0,
             rightOcclusionWidth: 0,
-            actionLaneSeparatorWidth: 0
+            actionLaneSeparatorFadeWidth: 0,
+            actionLaneSeparatorSolidWidth: 0,
+            actionLaneSeparatorFadeRampStartFraction: 0
         )
 
         override var isFlipped: Bool { true }
@@ -98,19 +102,43 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
                 )).fill()
             }
 
-            let actionLaneStartX = max(
-                bounds.minX,
-                bounds.maxX - max(0, mask.actionLaneSeparatorWidth)
+            let solidWidth = max(0, mask.actionLaneSeparatorSolidWidth)
+            let solidMinX = max(bounds.minX, bounds.maxX - solidWidth)
+            let solidIntersection = NSIntersectionRect(
+                NSRect(x: solidMinX, y: separatorY, width: solidWidth, height: 1),
+                NSRect(x: selectedMinX, y: separatorY, width: selectedMaxX - selectedMinX, height: 1)
             )
-            let fallbackMinX = max(selectedMinX, actionLaneStartX)
-            let fallbackMaxX = min(selectedMaxX, bounds.maxX)
-            if fallbackMaxX > fallbackMinX {
-                NSBezierPath(rect: NSRect(
-                    x: fallbackMinX,
-                    y: separatorY,
-                    width: fallbackMaxX - fallbackMinX,
-                    height: 1
-                )).fill()
+            if !solidIntersection.isEmpty {
+                NSBezierPath(rect: solidIntersection).fill()
+            }
+
+            let fadeWidth = max(0, mask.actionLaneSeparatorFadeWidth)
+            let fadeFrame = NSRect(
+                x: solidMinX - fadeWidth,
+                y: separatorY,
+                width: fadeWidth,
+                height: 1
+            )
+            let fadeIntersection = NSIntersectionRect(
+                fadeFrame,
+                NSRect(x: selectedMinX, y: separatorY, width: selectedMaxX - selectedMinX, height: 1)
+            )
+            if !fadeIntersection.isEmpty {
+                let clearSeparator = separatorColor.withAlphaComponent(0)
+                let rampStart = min(
+                    max(0, mask.actionLaneSeparatorFadeRampStartFraction),
+                    0.95
+                )
+                let gradient = NSGradient(
+                    colorsAndLocations:
+                        (clearSeparator, 0),
+                        (clearSeparator, rampStart),
+                        (separatorColor, 1)
+                )
+                NSGraphicsContext.saveGraphicsState()
+                NSBezierPath(rect: fadeIntersection).addClip()
+                gradient?.draw(in: fadeFrame, angle: 0)
+                NSGraphicsContext.restoreGraphicsState()
             }
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
@@ -1,0 +1,140 @@
+import AppKit
+import SwiftUI
+
+struct TabBarSelectionChromeMask: Equatable {
+    let leftFadeWidth: CGFloat
+    let rightFadeWidth: CGFloat
+    let rightOcclusionWidth: CGFloat
+    let actionLaneSeparatorWidth: CGFloat
+}
+
+struct TabBarSelectionChromeView: NSViewRepresentable {
+    let selectedTabId: UUID?
+    let geometryRegistry: TabBarItemGeometryRegistry
+    let indicatorColor: NSColor
+    let separatorColor: NSColor
+    let mask: TabBarSelectionChromeMask
+
+    func makeNSView(context: Context) -> ChromeNSView {
+        let view = ChromeNSView()
+        view.geometryRegistry = geometryRegistry
+        geometryRegistry.registerObserver(view)
+        update(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: ChromeNSView, context: Context) {
+        if nsView.geometryRegistry !== geometryRegistry {
+            nsView.geometryRegistry?.unregisterObserver(nsView)
+            nsView.geometryRegistry = geometryRegistry
+            geometryRegistry.registerObserver(nsView)
+        }
+        update(nsView)
+    }
+
+    private func update(_ view: ChromeNSView) {
+        view.selectedTabId = selectedTabId
+        view.indicatorColor = indicatorColor
+        view.separatorColor = separatorColor
+        view.mask = mask
+        view.needsDisplay = true
+    }
+
+    final class ChromeNSView: NSView {
+        weak var geometryRegistry: TabBarItemGeometryRegistry?
+        var selectedTabId: UUID?
+        var indicatorColor: NSColor = .controlAccentColor
+        var separatorColor: NSColor = .separatorColor
+        var mask = TabBarSelectionChromeMask(
+            leftFadeWidth: 0,
+            rightFadeWidth: 0,
+            rightOcclusionWidth: 0,
+            actionLaneSeparatorWidth: 0
+        )
+
+        override var isFlipped: Bool { true }
+        override var isOpaque: Bool { false }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            nil
+        }
+
+        override func draw(_ dirtyRect: NSRect) {
+            super.draw(dirtyRect)
+
+            let selectedFrame = selectedTabId.flatMap {
+                geometryRegistry?.frame(for: $0, in: self)
+            }
+            drawBottomSeparator(around: selectedFrame)
+            drawSelectedIndicator(in: selectedFrame)
+        }
+
+        private func drawBottomSeparator(around selectedFrame: CGRect?) {
+            separatorColor.setFill()
+            let separatorY = max(bounds.minY, bounds.maxY - 1)
+            guard let selectedFrame else {
+                NSBezierPath(
+                    rect: NSRect(x: bounds.minX, y: separatorY, width: bounds.width, height: 1)
+                ).fill()
+                return
+            }
+
+            let selectedMinX = min(max(selectedFrame.minX, bounds.minX), bounds.maxX)
+            let selectedMaxX = min(max(selectedFrame.maxX, bounds.minX), bounds.maxX)
+            if selectedMinX > bounds.minX {
+                NSBezierPath(rect: NSRect(
+                    x: bounds.minX,
+                    y: separatorY,
+                    width: selectedMinX - bounds.minX,
+                    height: 1
+                )).fill()
+            }
+            if selectedMaxX < bounds.maxX {
+                NSBezierPath(rect: NSRect(
+                    x: selectedMaxX,
+                    y: separatorY,
+                    width: bounds.maxX - selectedMaxX,
+                    height: 1
+                )).fill()
+            }
+
+            let actionLaneStartX = max(
+                bounds.minX,
+                bounds.maxX - max(0, mask.actionLaneSeparatorWidth)
+            )
+            let fallbackMinX = max(selectedMinX, actionLaneStartX)
+            let fallbackMaxX = min(selectedMaxX, bounds.maxX)
+            if fallbackMaxX > fallbackMinX {
+                NSBezierPath(rect: NSRect(
+                    x: fallbackMinX,
+                    y: separatorY,
+                    width: fallbackMaxX - fallbackMinX,
+                    height: 1
+                )).fill()
+            }
+        }
+
+        private func drawSelectedIndicator(in selectedFrame: CGRect?) {
+            guard var frame = selectedFrame else { return }
+            frame.origin.y = bounds.minY
+            frame.size.width = max(0, frame.width - TabBarMetrics.activeIndicatorTrailingInset)
+            frame.size.height = TabBarMetrics.activeIndicatorHeight
+
+            let clipMinX = min(bounds.maxX, bounds.minX + max(0, mask.leftFadeWidth))
+            let rightInset = max(0, mask.rightFadeWidth) + max(0, mask.rightOcclusionWidth)
+            let clipMaxX = max(bounds.minX, bounds.maxX - rightInset)
+            guard clipMaxX > clipMinX else { return }
+
+            NSGraphicsContext.saveGraphicsState()
+            NSBezierPath(rect: NSRect(
+                x: clipMinX,
+                y: bounds.minY,
+                width: clipMaxX - clipMinX,
+                height: bounds.height
+            )).addClip()
+            indicatorColor.setFill()
+            NSBezierPath(rect: frame).fill()
+            NSGraphicsContext.restoreGraphicsState()
+        }
+    }
+}

--- a/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
@@ -186,11 +186,15 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
                 gradientFrame: leftFadeFrame,
                 colors: [indicatorColor.withAlphaComponent(0), indicatorColor]
             )
-            drawIndicatorFade(
-                in: frame.intersection(rightFadeFrame),
-                gradientFrame: rightFadeFrame,
-                colors: [indicatorColor, indicatorColor.withAlphaComponent(0)]
-            )
+            // An action-lane fade removes tab content before foreground controls begin.
+            // Keep the indicator out of that region; ordinary scroll edges still fade it.
+            if mask.rightOcclusionWidth == 0 {
+                drawIndicatorFade(
+                    in: frame.intersection(rightFadeFrame),
+                    gradientFrame: rightFadeFrame,
+                    colors: [indicatorColor, indicatorColor.withAlphaComponent(0)]
+                )
+            }
         }
 
         private func drawIndicatorSegment(_ frame: NSRect, color: NSColor) {

--- a/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
@@ -42,7 +42,7 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
         view.needsDisplay = true
     }
 
-    final class ChromeNSView: NSView {
+    final class ChromeNSView: NSView, TabBarItemGeometryObserving {
         weak var geometryRegistry: TabBarItemGeometryRegistry?
         var selectedTabId: UUID?
         var indicatorColor: NSColor = .controlAccentColor
@@ -61,6 +61,10 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
 
         override func hitTest(_ point: NSPoint) -> NSView? {
             nil
+        }
+
+        func tabBarItemGeometryDidChange() {
+            needsDisplay = true
         }
 
         override func draw(_ dirtyRect: NSRect) {
@@ -104,10 +108,18 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
 
             let solidWidth = max(0, mask.actionLaneSeparatorSolidWidth)
             let solidMinX = max(bounds.minX, bounds.maxX - solidWidth)
-            let solidIntersection = NSIntersectionRect(
-                NSRect(x: solidMinX, y: separatorY, width: solidWidth, height: 1),
-                NSRect(x: selectedMinX, y: separatorY, width: selectedMaxX - selectedMinX, height: 1)
+            let selectedSeparatorFrame = NSRect(
+                x: selectedMinX,
+                y: separatorY,
+                width: selectedMaxX - selectedMinX,
+                height: 1
             )
+            let solidIntersection = NSRect(
+                x: solidMinX,
+                y: separatorY,
+                width: solidWidth,
+                height: 1
+            ).intersection(selectedSeparatorFrame)
             if !solidIntersection.isEmpty {
                 NSBezierPath(rect: solidIntersection).fill()
             }
@@ -119,10 +131,7 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
                 width: fadeWidth,
                 height: 1
             )
-            let fadeIntersection = NSIntersectionRect(
-                fadeFrame,
-                NSRect(x: selectedMinX, y: separatorY, width: selectedMaxX - selectedMinX, height: 1)
-            )
+            let fadeIntersection = fadeFrame.intersection(selectedSeparatorFrame)
             if !fadeIntersection.isEmpty {
                 let clearSeparator = separatorColor.withAlphaComponent(0)
                 let rampStart = min(
@@ -148,20 +157,57 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
             frame.size.width = max(0, frame.width - TabBarMetrics.activeIndicatorTrailingInset)
             frame.size.height = TabBarMetrics.activeIndicatorHeight
 
-            let clipMinX = min(bounds.maxX, bounds.minX + max(0, mask.leftFadeWidth))
-            let rightInset = max(0, mask.rightFadeWidth) + max(0, mask.rightOcclusionWidth)
-            let clipMaxX = max(bounds.minX, bounds.maxX - rightInset)
-            guard clipMaxX > clipMinX else { return }
-
-            NSGraphicsContext.saveGraphicsState()
-            NSBezierPath(rect: NSRect(
-                x: clipMinX,
+            let leftFadeFrame = NSRect(
+                x: bounds.minX,
                 y: bounds.minY,
-                width: clipMaxX - clipMinX,
+                width: min(bounds.width, max(0, mask.leftFadeWidth)),
                 height: bounds.height
-            )).addClip()
-            indicatorColor.setFill()
+            )
+            let rightFadeMaxX = max(
+                bounds.minX,
+                bounds.maxX - max(0, mask.rightOcclusionWidth)
+            )
+            let rightFadeFrame = NSRect(
+                x: max(bounds.minX, rightFadeMaxX - max(0, mask.rightFadeWidth)),
+                y: bounds.minY,
+                width: min(max(0, mask.rightFadeWidth), rightFadeMaxX - bounds.minX),
+                height: bounds.height
+            )
+            let solidFrame = NSRect(
+                x: leftFadeFrame.maxX,
+                y: bounds.minY,
+                width: max(0, rightFadeFrame.minX - leftFadeFrame.maxX),
+                height: bounds.height
+            )
+
+            drawIndicatorSegment(frame.intersection(solidFrame), color: indicatorColor)
+            drawIndicatorFade(
+                in: frame.intersection(leftFadeFrame),
+                gradientFrame: leftFadeFrame,
+                colors: [indicatorColor.withAlphaComponent(0), indicatorColor]
+            )
+            drawIndicatorFade(
+                in: frame.intersection(rightFadeFrame),
+                gradientFrame: rightFadeFrame,
+                colors: [indicatorColor, indicatorColor.withAlphaComponent(0)]
+            )
+        }
+
+        private func drawIndicatorSegment(_ frame: NSRect, color: NSColor) {
+            guard !frame.isEmpty else { return }
+            color.setFill()
             NSBezierPath(rect: frame).fill()
+        }
+
+        private func drawIndicatorFade(
+            in frame: NSRect,
+            gradientFrame: NSRect,
+            colors: [NSColor]
+        ) {
+            guard !frame.isEmpty, gradientFrame.width > 0 else { return }
+            NSGraphicsContext.saveGraphicsState()
+            NSBezierPath(rect: frame).addClip()
+            NSGradient(colors: colors)?.draw(in: gradientFrame, angle: 0)
             NSGraphicsContext.restoreGraphicsState()
         }
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1486,6 +1486,9 @@ struct TabBarView: View {
             }
         }
         .onPreferenceChange(TabFramePreferenceKey.self) { frames in
+#if DEBUG
+            BonsplitDebugCounters.recordTabBarLayoutFeedbackMutation()
+#endif
             withTransaction(Transaction(animation: nil)) {
                 tabFramesInBar = frames
             }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2765,7 +2765,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
         nsView.onDoubleClick = onDoubleClick
     }
 
-    final class DragNSView: NSView {
+    final class DragNSView: NSView, TabBarItemGeometryObserving {
         var hitRegion = HitRegion.entireBounds {
             didSet {
                 unregisterGeometryObserver(from: oldValue)
@@ -2806,6 +2806,10 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
         override func layout() {
             super.layout()
+            invalidateWindowDragCursorRects()
+        }
+
+        func tabBarItemGeometryDidChange() {
             invalidateWindowDragCursorRects()
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -118,85 +118,6 @@ enum BonsplitTabItemHitTesting {
     }
 }
 
-private struct TabItemHitRegionView: NSViewRepresentable {
-    func makeNSView(context: Context) -> RegionNSView {
-        RegionNSView()
-    }
-
-    func updateNSView(_ nsView: RegionNSView, context: Context) {}
-
-    final class RegionNSView: NSView, BonsplitTabItemHitRegionProviding {
-        nonisolated(unsafe) private var hitBounds: NSRect = .zero
-
-        override var mouseDownCanMoveWindow: Bool { false }
-
-        deinit {
-            BonsplitTabItemHitRegionRegistry.unregister(self)
-        }
-
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            syncHitBounds()
-            BonsplitTabItemHitRegionRegistry.unregister(self)
-            if window != nil {
-                BonsplitTabItemHitRegionRegistry.register(self)
-            }
-        }
-
-        override func viewDidMoveToSuperview() {
-            super.viewDidMoveToSuperview()
-            if superview == nil {
-                BonsplitTabItemHitRegionRegistry.unregister(self)
-            }
-        }
-
-        override func layout() {
-            super.layout()
-            syncHitBounds()
-        }
-
-        override func setFrameSize(_ newSize: NSSize) {
-            super.setFrameSize(newSize)
-            syncHitBounds()
-        }
-
-        override func setBoundsSize(_ newSize: NSSize) {
-            super.setBoundsSize(newSize)
-            syncHitBounds()
-        }
-
-        override func setBoundsOrigin(_ newOrigin: NSPoint) {
-            super.setBoundsOrigin(newOrigin)
-            syncHitBounds()
-        }
-
-        nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
-            hitBounds
-                .insetBy(
-                    dx: -BonsplitTabItemHitTesting.horizontalSlop,
-                    dy: -BonsplitTabItemHitTesting.verticalSlop
-                )
-                .contains(localPoint)
-        }
-
-        override func hitTest(_ point: NSPoint) -> NSView? {
-            nil
-        }
-
-        private func syncHitBounds() {
-            hitBounds = bounds
-        }
-    }
-}
-
-private struct TabFramePreferenceKey: PreferenceKey {
-    static let defaultValue: [UUID: CGRect] = [:]
-
-    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
-        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
-    }
-}
-
 private struct SplitButtonLaneWidthPreferenceKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
 
@@ -1094,13 +1015,13 @@ struct TabBarView: View {
     @State private var contentWidth: CGFloat = 0
     @State private var tabContentWidthExcludingSplitButtonLane: CGFloat?
     @State private var containerWidth: CGFloat = 0
-    @State private var tabFramesInBar: [UUID: CGRect] = [:]
     @State private var measuredSplitButtonLaneWidth: CGFloat = 0
     @State private var splitButtonScrollOffset: CGFloat = 0
     @State private var splitButtonContentWidth: CGFloat = 0
     @State private var splitButtonViewportWidth: CGFloat = 0
     @State private var controlKeyMonitor = TabControlShortcutKeyMonitor()
     @State private var scrollViewBridge = TabBarScrollViewBridge()
+    @State private var tabItemGeometryRegistry = TabBarItemGeometryRegistry()
 
     private var canScrollLeft: Bool {
         scrollOffset > 1
@@ -1200,13 +1121,6 @@ struct TabBarView: View {
         tabBarLayout.trailingTabContentInset
     }
 
-    private var selectedTabFrameInBar: CGRect? {
-        TabBarStyling.selectedTabFrame(
-            selectedTabId: pane.selectedTabId,
-            tabFrames: tabFramesInBar
-        )
-    }
-
     private var leadingScrollAnchorId: String {
         "tab-bar-leading-\(pane.id.id.uuidString)"
     }
@@ -1223,6 +1137,29 @@ struct TabBarView: View {
         )
     }
 
+    private var selectionChromeMask: TabBarSelectionChromeMask {
+        let fadeWidth: CGFloat = 24
+        let snapshot = chromeSnapshot
+        if snapshot.masksTabContentUnderActionLane {
+            return TabBarSelectionChromeMask(
+                leftFadeWidth: canScrollLeft ? fadeWidth : 0,
+                rightFadeWidth: snapshot.contentFadeWidth,
+                rightOcclusionWidth: snapshot.contentOcclusionWidth,
+                actionLaneSeparatorWidth: snapshot.drawsActionLaneSeparator
+                    ? snapshot.actionLaneGeometry.separatorTotalWidth
+                    : 0
+            )
+        }
+        return TabBarSelectionChromeMask(
+            leftFadeWidth: canScrollLeft ? fadeWidth : 0,
+            rightFadeWidth: canScrollRight ? fadeWidth : 0,
+            rightOcclusionWidth: 0,
+            actionLaneSeparatorWidth: snapshot.drawsActionLaneSeparator
+                ? snapshot.actionLaneGeometry.separatorTotalWidth
+                : 0
+        )
+    }
+
     private var visibleTabEntries: [(index: Int, tab: TabItem)] {
         if isFullWidthTabMode {
             let selectedTab = pane.selectedTab ?? pane.tabs.first
@@ -1234,6 +1171,65 @@ struct TabBarView: View {
 
         return pane.tabs.enumerated().map { index, tab in
             (index, tab)
+        }
+    }
+
+    private var tabIds: [UUID] {
+        pane.tabs.map(\.id)
+    }
+
+    @ViewBuilder
+    private var selectionChrome: some View {
+        TabBarSelectionChromeView(
+            selectedTabId: pane.selectedTabId,
+            geometryRegistry: tabItemGeometryRegistry,
+            indicatorColor: TabBarColors.nsColorActiveIndicator(saturation: tabBarSaturation),
+            separatorColor: TabBarColors.nsColorSeparator(for: appearance),
+            mask: selectionChromeMask
+        )
+        .allowsHitTesting(false)
+    }
+
+    @ViewBuilder
+    private var trailingEmptyChromeDragZone: some View {
+        TabBarDragZoneView(
+            hitRegion: .registeredTrailingEmptyChrome(
+                geometryRegistry: tabItemGeometryRegistry,
+                tabIds: tabIds,
+                reservedTrailingWidth: shouldRenderSplitButtons ? splitButtonsBackdropWidth : 0
+            ),
+            isMinimalMode: isMinimalMode,
+            isFocusedPane: isFocused,
+            onSingleClick: focusPaneFromTabBarChrome
+        ) {
+            performNewTerminalSplitButtonAction()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var dragAndHoverBackground: some View {
+        TabBarDragAndHoverView(
+            isMinimalMode: isMinimalMode,
+            geometryRegistry: tabItemGeometryRegistry,
+            tabIds: tabIds,
+            onDoubleClick: {
+                performNewTerminalSplitButtonAction()
+            },
+            onHoverChanged: { updateTabBarHover($0) }
+        )
+    }
+
+    @ViewBuilder
+    private var manualReorderTracker: some View {
+        if controller.configuration.allowTabReordering {
+            TabBarManualReorderTrackingView(
+                pane: pane,
+                bonsplitController: controller,
+                splitViewController: splitViewController,
+                geometryRegistry: tabItemGeometryRegistry,
+                dropTargetIndex: $dropTargetIndex,
+                dropLifecycle: $dropLifecycle
+            )
         }
     }
 
@@ -1341,6 +1337,7 @@ struct TabBarView: View {
                     .background(
                         TabBarScrollViewResolver { scrollView in
                             scrollViewBridge.attach(scrollView)
+                            tabItemGeometryRegistry.attachScrollView(scrollView)
                         }
                         .frame(width: 0, height: 0)
                     )
@@ -1397,28 +1394,14 @@ struct TabBarView: View {
         .frame(height: tabBarHeight)
         .coordinateSpace(name: "tabBar")
         .background(tabBarSurface)
-        .overlay(maskedSelectedTabIndicatorChrome)
         .overlay(alignment: .trailing) {
             splitButtonBackdropChrome
                 .opacity(shouldShowSplitButtons ? 1 : 0)
                 .allowsHitTesting(false)
                 .tabBarButtonAnimationsDisabled()
         }
-        .overlay(maskedTabBarBottomSeparatorChrome)
-        .overlay {
-            TabBarDragZoneView(
-                hitRegion: .trailingEmptyChrome(
-                    tabFrames: Array(tabFramesInBar.values),
-                    reservedTrailingWidth: shouldRenderSplitButtons ? splitButtonsBackdropWidth : 0
-                ),
-                isMinimalMode: isMinimalMode,
-                isFocusedPane: isFocused,
-                onSingleClick: focusPaneFromTabBarChrome
-            ) {
-                performNewTerminalSplitButtonAction()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+        .overlay(selectionChrome)
+        .overlay(trailingEmptyChromeDragZone)
         .overlay(alignment: .trailing) {
             splitButtonChrome
                 .frame(width: splitButtonsBackdropWidth, height: tabBarHeight, alignment: .trailing)
@@ -1428,29 +1411,11 @@ struct TabBarView: View {
                 }
                 .clipped()
         }
-        .background(TabBarDragAndHoverView(
-            isMinimalMode: isMinimalMode,
-            tabFrames: Array(tabFramesInBar.values),
-            onDoubleClick: {
-                performNewTerminalSplitButtonAction()
-            },
-            onHoverChanged: { updateTabBarHover($0) }
-        ))
+        .background(dragAndHoverBackground)
         .overlay(
             TabBarHoverTrackingView { updateTabBarHover($0) }
         )
-        .overlay {
-            if controller.configuration.allowTabReordering {
-                TabBarManualReorderTrackingView(
-                    pane: pane,
-                    bonsplitController: controller,
-                    splitViewController: splitViewController,
-                    tabFrames: tabFramesInBar,
-                    dropTargetIndex: $dropTargetIndex,
-                    dropLifecycle: $dropLifecycle
-                )
-            }
-        }
+        .overlay(manualReorderTracker)
         .background {
             if splitViewController.tabShortcutHintsEnabled {
                 TabBarHostWindowReader { window in
@@ -1483,14 +1448,6 @@ struct TabBarView: View {
                 controlKeyMonitor.start()
             } else {
                 controlKeyMonitor.stop()
-            }
-        }
-        .onPreferenceChange(TabFramePreferenceKey.self) { frames in
-#if DEBUG
-            BonsplitDebugCounters.recordTabBarLayoutFeedbackMutation()
-#endif
-            withTransaction(Transaction(animation: nil)) {
-                tabFramesInBar = frames
             }
         }
         .onPreferenceChange(SplitButtonLaneWidthPreferenceKey.self) { width in
@@ -1573,17 +1530,10 @@ struct TabBarView: View {
             }
         )
         .background(
-            TabItemHitRegionView()
-        )
-        .background(
-            GeometryReader { geometry in
-                let frame = geometry.frame(in: .named("tabBar"))
-                Color.clear
-                    .preference(
-                        key: TabFramePreferenceKey.self,
-                        value: [tab.id: frame]
-                    )
-            }
+            TabItemHitRegionView(
+                tabId: tab.id,
+                geometryRegistry: tabItemGeometryRegistry
+            )
         )
         .onDrag {
             createItemProvider(for: tab)
@@ -1712,8 +1662,6 @@ struct TabBarView: View {
                     if snapshot.paintsActionLaneSurface {
                         splitButtonBackdropSurface(snapshot: snapshot, totalWidth: geometry.size.width)
                     }
-
-                    splitButtonFallbackSeparator(snapshot: snapshot, totalWidth: geometry.size.width)
                 }
                 .frame(width: geometry.size.width, height: tabBarHeight, alignment: .topLeading)
             }
@@ -1749,57 +1697,6 @@ struct TabBarView: View {
                 .init(color: Color(nsColor: snapshot.backdropLeadingColor), location: 0),
                 .init(color: Color(nsColor: snapshot.backdropLeadingColor), location: rampStart),
                 .init(color: Color(nsColor: snapshot.backdropTrailingColor), location: 1)
-            ],
-            startPoint: .leading,
-            endPoint: .trailing
-        )
-    }
-
-    @ViewBuilder
-    private func splitButtonFallbackSeparator(snapshot: TabBarChromeSnapshot, totalWidth: CGFloat) -> some View {
-        let geometry = snapshot.actionLaneGeometry
-        let selectedGap = tabBarLayout.selectedSeparatorGap(
-            selectedTabFrame: selectedTabFrameInBar,
-            totalWidth: totalWidth
-        )
-        if let maskFrame = geometry.fallbackSeparatorMaskFrame(
-            totalWidth: totalWidth,
-            height: tabBarHeight,
-            selectedSeparatorGap: selectedGap
-        ) {
-            ZStack(alignment: .topLeading) {
-                let fadeFrame = geometry.separatorFadeFrame(totalWidth: totalWidth, height: tabBarHeight)
-                if fadeFrame.width > 0 {
-                    splitButtonSeparatorFadeSegment(snapshot: snapshot)
-                        .frame(width: fadeFrame.width, height: fadeFrame.height)
-                        .offset(x: fadeFrame.minX, y: fadeFrame.minY)
-                }
-                let solidFrame = geometry.separatorSolidFrame(totalWidth: totalWidth, height: tabBarHeight)
-                if solidFrame.width > 0 {
-                    Rectangle()
-                        .fill(TabBarColors.separator(for: appearance))
-                        .frame(width: solidFrame.width, height: solidFrame.height)
-                        .offset(x: solidFrame.minX, y: solidFrame.minY)
-                }
-            }
-            .frame(width: totalWidth, height: tabBarHeight, alignment: .topLeading)
-            .mask(alignment: .topLeading) {
-                Rectangle()
-                    .frame(width: maskFrame.width, height: maskFrame.height)
-                    .offset(x: maskFrame.minX, y: maskFrame.minY)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func splitButtonSeparatorFadeSegment(snapshot: TabBarChromeSnapshot) -> some View {
-        let separator = TabBarColors.separator(for: appearance)
-        let rampStart = snapshot.backdropFadeRampStartFraction
-        LinearGradient(
-            stops: [
-                .init(color: separator.opacity(0), location: 0),
-                .init(color: separator.opacity(0), location: rampStart),
-                .init(color: separator, location: 1)
             ],
             startPoint: .leading,
             endPoint: .trailing
@@ -2090,68 +1987,6 @@ struct TabBarView: View {
             .frame(height: tabBarHeight)
     }
 
-    @ViewBuilder
-    private var maskedSelectedTabIndicatorChrome: some View {
-        GeometryReader { geometry in
-            selectedTabIndicator(totalWidth: geometry.size.width)
-                .frame(width: geometry.size.width, height: tabBarHeight, alignment: .topLeading)
-                .mask(combinedMask)
-        }
-        .allowsHitTesting(false)
-    }
-
-    @ViewBuilder
-    private var maskedTabBarBottomSeparatorChrome: some View {
-        GeometryReader { geometry in
-            tabBarBottomSeparator(totalWidth: geometry.size.width)
-        }
-        .allowsHitTesting(false)
-    }
-
-    @ViewBuilder
-    private func selectedTabIndicator(totalWidth: CGFloat) -> some View {
-        if let frame = selectedIndicatorFrame(totalWidth: totalWidth) {
-            Rectangle()
-                .fill(TabBarColors.activeIndicator(saturation: tabBarSaturation))
-                .frame(width: frame.width, height: TabBarMetrics.activeIndicatorHeight)
-                .offset(x: frame.minX)
-                .transaction { transaction in
-                    transaction.animation = nil
-                }
-        }
-    }
-
-    @ViewBuilder
-    private func tabBarBottomSeparator(totalWidth: CGFloat) -> some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 0)
-            HStack(spacing: 0) {
-                let separator = TabBarColors.separator(for: appearance)
-                let gapRange = tabBarLayout.selectedSeparatorGap(
-                    selectedTabFrame: selectedTabFrameInBar,
-                    totalWidth: totalWidth
-                )
-                let segments = TabBarStyling.separatorSegments(
-                    totalWidth: totalWidth,
-                    gap: gapRange
-                )
-                Rectangle()
-                    .fill(separator)
-                    .frame(width: segments.left, height: 1)
-                Spacer(minLength: 0)
-                Rectangle()
-                    .fill(separator)
-                    .frame(width: segments.right, height: 1)
-            }
-        }
-    }
-
-    private func selectedIndicatorFrame(totalWidth: CGFloat) -> CGRect? {
-        tabBarLayout.selectedIndicatorFrame(
-            selectedTabFrame: selectedTabFrameInBar,
-            totalWidth: totalWidth
-        )
-    }
 }
 
 private struct TabBarLayerBackedColor: NSViewRepresentable {
@@ -2395,7 +2230,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
     let pane: PaneState
     let bonsplitController: BonsplitController
     let splitViewController: SplitViewController
-    let tabFrames: [UUID: CGRect]
+    let geometryRegistry: TabBarItemGeometryRegistry
     @Binding var dropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
 
@@ -2413,7 +2248,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
         view.pane = pane
         view.bonsplitController = bonsplitController
         view.splitViewController = splitViewController
-        view.tabFrames = tabFrames
+        view.geometryRegistry = geometryRegistry
         view.onDropStateChanged = { targetIndex, lifecycle in
             dropTargetIndex = targetIndex
             dropLifecycle = lifecycle
@@ -2424,7 +2259,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
         weak var pane: PaneState?
         weak var bonsplitController: BonsplitController?
         weak var splitViewController: SplitViewController?
-        var tabFrames: [UUID: CGRect] = [:]
+        weak var geometryRegistry: TabBarItemGeometryRegistry?
         var onDropStateChanged: ((Int?, TabDropLifecycle) -> Void)?
 
         private var localMouseMonitor: Any?
@@ -2605,7 +2440,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
 
         private func tab(at point: NSPoint, in pane: PaneState) -> TabItem? {
             for tab in pane.tabs {
-                guard let frame = tabFrames[tab.id] else { continue }
+                guard let frame = geometryRegistry?.frame(for: tab.id, in: self) else { continue }
                 if point.x >= frame.minX, point.x <= frame.maxX {
                     return tab
                 }
@@ -2622,7 +2457,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
 
             var lastFrame: CGRect?
             for (index, tab) in pane.tabs.enumerated() {
-                guard let frame = tabFrames[tab.id] else { continue }
+                guard let frame = geometryRegistry?.frame(for: tab.id, in: self) else { continue }
                 lastFrame = frame
                 if point.x < frame.midX {
                     return index
@@ -2660,14 +2495,16 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
 /// this view only receives hits in truly empty space.
 private struct TabBarDragAndHoverView: NSViewRepresentable {
     let isMinimalMode: Bool
-    let tabFrames: [CGRect]
+    let geometryRegistry: TabBarItemGeometryRegistry
+    let tabIds: [UUID]
     let onDoubleClick: () -> Bool
     let onHoverChanged: (Bool) -> Void
 
     func makeNSView(context: Context) -> TabBarBackgroundNSView {
         let view = TabBarBackgroundNSView()
         view.isMinimalMode = isMinimalMode
-        view.tabFrames = tabFrames
+        view.geometryRegistry = geometryRegistry
+        view.tabIds = tabIds
         view.onDoubleClick = onDoubleClick
         view.onHoverChanged = onHoverChanged
         return view
@@ -2675,14 +2512,16 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
     func updateNSView(_ nsView: TabBarBackgroundNSView, context: Context) {
         nsView.isMinimalMode = isMinimalMode
-        nsView.tabFrames = tabFrames
+        nsView.geometryRegistry = geometryRegistry
+        nsView.tabIds = tabIds
         nsView.onDoubleClick = onDoubleClick
         nsView.onHoverChanged = onHoverChanged
     }
 
     final class TabBarBackgroundNSView: NSView, BonsplitTabItemHitRegionProviding {
         var isMinimalMode = false
-        nonisolated(unsafe) var tabFrames: [CGRect] = []
+        nonisolated(unsafe) var tabIds: [UUID] = []
+        weak var geometryRegistry: TabBarItemGeometryRegistry?
         var onDoubleClick: (() -> Bool)?
         var onHoverChanged: ((Bool) -> Void)?
         private var hoverTrackingArea: NSTrackingArea?
@@ -2727,11 +2566,14 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         }
 
         nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
-            BonsplitTabItemHitTesting.containsTabLaneHit(
-                localPoint: localPoint,
-                tabFrames: tabFrames,
-                bounds: bounds
-            )
+            MainActor.assumeIsolated {
+                let frames = geometryRegistry?.frames(for: tabIds, in: self).values.map { $0 } ?? []
+                return BonsplitTabItemHitTesting.containsTabLaneHit(
+                    localPoint: localPoint,
+                    tabFrames: frames,
+                    bounds: bounds
+                )
+            }
         }
 
         override func updateTrackingAreas() {
@@ -2882,6 +2724,11 @@ struct TabBarDragZoneView: NSViewRepresentable {
     enum HitRegion {
         case entireBounds
         case trailingEmptyChrome(tabFrames: [CGRect], reservedTrailingWidth: CGFloat)
+        case registeredTrailingEmptyChrome(
+            geometryRegistry: TabBarItemGeometryRegistry,
+            tabIds: [UUID],
+            reservedTrailingWidth: CGFloat
+        )
     }
 
     var hitRegion: HitRegion = .entireBounds
@@ -2912,7 +2759,11 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
     final class DragNSView: NSView {
         var hitRegion = HitRegion.entireBounds {
-            didSet { invalidateWindowDragCursorRects() }
+            didSet {
+                unregisterGeometryObserver(from: oldValue)
+                registerGeometryObserver(from: hitRegion)
+                invalidateWindowDragCursorRects()
+            }
         }
         var hitTestEventTypeOverride: NSEvent.EventType?
         var isMinimalMode = false {
@@ -2927,6 +2778,10 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
         private static let windowDragStartDistanceSquared: CGFloat = 16
 
+        deinit {
+            unregisterGeometryObserver(from: hitRegion)
+        }
+
         // Must stay false so AppKit does not intercept mouseUp as part of its
         // own window-drag tracking. When AppKit steals mouseUp from the first
         // click, the second click of a double-click is registered as a fresh
@@ -2938,6 +2793,11 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            invalidateWindowDragCursorRects()
+        }
+
+        override func layout() {
+            super.layout()
             invalidateWindowDragCursorRects()
         }
 
@@ -3034,15 +2894,34 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 return true
             case .trailingEmptyChrome(let tabFrames, let reservedTrailingWidth):
                 guard isMouseDownOrDragCandidate else { return false }
-                let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
-                guard point.x < trailingLimit else { return false }
-                let paddedFrames = tabFrames.map {
-                    $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
-                }
-                guard !paddedFrames.contains(where: { $0.contains(point) }) else { return false }
-                let startX = paddedFrames.map(\.maxX).max() ?? bounds.minX
-                return point.x >= startX
+                return shouldCaptureTrailingEmptyChrome(
+                    at: point,
+                    tabFrames: tabFrames,
+                    reservedTrailingWidth: reservedTrailingWidth
+                )
+            case .registeredTrailingEmptyChrome(let geometryRegistry, let tabIds, let reservedTrailingWidth):
+                guard isMouseDownOrDragCandidate else { return false }
+                return shouldCaptureTrailingEmptyChrome(
+                    at: point,
+                    tabFrames: geometryRegistry.frames(for: tabIds, in: self).values.map { $0 },
+                    reservedTrailingWidth: reservedTrailingWidth
+                )
             }
+        }
+
+        private func shouldCaptureTrailingEmptyChrome(
+            at point: NSPoint,
+            tabFrames: [CGRect],
+            reservedTrailingWidth: CGFloat
+        ) -> Bool {
+            let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
+            guard point.x < trailingLimit else { return false }
+            let paddedFrames = tabFrames.map {
+                $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
+            }
+            guard !paddedFrames.contains(where: { $0.contains(point) }) else { return false }
+            let startX = paddedFrames.map(\.maxX).max() ?? bounds.minX
+            return point.x >= startX
         }
 
         func windowDragCursorRectsForCurrentState() -> [NSRect] {
@@ -3052,29 +2931,54 @@ struct TabBarDragZoneView: NSViewRepresentable {
             case .entireBounds:
                 return [bounds]
             case .trailingEmptyChrome(let tabFrames, let reservedTrailingWidth):
-                let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
-                guard trailingLimit > bounds.minX else { return [] }
-
-                let paddedFrames = tabFrames.map {
-                    $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
-                }
-                let startX = max(bounds.minX, paddedFrames.map(\.maxX).max() ?? bounds.minX)
-                guard trailingLimit > startX else { return [] }
-
-                return [
-                    NSRect(
-                        x: startX,
-                        y: bounds.minY,
-                        width: trailingLimit - startX,
-                        height: bounds.height
-                    )
-                ]
+                return trailingEmptyChromeCursorRects(
+                    tabFrames: tabFrames,
+                    reservedTrailingWidth: reservedTrailingWidth
+                )
+            case .registeredTrailingEmptyChrome(let geometryRegistry, let tabIds, let reservedTrailingWidth):
+                return trailingEmptyChromeCursorRects(
+                    tabFrames: geometryRegistry.frames(for: tabIds, in: self).values.map { $0 },
+                    reservedTrailingWidth: reservedTrailingWidth
+                )
             }
+        }
+
+        private func trailingEmptyChromeCursorRects(
+            tabFrames: [CGRect],
+            reservedTrailingWidth: CGFloat
+        ) -> [NSRect] {
+            let trailingLimit = bounds.maxX - max(0, reservedTrailingWidth)
+            guard trailingLimit > bounds.minX else { return [] }
+
+            let paddedFrames = tabFrames.map {
+                $0.insetBy(dx: -BonsplitTabItemHitTesting.horizontalSlop, dy: -2)
+            }
+            let startX = max(bounds.minX, paddedFrames.map(\.maxX).max() ?? bounds.minX)
+            guard trailingLimit > startX else { return [] }
+
+            return [
+                NSRect(
+                    x: startX,
+                    y: bounds.minY,
+                    width: trailingLimit - startX,
+                    height: bounds.height
+                )
+            ]
         }
 
         private func invalidateWindowDragCursorRects() {
             guard let window else { return }
             window.invalidateCursorRects(for: self)
+        }
+
+        private func registerGeometryObserver(from hitRegion: HitRegion) {
+            guard case .registeredTrailingEmptyChrome(let registry, _, _) = hitRegion else { return }
+            registry.registerObserver(self)
+        }
+
+        private func unregisterGeometryObserver(from hitRegion: HitRegion) {
+            guard case .registeredTrailingEmptyChrome(let registry, _, _) = hitRegion else { return }
+            registry.unregisterObserver(self)
         }
 
         private var isMouseDownOrDragCandidate: Bool {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1145,18 +1145,26 @@ struct TabBarView: View {
                 leftFadeWidth: canScrollLeft ? fadeWidth : 0,
                 rightFadeWidth: snapshot.contentFadeWidth,
                 rightOcclusionWidth: snapshot.contentOcclusionWidth,
-                actionLaneSeparatorWidth: snapshot.drawsActionLaneSeparator
-                    ? snapshot.actionLaneGeometry.separatorTotalWidth
-                    : 0
+                actionLaneSeparatorFadeWidth: snapshot.drawsActionLaneSeparator
+                    ? snapshot.actionLaneGeometry.separatorFadeWidth
+                    : 0,
+                actionLaneSeparatorSolidWidth: snapshot.drawsActionLaneSeparator
+                    ? snapshot.actionLaneGeometry.backgroundSolidWidth
+                    : 0,
+                actionLaneSeparatorFadeRampStartFraction: snapshot.backdropFadeRampStartFraction
             )
         }
         return TabBarSelectionChromeMask(
             leftFadeWidth: canScrollLeft ? fadeWidth : 0,
             rightFadeWidth: canScrollRight ? fadeWidth : 0,
             rightOcclusionWidth: 0,
-            actionLaneSeparatorWidth: snapshot.drawsActionLaneSeparator
-                ? snapshot.actionLaneGeometry.separatorTotalWidth
-                : 0
+            actionLaneSeparatorFadeWidth: snapshot.drawsActionLaneSeparator
+                ? snapshot.actionLaneGeometry.separatorFadeWidth
+                : 0,
+            actionLaneSeparatorSolidWidth: snapshot.drawsActionLaneSeparator
+                ? snapshot.actionLaneGeometry.backgroundSolidWidth
+                : 0,
+            actionLaneSeparatorFadeRampStartFraction: snapshot.backdropFadeRampStartFraction
         )
     }
 

--- a/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
+++ b/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
@@ -7,13 +7,19 @@ import Foundation
 /// detect transient structural updates that can cause visible flashes.
 public enum BonsplitDebugCounters {
     public private(set) static var arrangedSubviewUnderflowCount: Int = 0
+    public private(set) static var tabBarLayoutFeedbackMutationCount: Int = 0
 
     public static func reset() {
         arrangedSubviewUnderflowCount = 0
+        tabBarLayoutFeedbackMutationCount = 0
     }
 
     internal static func recordArrangedSubviewUnderflow() {
         arrangedSubviewUnderflowCount += 1
+    }
+
+    internal static func recordTabBarLayoutFeedbackMutation() {
+        tabBarLayoutFeedbackMutationCount += 1
     }
 }
 #endif

--- a/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
+++ b/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
@@ -7,19 +7,19 @@ import Foundation
 /// detect transient structural updates that can cause visible flashes.
 public enum BonsplitDebugCounters {
     public private(set) static var arrangedSubviewUnderflowCount: Int = 0
-    public private(set) static var tabBarLayoutFeedbackMutationCount: Int = 0
+    public private(set) static var tabFrameLayoutFeedbackMutationCount: Int = 0
 
     public static func reset() {
         arrangedSubviewUnderflowCount = 0
-        tabBarLayoutFeedbackMutationCount = 0
+        tabFrameLayoutFeedbackMutationCount = 0
     }
 
     internal static func recordArrangedSubviewUnderflow() {
         arrangedSubviewUnderflowCount += 1
     }
 
-    internal static func recordTabBarLayoutFeedbackMutation() {
-        tabBarLayoutFeedbackMutationCount += 1
+    internal static func recordTabFrameLayoutFeedbackMutation() {
+        tabFrameLayoutFeedbackMutationCount += 1
     }
 }
 #endif

--- a/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
+++ b/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
@@ -7,19 +7,13 @@ import Foundation
 /// detect transient structural updates that can cause visible flashes.
 public enum BonsplitDebugCounters {
     public private(set) static var arrangedSubviewUnderflowCount: Int = 0
-    public private(set) static var tabFrameLayoutFeedbackMutationCount: Int = 0
 
     public static func reset() {
         arrangedSubviewUnderflowCount = 0
-        tabFrameLayoutFeedbackMutationCount = 0
     }
 
     internal static func recordArrangedSubviewUnderflow() {
         arrangedSubviewUnderflowCount += 1
-    }
-
-    internal static func recordTabFrameLayoutFeedbackMutation() {
-        tabFrameLayoutFeedbackMutationCount += 1
     }
 }
 #endif

--- a/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
+++ b/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
@@ -7,8 +7,8 @@ import Testing
 @MainActor
 @Suite("Tab bar layout feedback")
 struct TabBarLayoutFeedbackTests {
-    @Test("Scrolling 50 content-sized tabs does not feed measured frames into SwiftUI state")
-    func scrollingManyTabsDoesNotMutateLayoutFeedbackState() throws {
+    @Test("Scrolling keeps 50 content-sized tab frames live in AppKit")
+    func scrollingManyTabsKeepsPlatformGeometryLive() throws {
         let size = NSSize(width: 420, height: TabBarMetrics.barHeight)
         let controller = BonsplitController(
             configuration: BonsplitConfiguration(appearance: .default)
@@ -60,7 +60,6 @@ struct TabBarLayoutFeedbackTests {
         )
         #expect(maximumOffset > 0)
 
-        BonsplitDebugCounters.reset()
         for step in 1...8 {
             let offset = maximumOffset * CGFloat(step) / 8
             scrollView.contentView.scroll(to: NSPoint(x: offset, y: 0))
@@ -75,11 +74,6 @@ struct TabBarLayoutFeedbackTests {
         let scrolledFirstFrame = try #require(registeredFrames[tabs[0].id])
         #expect(registeredFrames.count == tabs.count)
         #expect(abs((initialFirstFrame.minX - maximumOffset) - scrolledFirstFrame.minX) <= 1)
-
-        #expect(
-            BonsplitDebugCounters.tabFrameLayoutFeedbackMutationCount == 0,
-            "Tab geometry must remain inside AppKit layout instead of invalidating the SwiftUI view graph."
-        )
     }
 
     private func settleLayout(in window: NSWindow, hostingView: NSView, passes: Int = 6) {

--- a/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
+++ b/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
@@ -1,0 +1,102 @@
+import AppKit
+@testable import Bonsplit
+import SwiftUI
+import Testing
+
+#if DEBUG
+@MainActor
+@Suite("Tab bar layout feedback")
+struct TabBarLayoutFeedbackTests {
+    @Test("Scrolling 50 content-sized tabs does not feed measured frames into SwiftUI state")
+    func scrollingManyTabsDoesNotMutateLayoutFeedbackState() throws {
+        let size = NSSize(width: 420, height: TabBarMetrics.barHeight)
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(appearance: .default)
+        )
+        controller.tabShortcutHintsEnabled = false
+        let pane = try #require(controller.internalController.rootNode.allPanes.first)
+        let tabs = (0..<50).map { index in
+            TabItem(
+                title: "Terminal \(index + 1) — \(String(repeating: "x", count: index % 17))",
+                icon: "terminal.fill",
+                kind: "terminal"
+            )
+        }
+        pane.tabs = tabs
+        pane.selectedTabId = tabs.first?.id
+
+        let hostingView = NSHostingView(
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: false)
+                .environment(controller)
+                .environment(controller.internalController)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostingView)
+        window.makeKeyAndOrderFront(nil)
+
+        settleLayout(in: window, hostingView: hostingView)
+        let scrollView = try #require(tabBarScrollView(in: hostingView))
+        let maximumOffset = max(
+            0,
+            max(
+                scrollView.documentView?.frame.width ?? 0,
+                scrollView.documentView?.bounds.width ?? 0
+            ) - scrollView.contentView.bounds.width
+        )
+        #expect(maximumOffset > 0)
+
+        BonsplitDebugCounters.reset()
+        for step in 1...8 {
+            let offset = maximumOffset * CGFloat(step) / 8
+            scrollView.contentView.scroll(to: NSPoint(x: offset, y: 0))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            settleLayout(in: window, hostingView: hostingView, passes: 2)
+        }
+
+        #expect(
+            BonsplitDebugCounters.tabBarLayoutFeedbackMutationCount == 0,
+            "Tab geometry must remain inside AppKit layout instead of invalidating the SwiftUI view graph."
+        )
+    }
+
+    private func settleLayout(in window: NSWindow, hostingView: NSView, passes: Int = 6) {
+        for _ in 0..<passes {
+            window.contentView?.layoutSubtreeIfNeeded()
+            hostingView.layoutSubtreeIfNeeded()
+            RunLoop.current.run(mode: .default, before: Date.now.addingTimeInterval(0.01))
+        }
+    }
+
+    private func tabBarScrollView(in root: NSView) -> NSScrollView? {
+        descendants(ofType: NSScrollView.self, in: root).first { scrollView in
+            let documentHeight = max(
+                scrollView.documentView?.frame.height ?? 0,
+                scrollView.documentView?.bounds.height ?? 0
+            )
+            return abs(scrollView.frame.height - TabBarMetrics.barHeight) <= 0.5
+                && abs(documentHeight - TabBarMetrics.barHeight) <= 0.5
+                && scrollView.frame.width > 0
+        }
+    }
+
+    private func descendants<T: NSView>(ofType type: T.Type, in root: NSView) -> [T] {
+        var matches: [T] = []
+        if let match = root as? T {
+            matches.append(match)
+        }
+        for subview in root.subviews {
+            matches.append(contentsOf: descendants(ofType: type, in: subview))
+        }
+        return matches
+    }
+}
+#endif

--- a/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
+++ b/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
@@ -45,6 +45,12 @@ struct TabBarLayoutFeedbackTests {
 
         settleLayout(in: window, hostingView: hostingView)
         let scrollView = try #require(tabBarScrollView(in: hostingView))
+        let chromeView = try #require(
+            descendants(ofType: TabBarSelectionChromeView.ChromeNSView.self, in: hostingView).first
+        )
+        let initialFirstFrame = try #require(
+            chromeView.geometryRegistry?.frame(for: tabs[0].id, in: chromeView)
+        )
         let maximumOffset = max(
             0,
             max(
@@ -62,8 +68,16 @@ struct TabBarLayoutFeedbackTests {
             settleLayout(in: window, hostingView: hostingView, passes: 2)
         }
 
+        let registeredFrames = try #require(chromeView.geometryRegistry?.frames(
+            for: tabs.map(\.id),
+            in: chromeView
+        ))
+        let scrolledFirstFrame = try #require(registeredFrames[tabs[0].id])
+        #expect(registeredFrames.count == tabs.count)
+        #expect(abs((initialFirstFrame.minX - maximumOffset) - scrolledFirstFrame.minX) <= 1)
+
         #expect(
-            BonsplitDebugCounters.tabBarLayoutFeedbackMutationCount == 0,
+            BonsplitDebugCounters.tabFrameLayoutFeedbackMutationCount == 0,
             "Tab geometry must remain inside AppKit layout instead of invalidating the SwiftUI view graph."
         )
     }

--- a/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
+++ b/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
@@ -1,20 +1,18 @@
 import AppKit
 @testable import Bonsplit
 import SwiftUI
-import Testing
+import XCTest
 
 #if DEBUG
 @MainActor
-@Suite("Tab bar layout feedback")
-struct TabBarLayoutFeedbackTests {
-    @Test("Scrolling keeps 50 content-sized tab frames live in AppKit")
-    func scrollingManyTabsKeepsPlatformGeometryLive() throws {
+final class TabBarLayoutFeedbackTests: XCTestCase {
+    func testScrollingManyTabsKeepsPlatformGeometryLive() throws {
         let size = NSSize(width: 420, height: TabBarMetrics.barHeight)
         let controller = BonsplitController(
             configuration: BonsplitConfiguration(appearance: .default)
         )
         controller.tabShortcutHintsEnabled = false
-        let pane = try #require(controller.internalController.rootNode.allPanes.first)
+        let pane = try XCTUnwrap(controller.internalController.rootNode.allPanes.first)
         let tabs = (0..<50).map { index in
             TabItem(
                 title: "Terminal \(index + 1) — \(String(repeating: "x", count: index % 17))",
@@ -37,18 +35,18 @@ struct TabBarLayoutFeedbackTests {
             defer: false
         )
         defer { window.orderOut(nil) }
-        let contentView = try #require(window.contentView)
+        let contentView = try XCTUnwrap(window.contentView)
         hostingView.frame = NSRect(origin: .zero, size: size)
         hostingView.autoresizingMask = [.width, .height]
         contentView.addSubview(hostingView)
         window.makeKeyAndOrderFront(nil)
 
         settleLayout(in: window, hostingView: hostingView)
-        let scrollView = try #require(tabBarScrollView(in: hostingView))
-        let chromeView = try #require(
+        let scrollView = try XCTUnwrap(tabBarScrollView(in: hostingView))
+        let chromeView = try XCTUnwrap(
             descendants(ofType: TabBarSelectionChromeView.ChromeNSView.self, in: hostingView).first
         )
-        let initialFirstFrame = try #require(
+        let initialFirstFrame = try XCTUnwrap(
             chromeView.geometryRegistry?.frame(for: tabs[0].id, in: chromeView)
         )
         let maximumOffset = max(
@@ -58,7 +56,7 @@ struct TabBarLayoutFeedbackTests {
                 scrollView.documentView?.bounds.width ?? 0
             ) - scrollView.contentView.bounds.width
         )
-        #expect(maximumOffset > 0)
+        XCTAssertGreaterThan(maximumOffset, 0)
 
         for step in 1...8 {
             let offset = maximumOffset * CGFloat(step) / 8
@@ -67,13 +65,16 @@ struct TabBarLayoutFeedbackTests {
             settleLayout(in: window, hostingView: hostingView, passes: 2)
         }
 
-        let registeredFrames = try #require(chromeView.geometryRegistry?.frames(
+        let registeredFrames = try XCTUnwrap(chromeView.geometryRegistry?.frames(
             for: tabs.map(\.id),
             in: chromeView
         ))
-        let scrolledFirstFrame = try #require(registeredFrames[tabs[0].id])
-        #expect(registeredFrames.count == tabs.count)
-        #expect(abs((initialFirstFrame.minX - maximumOffset) - scrolledFirstFrame.minX) <= 1)
+        let scrolledFirstFrame = try XCTUnwrap(registeredFrames[tabs[0].id])
+        XCTAssertEqual(registeredFrames.count, tabs.count)
+        XCTAssertLessThanOrEqual(
+            abs((initialFirstFrame.minX - maximumOffset) - scrolledFirstFrame.minX),
+            1
+        )
     }
 
     private func settleLayout(in window: NSWindow, hostingView: NSView, passes: Int = 6) {


### PR DESCRIPTION
## Summary

Fixes the tab-strip layout feedback edge behind manaflow-ai/cmux#7975.

Each tab previously published its frame from a `GeometryReader`. `TabFramePreferenceKey` merged every frame and `TabBarView.onPreferenceChange` wrote the O(N) dictionary into `@State`, so scrolling or remeasuring a content-sized strip invalidated the same SwiftUI graph that produced the geometry.

The content-hugging change used by cmux 0.64.17 increased the cost of that cycle, but intrinsic sizing was not itself the invalidation source.

## Fix

- Remove the per-tab frame preference and SwiftUI frame dictionary.
- Keep weak tab platform-view references in a main-actor AppKit geometry registry.
- Query live AppKit frames for selected chrome, drag reorder, empty-chrome hit testing, and cursor regions.
- Observe `NSView.boundsDidChangeNotification` on the clip view and redraw AppKit consumers without publishing geometry or requesting SwiftUI layout.
- Preserve scroll-edge indicator fades, action-lane clipping, and the shared action-lane separator fade.

## Regression evidence

- Test-only red commit `362e097`: https://github.com/manaflow-ai/bonsplit/actions/runs/29267849834
  - 50 content-sized tabs across eight scroll offsets
  - observed 8 frame-to-SwiftUI state mutations
- Final green head `a0400b3`: https://github.com/manaflow-ai/bonsplit/actions/runs/29288035346
  - the frame preference, frame dictionary, and preference callback are absent, leaving 0 frame-to-SwiftUI mutations
  - all 50 live registry frames remain available and track scrolling
  - 192 XCTest tests passed with zero failures; the 50-tab regression passed in 0.701 seconds

The final regression uses XCTest to preserve bonsplit's documented Swift 5.9/Xcode 15 compatibility.

## Localization

No user-facing strings or localization catalogs changed.
