### PR TITLE
Keep tab bar actions above portal resize hit regions

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -132,7 +132,6 @@ struct TabItemHitRegionView: NSViewRepresentable {
         nonisolated(unsafe) private var hitBounds: NSRect = .zero
         private var tabId: UUID?
         private weak var geometryRegistry: TabBarItemGeometryRegistry?
-        private let interactiveScrollObserver = BonsplitTabBarInteractiveScrollObserver()
 
         override var mouseDownCanMoveWindow: Bool { false }
 
@@ -148,7 +147,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
                 self.geometryRegistry = geometryRegistry
             }
             registerGeometryIfVisible()
-            interactiveScrollObserver.refresh(for: self)
+            BonsplitTabBarInteractiveHitRegionRegistry.observeScrolling(for: self)
         }
 
         override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -163,9 +162,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
             if window != nil {
                 BonsplitTabItemHitRegionRegistry.register(self)
                 BonsplitTabBarInteractiveHitRegionRegistry.register(self)
-                interactiveScrollObserver.refresh(for: self)
-            } else {
-                interactiveScrollObserver.stop()
+                BonsplitTabBarInteractiveHitRegionRegistry.observeScrolling(for: self)
             }
             registerGeometryIfVisible()
         }
@@ -176,10 +173,9 @@ struct TabItemHitRegionView: NSViewRepresentable {
                 unregisterGeometry()
                 BonsplitTabItemHitRegionRegistry.unregister(self)
                 BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
-                interactiveScrollObserver.stop()
             } else {
                 registerGeometryIfVisible()
-                interactiveScrollObserver.refresh(for: self)
+                BonsplitTabBarInteractiveHitRegionRegistry.observeScrolling(for: self)
             }
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -149,11 +149,15 @@ struct TabItemHitRegionView: NSViewRepresentable {
             registerGeometryIfVisible()
         }
 
+        override func viewWillMove(toWindow newWindow: NSWindow?) {
+            BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
+            super.viewWillMove(toWindow: newWindow)
+        }
+
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             syncHitBounds()
             BonsplitTabItemHitRegionRegistry.unregister(self)
-            BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
             if window != nil {
                 BonsplitTabItemHitRegionRegistry.register(self)
                 BonsplitTabBarInteractiveHitRegionRegistry.register(self)

--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -125,7 +125,10 @@ struct TabItemHitRegionView: NSViewRepresentable {
         nsView.configure(tabId: tabId, geometryRegistry: geometryRegistry)
     }
 
-    final class RegionNSView: NSView, BonsplitTabItemHitRegionProviding {
+    final class RegionNSView: NSView,
+        BonsplitTabItemHitRegionProviding,
+        BonsplitTabBarInteractiveRectProviding
+    {
         nonisolated(unsafe) private var hitBounds: NSRect = .zero
         private var tabId: UUID?
         private weak var geometryRegistry: TabBarItemGeometryRegistry?
@@ -150,8 +153,10 @@ struct TabItemHitRegionView: NSViewRepresentable {
             super.viewDidMoveToWindow()
             syncHitBounds()
             BonsplitTabItemHitRegionRegistry.unregister(self)
+            BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
             if window != nil {
                 BonsplitTabItemHitRegionRegistry.register(self)
+                BonsplitTabBarInteractiveHitRegionRegistry.register(self)
             }
             registerGeometryIfVisible()
         }
@@ -161,6 +166,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
             if superview == nil {
                 unregisterGeometry()
                 BonsplitTabItemHitRegionRegistry.unregister(self)
+                BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
             } else {
                 registerGeometryIfVisible()
             }
@@ -170,24 +176,36 @@ struct TabItemHitRegionView: NSViewRepresentable {
             super.layout()
             syncHitBounds()
             geometryRegistry?.geometryDidChange()
+            BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(self)
         }
 
         override func setFrameSize(_ newSize: NSSize) {
             super.setFrameSize(newSize)
             syncHitBounds()
             geometryRegistry?.geometryDidChange()
+            BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(self)
         }
 
         override func setBoundsSize(_ newSize: NSSize) {
             super.setBoundsSize(newSize)
             syncHitBounds()
             geometryRegistry?.geometryDidChange()
+            BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(self)
         }
 
         override func setBoundsOrigin(_ newOrigin: NSPoint) {
             super.setBoundsOrigin(newOrigin)
             syncHitBounds()
             geometryRegistry?.geometryDidChange()
+            BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(self)
+        }
+
+        override func setFrameOrigin(_ newOrigin: NSPoint) {
+            let changed = frame.origin != newOrigin
+            super.setFrameOrigin(newOrigin)
+            if changed {
+                BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(self)
+            }
         }
 
         nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
@@ -197,6 +215,13 @@ struct TabItemHitRegionView: NSViewRepresentable {
                     dy: -BonsplitTabItemHitTesting.verticalSlop
                 )
                 .contains(localPoint)
+        }
+
+        func bonsplitTabBarInteractiveHitRects() -> [NSRect] {
+            [hitBounds.insetBy(
+                dx: -BonsplitTabItemHitTesting.horizontalSlop,
+                dy: -BonsplitTabItemHitTesting.verticalSlop
+            )]
         }
 
         override func hitTest(_ point: NSPoint) -> NSView? {

--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -132,6 +132,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
         nonisolated(unsafe) private var hitBounds: NSRect = .zero
         private var tabId: UUID?
         private weak var geometryRegistry: TabBarItemGeometryRegistry?
+        private let interactiveScrollObserver = BonsplitTabBarInteractiveScrollObserver()
 
         override var mouseDownCanMoveWindow: Bool { false }
 
@@ -147,6 +148,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
                 self.geometryRegistry = geometryRegistry
             }
             registerGeometryIfVisible()
+            interactiveScrollObserver.refresh(for: self)
         }
 
         override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -161,6 +163,9 @@ struct TabItemHitRegionView: NSViewRepresentable {
             if window != nil {
                 BonsplitTabItemHitRegionRegistry.register(self)
                 BonsplitTabBarInteractiveHitRegionRegistry.register(self)
+                interactiveScrollObserver.refresh(for: self)
+            } else {
+                interactiveScrollObserver.stop()
             }
             registerGeometryIfVisible()
         }
@@ -171,8 +176,10 @@ struct TabItemHitRegionView: NSViewRepresentable {
                 unregisterGeometry()
                 BonsplitTabItemHitRegionRegistry.unregister(self)
                 BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
+                interactiveScrollObserver.stop()
             } else {
                 registerGeometryIfVisible()
+                interactiveScrollObserver.refresh(for: self)
             }
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -47,6 +47,72 @@ public enum BonsplitTabBarHitRegionRegistry {
     }
 }
 
+/// Exact window-space regions occupied by interactive tab-bar controls.
+/// Portal hosts use these regions to keep split-divider hit bands from
+/// covering buttons rendered underneath them.
+public enum BonsplitTabBarInteractiveHitRegionRegistry {
+    public static let didChangeNotification = Notification.Name(
+        "BonsplitTabBarInteractiveHitRegionsDidChange"
+    )
+
+    private static let lock = NSLock()
+    private static let registeredViews = NSHashTable<NSView>.weakObjects()
+
+    static func register(_ view: NSView) {
+        lock.lock()
+        registeredViews.add(view)
+        lock.unlock()
+        notifyChanged(in: view.window)
+    }
+
+    static func unregister(_ view: NSView) {
+        let oldWindow = view.window
+        lock.lock()
+        registeredViews.remove(view)
+        lock.unlock()
+        notifyChanged(in: oldWindow)
+    }
+
+    static func geometryDidChange(_ view: NSView) {
+        notifyChanged(in: view.window)
+    }
+
+    private static func snapshot() -> [NSView] {
+        lock.lock()
+        let views = registeredViews.allObjects
+        lock.unlock()
+        return views
+    }
+
+    private static func isVisibleInHierarchy(_ view: NSView) -> Bool {
+        var current: NSView? = view
+        while let candidate = current {
+            guard !candidate.isHidden, candidate.alphaValue > 0 else { return false }
+            current = candidate.superview
+        }
+        return true
+    }
+
+    public static func windowRects(in window: NSWindow) -> [NSRect] {
+        let epsilon = max(0.5, 1.0 / max(1.0, window.backingScaleFactor))
+        return snapshot().compactMap { view in
+            guard view.window === window, isVisibleInHierarchy(view) else { return nil }
+            let visibleBounds = view.visibleRect.intersection(view.bounds)
+            guard !visibleBounds.isNull, visibleBounds.width > 0, visibleBounds.height > 0 else { return nil }
+            return view.convert(visibleBounds, to: nil).insetBy(dx: -epsilon, dy: -epsilon)
+        }
+    }
+
+    public static func containsWindowPoint(_ windowPoint: CGPoint, in window: NSWindow) -> Bool {
+        windowRects(in: window).contains { $0.contains(windowPoint) }
+    }
+
+    private static func notifyChanged(in window: NSWindow?) {
+        guard let window else { return }
+        NotificationCenter.default.post(name: didChangeNotification, object: window)
+    }
+}
+
 public protocol BonsplitTabItemHitRegionProviding: AnyObject {
     func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool
 }
@@ -1794,6 +1860,7 @@ struct TabBarView: View {
             ForEach(buttons.indices, id: \.self) { index in
                 let button = buttons[index]
                 splitActionButton(button, tooltips: tooltips)
+                .background(SplitActionHitRegionView())
                 .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
                 .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
             }
@@ -2117,6 +2184,59 @@ private final class SplitActionMouseDownNSView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         onMouseDown?()
+    }
+}
+
+private struct SplitActionHitRegionView: NSViewRepresentable {
+    func makeNSView(context: Context) -> SplitActionHitRegionNSView {
+        SplitActionHitRegionNSView()
+    }
+
+    func updateNSView(_ nsView: SplitActionHitRegionNSView, context: Context) {
+        // AppKit frame callbacks below publish geometry changes.
+    }
+}
+
+private final class SplitActionHitRegionNSView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    deinit {
+        BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
+        super.viewWillMove(toWindow: newWindow)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            BonsplitTabBarInteractiveHitRegionRegistry.register(self)
+        }
+    }
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        if superview == nil {
+            BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
+        }
+    }
+
+    override func setFrameOrigin(_ newOrigin: NSPoint) {
+        let changed = frame.origin != newOrigin
+        super.setFrameOrigin(newOrigin)
+        if changed {
+            BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(self)
+        }
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        let changed = frame.size != newSize
+        super.setFrameSize(newSize)
+        if changed {
+            BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(self)
+        }
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -51,6 +51,11 @@ public enum BonsplitTabBarHitRegionRegistry {
 /// Portal hosts use these regions to keep split-divider hit bands from
 /// covering buttons rendered underneath them.
 @MainActor
+protocol BonsplitTabBarInteractiveRectProviding: AnyObject {
+    func bonsplitTabBarInteractiveHitRects() -> [NSRect]
+}
+
+@MainActor
 public enum BonsplitTabBarInteractiveHitRegionRegistry {
     public static let didChangeNotification = Notification.Name(
         "BonsplitTabBarInteractiveHitRegionsDidChange"
@@ -96,11 +101,17 @@ public enum BonsplitTabBarInteractiveHitRegionRegistry {
 
     public static func windowRects(in window: NSWindow) -> [NSRect] {
         let epsilon = max(0.5, 1.0 / max(1.0, window.backingScaleFactor))
-        return snapshot().compactMap { view in
-            guard view.window === window, isVisibleInHierarchy(view) else { return nil }
+        return snapshot().flatMap { view -> [NSRect] in
+            guard view.window === window, isVisibleInHierarchy(view) else { return [] }
+            if let provider = view as? BonsplitTabBarInteractiveRectProviding {
+                return provider.bonsplitTabBarInteractiveHitRects().compactMap { localRect in
+                    guard !localRect.isNull, localRect.width > 0, localRect.height > 0 else { return nil }
+                    return view.convert(localRect, to: nil).insetBy(dx: -epsilon, dy: -epsilon)
+                }
+            }
             let visibleBounds = view.visibleRect.intersection(view.bounds)
-            guard !visibleBounds.isNull, visibleBounds.width > 0, visibleBounds.height > 0 else { return nil }
-            return view.convert(visibleBounds, to: nil).insetBy(dx: -epsilon, dy: -epsilon)
+            guard !visibleBounds.isNull, visibleBounds.width > 0, visibleBounds.height > 0 else { return [] }
+            return [view.convert(visibleBounds, to: nil).insetBy(dx: -epsilon, dy: -epsilon)]
         }
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -141,9 +141,27 @@ public enum BonsplitTabBarInteractiveHitRegionRegistry {
         return snapshot().flatMap { view -> [NSRect] in
             guard view.window === window, isVisibleInHierarchy(view) else { return [] }
             if let provider = view as? BonsplitTabBarInteractiveRectProviding {
+                let visibleBounds = view.visibleRect.intersection(view.bounds)
+                guard !visibleBounds.isNull,
+                      visibleBounds.width > 0,
+                      visibleBounds.height > 0 else { return [] }
                 return provider.bonsplitTabBarInteractiveHitRects().compactMap { localRect in
                     guard !localRect.isNull, localRect.width > 0, localRect.height > 0 else { return nil }
-                    return view.convert(localRect, to: nil).insetBy(dx: -epsilon, dy: -epsilon)
+                    let leftSlop = max(0, view.bounds.minX - localRect.minX)
+                    let rightSlop = max(0, localRect.maxX - view.bounds.maxX)
+                    let bottomSlop = max(0, view.bounds.minY - localRect.minY)
+                    let topSlop = max(0, localRect.maxY - view.bounds.maxY)
+                    let visibleHitBounds = NSRect(
+                        x: visibleBounds.minX - leftSlop,
+                        y: visibleBounds.minY - bottomSlop,
+                        width: visibleBounds.width + leftSlop + rightSlop,
+                        height: visibleBounds.height + bottomSlop + topSlop
+                    )
+                    let clippedRect = localRect.intersection(visibleHitBounds)
+                    guard !clippedRect.isNull,
+                          clippedRect.width > 0,
+                          clippedRect.height > 0 else { return nil }
+                    return view.convert(clippedRect, to: nil).insetBy(dx: -epsilon, dy: -epsilon)
                 }
             }
             let visibleBounds = view.visibleRect.intersection(view.bounds)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -63,6 +63,31 @@ public enum BonsplitTabBarInteractiveHitRegionRegistry {
 
     private static let lock = NSLock()
     private static let registeredViews = NSHashTable<NSView>.weakObjects()
+    private static let clipViewObserverAssociationToken = NSObject()
+
+    @MainActor
+    private final class ClipViewBoundsObserver {
+        private var boundsObserver: NSObjectProtocol?
+
+        init(clipView: NSClipView) {
+            clipView.postsBoundsChangedNotifications = true
+            boundsObserver = NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: clipView,
+                queue: .main
+            ) { [weak clipView] _ in
+                MainActor.assumeIsolated {
+                    notifyChanged(in: clipView?.window)
+                }
+            }
+        }
+
+        deinit {
+            if let boundsObserver {
+                NotificationCenter.default.removeObserver(boundsObserver)
+            }
+        }
+    }
 
     static func register(_ view: NSView) {
         lock.lock()
@@ -81,6 +106,18 @@ public enum BonsplitTabBarInteractiveHitRegionRegistry {
 
     static func geometryDidChange(_ view: NSView) {
         notifyChanged(in: view.window)
+    }
+
+    static func observeScrolling(for view: NSView) {
+        guard let clipView = view.enclosingScrollView?.contentView else { return }
+        let key = UnsafeRawPointer(Unmanaged.passUnretained(clipViewObserverAssociationToken).toOpaque())
+        guard objc_getAssociatedObject(clipView, key) == nil else { return }
+        objc_setAssociatedObject(
+            clipView,
+            key,
+            ClipViewBoundsObserver(clipView: clipView),
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
     }
 
     private static func snapshot() -> [NSView] {
@@ -122,48 +159,6 @@ public enum BonsplitTabBarInteractiveHitRegionRegistry {
     private static func notifyChanged(in window: NSWindow?) {
         guard let window else { return }
         NotificationCenter.default.post(name: didChangeNotification, object: window)
-    }
-}
-
-@MainActor
-final class BonsplitTabBarInteractiveScrollObserver {
-    private weak var regionView: NSView?
-    private weak var clipView: NSClipView?
-    private var boundsObserver: NSObjectProtocol?
-
-    func refresh(for view: NSView) {
-        let nextClipView = view.enclosingScrollView?.contentView
-        guard nextClipView !== clipView else { return }
-        stop()
-        regionView = view
-        guard let nextClipView else { return }
-        clipView = nextClipView
-        nextClipView.postsBoundsChangedNotifications = true
-        boundsObserver = NotificationCenter.default.addObserver(
-            forName: NSView.boundsDidChangeNotification,
-            object: nextClipView,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                guard let view = self?.regionView else { return }
-                BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(view)
-            }
-        }
-    }
-
-    func stop() {
-        if let boundsObserver {
-            NotificationCenter.default.removeObserver(boundsObserver)
-        }
-        boundsObserver = nil
-        clipView = nil
-        regionView = nil
-    }
-
-    deinit {
-        if let boundsObserver {
-            NotificationCenter.default.removeObserver(boundsObserver)
-        }
     }
 }
 
@@ -2251,13 +2246,11 @@ private struct SplitActionHitRegionView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: SplitActionHitRegionNSView, context: Context) {
-        nsView.refreshScrollObservation()
+        BonsplitTabBarInteractiveHitRegionRegistry.observeScrolling(for: nsView)
     }
 }
 
 private final class SplitActionHitRegionNSView: NSView {
-    private let scrollObserver = BonsplitTabBarInteractiveScrollObserver()
-
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -2269,9 +2262,7 @@ private final class SplitActionHitRegionNSView: NSView {
         super.viewDidMoveToWindow()
         if window != nil {
             BonsplitTabBarInteractiveHitRegionRegistry.register(self)
-            refreshScrollObservation()
-        } else {
-            scrollObserver.stop()
+            BonsplitTabBarInteractiveHitRegionRegistry.observeScrolling(for: self)
         }
     }
 
@@ -2279,14 +2270,9 @@ private final class SplitActionHitRegionNSView: NSView {
         super.viewDidMoveToSuperview()
         if superview == nil {
             BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
-            scrollObserver.stop()
         } else {
-            refreshScrollObservation()
+            BonsplitTabBarInteractiveHitRegionRegistry.observeScrolling(for: self)
         }
-    }
-
-    func refreshScrollObservation() {
-        scrollObserver.refresh(for: self)
     }
 
     override func setFrameOrigin(_ newOrigin: NSPoint) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -50,6 +50,7 @@ public enum BonsplitTabBarHitRegionRegistry {
 /// Exact window-space regions occupied by interactive tab-bar controls.
 /// Portal hosts use these regions to keep split-divider hit bands from
 /// covering buttons rendered underneath them.
+@MainActor
 public enum BonsplitTabBarInteractiveHitRegionRegistry {
     public static let didChangeNotification = Notification.Name(
         "BonsplitTabBarInteractiveHitRegionsDidChange"
@@ -1860,9 +1861,13 @@ struct TabBarView: View {
             ForEach(buttons.indices, id: \.self) { index in
                 let button = buttons[index]
                 splitActionButton(button, tooltips: tooltips)
-                .background(SplitActionHitRegionView())
-                .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
-                .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
+                    .background {
+                        if shouldShowSplitButtons {
+                            SplitActionHitRegionView()
+                        }
+                    }
+                    .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
+                    .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
             }
         }
         .padding(.leading, TabBarStyling.splitButtonsLeadingPadding)
@@ -2199,10 +2204,6 @@ private struct SplitActionHitRegionView: NSViewRepresentable {
 
 private final class SplitActionHitRegionNSView: NSView {
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
-
-    deinit {
-        BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
-    }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
         BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -125,6 +125,48 @@ public enum BonsplitTabBarInteractiveHitRegionRegistry {
     }
 }
 
+@MainActor
+final class BonsplitTabBarInteractiveScrollObserver {
+    private weak var regionView: NSView?
+    private weak var clipView: NSClipView?
+    private var boundsObserver: NSObjectProtocol?
+
+    func refresh(for view: NSView) {
+        let nextClipView = view.enclosingScrollView?.contentView
+        guard nextClipView !== clipView else { return }
+        stop()
+        regionView = view
+        guard let nextClipView else { return }
+        clipView = nextClipView
+        nextClipView.postsBoundsChangedNotifications = true
+        boundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: nextClipView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let view = self?.regionView else { return }
+                BonsplitTabBarInteractiveHitRegionRegistry.geometryDidChange(view)
+            }
+        }
+    }
+
+    func stop() {
+        if let boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+        }
+        boundsObserver = nil
+        clipView = nil
+        regionView = nil
+    }
+
+    deinit {
+        if let boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+        }
+    }
+}
+
 public protocol BonsplitTabItemHitRegionProviding: AnyObject {
     func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool
 }
@@ -2209,11 +2251,13 @@ private struct SplitActionHitRegionView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: SplitActionHitRegionNSView, context: Context) {
-        // AppKit frame callbacks below publish geometry changes.
+        nsView.refreshScrollObservation()
     }
 }
 
 private final class SplitActionHitRegionNSView: NSView {
+    private let scrollObserver = BonsplitTabBarInteractiveScrollObserver()
+
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
@@ -2225,6 +2269,9 @@ private final class SplitActionHitRegionNSView: NSView {
         super.viewDidMoveToWindow()
         if window != nil {
             BonsplitTabBarInteractiveHitRegionRegistry.register(self)
+            refreshScrollObservation()
+        } else {
+            scrollObserver.stop()
         }
     }
 
@@ -2232,7 +2279,14 @@ private final class SplitActionHitRegionNSView: NSView {
         super.viewDidMoveToSuperview()
         if superview == nil {
             BonsplitTabBarInteractiveHitRegionRegistry.unregister(self)
+            scrollObserver.stop()
+        } else {
+            refreshScrollObservation()
         }
+    }
+
+    func refreshScrollObservation() {
+        scrollObserver.refresh(for: self)
     }
 
     override func setFrameOrigin(_ newOrigin: NSPoint) {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1038,6 +1038,38 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarInteractiveHitRegionRegistryUsesProviderRects() {
+        final class TabRegionView: NSView, BonsplitTabBarInteractiveRectProviding {
+            func bonsplitTabBarInteractiveHitRects() -> [NSRect] {
+                [bounds.insetBy(dx: -10, dy: -6)]
+            }
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let tab = TabRegionView(frame: NSRect(x: 100, y: 132, width: 80, height: 24))
+        contentView.addSubview(tab)
+        BonsplitTabBarInteractiveHitRegionRegistry.register(tab)
+        defer { BonsplitTabBarInteractiveHitRegionRegistry.unregister(tab) }
+
+        let slopPoint = tab.convert(NSPoint(x: -5, y: 12), to: nil)
+        XCTAssertTrue(
+            BonsplitTabBarInteractiveHitRegionRegistry.containsWindowPoint(slopPoint, in: window),
+            "Cursor exclusions must cover the same expanded hit rect as the tab item."
+        )
+    }
+
+    @MainActor
     func testTabItemHitRegionRegistryTracksOnlyRealTabFrames() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1006,6 +1006,38 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarInteractiveHitRegionRegistryTracksExactControlBounds() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let action = NSView(frame: NSRect(x: 220, y: 132, width: 24, height: 24))
+        contentView.addSubview(action)
+        BonsplitTabBarInteractiveHitRegionRegistry.register(action)
+        defer { BonsplitTabBarInteractiveHitRegionRegistry.unregister(action) }
+
+        let actionPoint = action.convert(NSPoint(x: 12, y: 12), to: nil)
+        XCTAssertTrue(
+            BonsplitTabBarInteractiveHitRegionRegistry.containsWindowPoint(actionPoint, in: window),
+            "The registry should expose the action control's real window-space bounds"
+        )
+
+        let neighboringChromePoint = action.convert(NSPoint(x: -8, y: 12), to: nil)
+        XCTAssertFalse(
+            BonsplitTabBarInteractiveHitRegionRegistry.containsWindowPoint(neighboringChromePoint, in: window),
+            "Empty tab-bar chrome beside an action must remain available to divider hit testing"
+        )
+    }
+
+    @MainActor
     func testTabItemHitRegionRegistryTracksOnlyRealTabFrames() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1070,6 +1070,51 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabItemInteractiveRegionNotifiesOldWindowWhenMoved() {
+        let oldWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let newWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            oldWindow.orderOut(nil)
+            newWindow.orderOut(nil)
+        }
+        guard let oldContentView = oldWindow.contentView,
+              let newContentView = newWindow.contentView else {
+            XCTFail("Expected content views")
+            return
+        }
+
+        let region = TabItemHitRegionView.RegionNSView(frame: NSRect(x: 20, y: 20, width: 80, height: 24))
+        oldContentView.addSubview(region)
+        var oldWindowNotifications = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: BonsplitTabBarInteractiveHitRegionRegistry.didChangeNotification,
+            object: oldWindow,
+            queue: .main
+        ) { _ in
+            oldWindowNotifications += 1
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        newContentView.addSubview(region)
+
+        XCTAssertGreaterThan(
+            oldWindowNotifications,
+            0,
+            "Moving a tab marker must invalidate cursor exclusions in its old window."
+        )
+    }
+
+    @MainActor
     func testTabItemHitRegionRegistryTracksOnlyRealTabFrames() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1131,7 +1131,9 @@ final class BonsplitTests: XCTestCase {
         let scrollView = NSScrollView(frame: NSRect(x: 0, y: 120, width: 240, height: 40))
         let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 40))
         let region = TabItemHitRegionView.RegionNSView(frame: NSRect(x: 300, y: 8, width: 80, height: 24))
+        let secondRegion = TabItemHitRegionView.RegionNSView(frame: NSRect(x: 400, y: 8, width: 80, height: 24))
         documentView.addSubview(region)
+        documentView.addSubview(secondRegion)
         scrollView.documentView = documentView
         contentView.addSubview(scrollView)
 
@@ -1152,6 +1154,17 @@ final class BonsplitTests: XCTestCase {
             notifications,
             0,
             "Scrolling a tab marker must invalidate its window-space cursor exclusion."
+        )
+
+        notifications = 0
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+        XCTAssertEqual(
+            notifications,
+            1,
+            "One clip-view scroll event must coalesce to one cursor-region invalidation."
         )
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1130,12 +1130,19 @@ final class BonsplitTests: XCTestCase {
 
         let scrollView = NSScrollView(frame: NSRect(x: 0, y: 120, width: 240, height: 40))
         let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 40))
-        let region = TabItemHitRegionView.RegionNSView(frame: NSRect(x: 300, y: 8, width: 80, height: 24))
+        let region = TabItemHitRegionView.RegionNSView(frame: NSRect(x: 260, y: 8, width: 80, height: 24))
         let secondRegion = TabItemHitRegionView.RegionNSView(frame: NSRect(x: 400, y: 8, width: 80, height: 24))
         documentView.addSubview(region)
         documentView.addSubview(secondRegion)
         scrollView.documentView = documentView
         contentView.addSubview(scrollView)
+
+        let offscreenPoint = region.convert(NSPoint(x: 40, y: 12), to: nil)
+        XCTAssertFalse(
+            BonsplitTabBarInteractiveHitRegionRegistry.windowRects(in: window)
+                .contains { $0.contains(offscreenPoint) },
+            "A tab outside the scroll viewport must not create a cursor exclusion."
+        )
 
         var notifications = 0
         let observer = NotificationCenter.default.addObserver(
@@ -1149,6 +1156,13 @@ final class BonsplitTests: XCTestCase {
 
         scrollView.contentView.scroll(to: NSPoint(x: 120, y: 0))
         scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        let visiblePoint = region.convert(NSPoint(x: 40, y: 12), to: nil)
+        XCTAssertTrue(
+            BonsplitTabBarInteractiveHitRegionRegistry.windowRects(in: window)
+                .contains { $0.contains(visiblePoint) },
+            "A tab scrolled into view must create a cursor exclusion."
+        )
 
         XCTAssertGreaterThan(
             notifications,

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1115,6 +1115,47 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabItemInteractiveRegionNotifiesWhenScrollBoundsMove() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 120, width: 240, height: 40))
+        let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 40))
+        let region = TabItemHitRegionView.RegionNSView(frame: NSRect(x: 300, y: 8, width: 80, height: 24))
+        documentView.addSubview(region)
+        scrollView.documentView = documentView
+        contentView.addSubview(scrollView)
+
+        var notifications = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: BonsplitTabBarInteractiveHitRegionRegistry.didChangeNotification,
+            object: window,
+            queue: .main
+        ) { _ in
+            notifications += 1
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        scrollView.contentView.scroll(to: NSPoint(x: 120, y: 0))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        XCTAssertGreaterThan(
+            notifications,
+            0,
+            "Scrolling a tab marker must invalidate its window-space cursor exclusion."
+        )
+    }
+
+    @MainActor
     func testTabItemHitRegionRegistryTracksOnlyRealTabFrames() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),


### PR DESCRIPTION
## Summary

- expose exact visible tab-bar action hit regions to host portals
- publish geometry changes so host cursor rectangles stay current
- keep the registry passive so it does not alter button event handling

## Test plan

- `swift test` (192 tests pass)
- cmux portal regression coverage in https://github.com/manaflow-ai/cmux/pull/7839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose exact window-space hit regions for tab-bar buttons and tabs, clip them to the visible viewport, and keep them updated on layout, scrolling (coalesced), and window moves so portals keep resize bands off controls. Button event handling is unchanged.

- **Bug Fixes**
  - Added `BonsplitTabBarInteractiveHitRegionRegistry` and `BonsplitTabBarInteractiveRectProviding` with `didChangeNotification`; tracks only registered interactive views, clips to `visibleRect`, inflates slightly to avoid rounding gaps, and coalesces scroll invalidations via clip-view bounds changes.
  - Tab items: `TabItemHitRegionView.RegionNSView` now provides expanded hit rects, registers/unregisters with the interactive registry, posts geometry updates on layout/frame/bounds/origin changes (including frame-origin), observes scrolling, and notifies the old window when moved.
  - Actions: Split buttons render a `SplitActionHitRegionView` background only when visible; it auto-registers/unregisters, observes scrolling, and posts updates on frame-origin/size changes. Neighboring chrome stays available for divider hit testing.

<sup>Written for commit 859a6c251ecfcb97d31910604404cf3f759884ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-divider hit testing so tab-bar controls remain clickable.
  * Split action buttons now respond accurately within their visible bounds.
* **Tests**
  * Added regression coverage to verify precise interactive hit regions and prevent clicks from incorrectly registering in adjacent tab-bar areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->