### PR TITLE
Fix tab overflow selection geometry

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -13,14 +13,35 @@ protocol TabBarItemGeometryObserving: AnyObject {
 /// scrolling the strip cannot invalidate the graph that produced the frames.
 @MainActor
 final class TabBarItemGeometryRegistry {
+    private struct ScrollMetrics {
+        let offset: CGFloat
+        let documentWidth: CGFloat
+        let viewportWidth: CGFloat
+    }
+
+    private enum ScrollIntent: Equatable {
+        case leading
+        case revealSelectedTab(UUID)
+    }
+
     private let itemViews = NSMapTable<NSUUID, NSView>.strongToWeakObjects()
     private let observers = NSHashTable<AnyObject>.weakObjects()
     private weak var scrollView: NSScrollView?
     private var scrollBoundsObserver: NSObjectProtocol?
+    private var documentFrameObserver: NSObjectProtocol?
+    private var documentBoundsObserver: NSObjectProtocol?
+    private var selectedTabId: UUID?
+    private var pendingScrollIntent: ScrollIntent?
 
     deinit {
         if let scrollBoundsObserver {
             NotificationCenter.default.removeObserver(scrollBoundsObserver)
+        }
+        if let documentFrameObserver {
+            NotificationCenter.default.removeObserver(documentFrameObserver)
+        }
+        if let documentBoundsObserver {
+            NotificationCenter.default.removeObserver(documentBoundsObserver)
         }
     }
 
@@ -50,7 +71,16 @@ final class TabBarItemGeometryRegistry {
             NotificationCenter.default.removeObserver(scrollBoundsObserver)
             self.scrollBoundsObserver = nil
         }
+        if let documentFrameObserver {
+            NotificationCenter.default.removeObserver(documentFrameObserver)
+            self.documentFrameObserver = nil
+        }
+        if let documentBoundsObserver {
+            NotificationCenter.default.removeObserver(documentBoundsObserver)
+            self.documentBoundsObserver = nil
+        }
         self.scrollView = scrollView
+        makeScrollStackTransparent(scrollView)
         guard let clipView = scrollView?.contentView else {
             invalidateObservers()
             return
@@ -68,7 +98,43 @@ final class TabBarItemGeometryRegistry {
                 self?.invalidateObservers()
             }
         }
+        if let documentView = scrollView?.documentView {
+            documentView.postsFrameChangedNotifications = true
+            documentView.postsBoundsChangedNotifications = true
+            documentFrameObserver = makeDocumentGeometryObserver(
+                name: NSView.frameDidChangeNotification,
+                documentView: documentView
+            )
+            documentBoundsObserver = makeDocumentGeometryObserver(
+                name: NSView.boundsDidChangeNotification,
+                documentView: documentView
+            )
+        }
         invalidateObservers()
+        enforceLeadingEdgeIfContentFits()
+    }
+
+    /// Records the selected tab as a viewport intent until live AppKit geometry can satisfy it.
+    func revealSelection(_ tabId: UUID?) {
+        selectedTabId = tabId
+        pendingScrollIntent = tabId.map(ScrollIntent.revealSelectedTab) ?? .leading
+        reconcilePendingScrollIntent()
+    }
+
+    /// Preserves a resize's current anchor while keeping the clip view inside its valid range.
+    func viewportLayoutDidChange() {
+        guard let metrics = currentScrollMetrics(), metrics.viewportWidth > 0 else { return }
+        guard !TabBarStyling.shouldKeepLeadingAligned(
+            contentWidth: metrics.documentWidth,
+            containerWidth: metrics.viewportWidth
+        ) else {
+            setHorizontalOffset(0, metrics: metrics)
+            return
+        }
+
+        let maximumOffset = max(0, metrics.documentWidth - metrics.viewportWidth)
+        let clampedOffset = min(max(metrics.offset, 0), maximumOffset)
+        setHorizontalOffset(clampedOffset, metrics: metrics)
     }
 
     func frame(for tabId: UUID, in targetView: NSView) -> CGRect? {
@@ -91,8 +157,146 @@ final class TabBarItemGeometryRegistry {
         return frames
     }
 
-    func geometryDidChange() {
+    func geometryDidChange(for tabId: UUID) {
+        if tabId == selectedTabId {
+            reconcilePendingScrollIntent()
+        }
         invalidateObservers()
+    }
+
+    private func reconcilePendingScrollIntent() {
+        guard let intent = pendingScrollIntent else { return }
+
+        let didReconcile: Bool
+        switch intent {
+        case .leading:
+            didReconcile = scrollToLeadingEdgeIfReady()
+        case .revealSelectedTab(let tabId):
+            didReconcile = revealTabIfClipped(tabId)
+        }
+
+        if didReconcile, pendingScrollIntent == intent {
+            pendingScrollIntent = nil
+        }
+    }
+
+    private func makeDocumentGeometryObserver(
+        name: Notification.Name,
+        documentView: NSView
+    ) -> NSObjectProtocol {
+        NotificationCenter.default.addObserver(
+            forName: name,
+            object: documentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.documentGeometryDidChange()
+            }
+        }
+    }
+
+    private func documentGeometryDidChange() {
+        pendingScrollIntent = selectedTabId.map(ScrollIntent.revealSelectedTab) ?? .leading
+        viewportLayoutDidChange()
+        invalidateObservers()
+    }
+
+    @discardableResult
+    private func scrollToLeadingEdgeIfReady() -> Bool {
+        guard let metrics = currentScrollMetrics(), metrics.viewportWidth > 0 else { return false }
+        setHorizontalOffset(0, metrics: metrics)
+        return true
+    }
+
+    @discardableResult
+    private func revealTabIfClipped(_ tabId: UUID) -> Bool {
+        guard let scrollView,
+              let documentView = scrollView.documentView,
+              let itemView = itemViews.object(forKey: tabId as NSUUID),
+              itemView.window === scrollView.window,
+              isVisibleInHierarchy(itemView),
+              let metrics = currentScrollMetrics(),
+              metrics.viewportWidth > 0 else {
+            return false
+        }
+
+        let itemFrame = itemView.convert(itemView.bounds, to: documentView)
+        guard itemFrame.width > 0,
+              itemFrame.minX >= -0.5,
+              itemFrame.maxX <= metrics.documentWidth + 0.5 else {
+            return false
+        }
+
+        if TabBarStyling.shouldKeepLeadingAligned(
+            contentWidth: metrics.documentWidth,
+            containerWidth: metrics.viewportWidth
+        ) {
+            setHorizontalOffset(0, metrics: metrics)
+            return true
+        }
+
+        let visibleRange = metrics.offset...(metrics.offset + metrics.viewportWidth)
+        guard itemFrame.minX < visibleRange.lowerBound - 0.5
+                || itemFrame.maxX > visibleRange.upperBound + 0.5 else {
+            return true
+        }
+
+        let maximumOffset = max(0, metrics.documentWidth - metrics.viewportWidth)
+        let centeredOffset = itemFrame.midX - (metrics.viewportWidth / 2)
+        let targetOffset = min(max(centeredOffset, 0), maximumOffset)
+        setHorizontalOffset(targetOffset, metrics: metrics)
+        return true
+    }
+
+    private func currentScrollMetrics() -> ScrollMetrics? {
+        guard let scrollView else { return nil }
+        let clipView = scrollView.contentView
+        let documentWidth = max(
+            scrollView.documentView?.frame.width ?? 0,
+            scrollView.documentView?.bounds.width ?? 0
+        )
+        return ScrollMetrics(
+            offset: clipView.bounds.origin.x,
+            documentWidth: documentWidth,
+            viewportWidth: clipView.bounds.width
+        )
+    }
+
+    private func enforceLeadingEdgeIfContentFits() {
+        guard let metrics = currentScrollMetrics(), metrics.viewportWidth > 0 else { return }
+        guard TabBarStyling.shouldKeepLeadingAligned(
+            contentWidth: metrics.documentWidth,
+            containerWidth: metrics.viewportWidth
+        ) else {
+            return
+        }
+        setHorizontalOffset(0, metrics: metrics)
+    }
+
+    private func setHorizontalOffset(_ targetOffset: CGFloat, metrics: ScrollMetrics) {
+        guard abs(targetOffset - metrics.offset) > 0.5, let scrollView else { return }
+        let clipView = scrollView.contentView
+        clipView.scroll(to: NSPoint(x: targetOffset, y: clipView.bounds.origin.y))
+        scrollView.reflectScrolledClipView(clipView)
+    }
+
+    private func makeScrollStackTransparent(_ scrollView: NSScrollView?) {
+        scrollView?.drawsBackground = false
+        scrollView?.backgroundColor = .clear
+        scrollView?.wantsLayer = true
+        scrollView?.layer?.backgroundColor = NSColor.clear.cgColor
+        scrollView?.layer?.isOpaque = false
+
+        let clipView = scrollView?.contentView
+        clipView?.drawsBackground = false
+        clipView?.backgroundColor = .clear
+        clipView?.wantsLayer = true
+        clipView?.layer?.backgroundColor = NSColor.clear.cgColor
+        clipView?.layer?.isOpaque = false
+
+        scrollView?.documentView?.wantsLayer = true
+        scrollView?.documentView?.layer?.backgroundColor = NSColor.clear.cgColor
+        scrollView?.documentView?.layer?.isOpaque = false
     }
 
     private func invalidateObservers() {
@@ -129,10 +333,13 @@ struct TabItemHitRegionView: NSViewRepresentable {
         nonisolated(unsafe) private var hitBounds: NSRect = .zero
         private var tabId: UUID?
         private weak var geometryRegistry: TabBarItemGeometryRegistry?
+        private var containerFrameObserver: NSObjectProtocol?
+        private var containerBoundsObserver: NSObjectProtocol?
 
         override var mouseDownCanMoveWindow: Bool { false }
 
         deinit {
+            invalidateContainerGeometryObservers()
             unregisterGeometry()
             BonsplitTabItemHitRegionRegistry.unregister(self)
         }
@@ -158,6 +365,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
 
         override func viewDidMoveToSuperview() {
             super.viewDidMoveToSuperview()
+            observeContainerGeometry()
             if superview == nil {
                 unregisterGeometry()
                 BonsplitTabItemHitRegionRegistry.unregister(self)
@@ -169,25 +377,25 @@ struct TabItemHitRegionView: NSViewRepresentable {
         override func layout() {
             super.layout()
             syncHitBounds()
-            geometryRegistry?.geometryDidChange()
+            notifyGeometryDidChange()
         }
 
         override func setFrameSize(_ newSize: NSSize) {
             super.setFrameSize(newSize)
             syncHitBounds()
-            geometryRegistry?.geometryDidChange()
+            notifyGeometryDidChange()
         }
 
         override func setBoundsSize(_ newSize: NSSize) {
             super.setBoundsSize(newSize)
             syncHitBounds()
-            geometryRegistry?.geometryDidChange()
+            notifyGeometryDidChange()
         }
 
         override func setBoundsOrigin(_ newOrigin: NSPoint) {
             super.setBoundsOrigin(newOrigin)
             syncHitBounds()
-            geometryRegistry?.geometryDidChange()
+            notifyGeometryDidChange()
         }
 
         nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
@@ -205,12 +413,59 @@ struct TabItemHitRegionView: NSViewRepresentable {
 
         private func registerGeometryIfVisible() {
             guard window != nil, superview != nil, let tabId else { return }
+            geometryRegistry?.attachScrollView(enclosingScrollView)
             geometryRegistry?.register(self, for: tabId)
         }
 
         private func unregisterGeometry() {
             guard let tabId else { return }
             geometryRegistry?.unregister(self, for: tabId)
+        }
+
+        private func observeContainerGeometry() {
+            invalidateContainerGeometryObservers()
+            guard let containerView = superview else { return }
+            containerView.postsFrameChangedNotifications = true
+            containerView.postsBoundsChangedNotifications = true
+            containerFrameObserver = makeContainerGeometryObserver(
+                name: NSView.frameDidChangeNotification,
+                containerView: containerView
+            )
+            containerBoundsObserver = makeContainerGeometryObserver(
+                name: NSView.boundsDidChangeNotification,
+                containerView: containerView
+            )
+        }
+
+        private func makeContainerGeometryObserver(
+            name: Notification.Name,
+            containerView: NSView
+        ) -> NSObjectProtocol {
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: containerView,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.notifyGeometryDidChange()
+                }
+            }
+        }
+
+        private func invalidateContainerGeometryObservers() {
+            if let containerFrameObserver {
+                NotificationCenter.default.removeObserver(containerFrameObserver)
+                self.containerFrameObserver = nil
+            }
+            if let containerBoundsObserver {
+                NotificationCenter.default.removeObserver(containerBoundsObserver)
+                self.containerBoundsObserver = nil
+            }
+        }
+
+        private func notifyGeometryDidChange() {
+            guard let tabId else { return }
+            geometryRegistry?.geometryDidChange(for: tabId)
         }
 
         private func syncHitBounds() {

--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -29,15 +29,21 @@ final class TabBarItemGeometryRegistry {
     private let observers = NSHashTable<AnyObject>.weakObjects()
     private weak var scrollView: NSScrollView?
     private var scrollBoundsObserver: NSObjectProtocol?
+    private var liveScrollObserver: NSObjectProtocol?
     private var documentFrameObserver: NSObjectProtocol?
     private var documentBoundsObserver: NSObjectProtocol?
     private var selectedTabId: UUID?
+    private var lastObservedSelectedTabDocumentFrame: CGRect?
     private var pendingScrollIntent: ScrollIntent?
+    private var expectedProgrammaticOffset: CGFloat?
     private var trailingObscuredWidth: CGFloat = 0
 
     deinit {
         if let scrollBoundsObserver {
             NotificationCenter.default.removeObserver(scrollBoundsObserver)
+        }
+        if let liveScrollObserver {
+            NotificationCenter.default.removeObserver(liveScrollObserver)
         }
         if let documentFrameObserver {
             NotificationCenter.default.removeObserver(documentFrameObserver)
@@ -49,6 +55,9 @@ final class TabBarItemGeometryRegistry {
 
     func register(_ view: NSView, for tabId: UUID) {
         itemViews.setObject(view, forKey: tabId as NSUUID)
+        if tabId == selectedTabId {
+            reconcilePendingScrollIntent()
+        }
         invalidateObservers()
     }
 
@@ -73,6 +82,10 @@ final class TabBarItemGeometryRegistry {
             NotificationCenter.default.removeObserver(scrollBoundsObserver)
             self.scrollBoundsObserver = nil
         }
+        if let liveScrollObserver {
+            NotificationCenter.default.removeObserver(liveScrollObserver)
+            self.liveScrollObserver = nil
+        }
         if let documentFrameObserver {
             NotificationCenter.default.removeObserver(documentFrameObserver)
             self.documentFrameObserver = nil
@@ -81,6 +94,8 @@ final class TabBarItemGeometryRegistry {
             NotificationCenter.default.removeObserver(documentBoundsObserver)
             self.documentBoundsObserver = nil
         }
+        expectedProgrammaticOffset = nil
+        lastObservedSelectedTabDocumentFrame = nil
         self.scrollView = scrollView
         makeScrollStackTransparent(scrollView)
         guard let clipView = scrollView?.contentView else {
@@ -97,7 +112,16 @@ final class TabBarItemGeometryRegistry {
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                self?.invalidateObservers()
+                self?.scrollBoundsDidChange()
+            }
+        }
+        liveScrollObserver = NotificationCenter.default.addObserver(
+            forName: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.userWillScroll()
             }
         }
         if let documentView = scrollView?.documentView {
@@ -112,12 +136,19 @@ final class TabBarItemGeometryRegistry {
                 documentView: documentView
             )
         }
+        if let selectedTabId {
+            pendingScrollIntent = .revealSelectedTab(selectedTabId)
+        }
         invalidateObservers()
+        reconcilePendingScrollIntent()
         enforceLeadingEdgeIfContentFits()
     }
 
     /// Records the selected tab as a viewport intent until live AppKit geometry can satisfy it.
     func revealSelection(_ tabId: UUID?) {
+        if selectedTabId != tabId {
+            lastObservedSelectedTabDocumentFrame = nil
+        }
         selectedTabId = tabId
         pendingScrollIntent = tabId.map(ScrollIntent.revealSelectedTab) ?? .leading
         reconcilePendingScrollIntent()
@@ -172,9 +203,42 @@ final class TabBarItemGeometryRegistry {
 
     func geometryDidChange(for tabId: UUID) {
         if tabId == selectedTabId {
+            if selectedTabFrameDidChange(tabId) {
+                pendingScrollIntent = .revealSelectedTab(tabId)
+            }
             reconcilePendingScrollIntent()
         }
         invalidateObservers()
+    }
+
+    private func scrollBoundsDidChange() {
+        if let expectedProgrammaticOffset,
+           let metrics = currentScrollMetrics(),
+           abs(metrics.offset - expectedProgrammaticOffset) > 0.5 {
+            setHorizontalOffset(expectedProgrammaticOffset, metrics: metrics)
+        }
+        invalidateObservers()
+    }
+
+    private func userWillScroll() {
+        expectedProgrammaticOffset = nil
+        pendingScrollIntent = nil
+    }
+
+    private func selectedTabFrameDidChange(_ tabId: UUID) -> Bool {
+        guard let scrollView,
+              let documentView = scrollView.documentView,
+              let itemView = itemViews.object(forKey: tabId as NSUUID),
+              itemView.window === scrollView.window,
+              isVisibleInHierarchy(itemView) else {
+            return false
+        }
+
+        let currentFrame = itemView.convert(itemView.bounds, to: documentView)
+        defer { lastObservedSelectedTabDocumentFrame = currentFrame }
+        guard let previousFrame = lastObservedSelectedTabDocumentFrame else { return true }
+        return abs(currentFrame.minX - previousFrame.minX) > 0.5
+            || abs(currentFrame.maxX - previousFrame.maxX) > 0.5
     }
 
     private func reconcilePendingScrollIntent() {
@@ -239,6 +303,7 @@ final class TabBarItemGeometryRegistry {
               itemFrame.maxX <= metrics.documentWidth + 0.5 else {
             return false
         }
+        lastObservedSelectedTabDocumentFrame = itemFrame
 
         if TabBarStyling.shouldKeepLeadingAligned(
             contentWidth: metrics.documentWidth,
@@ -251,6 +316,7 @@ final class TabBarItemGeometryRegistry {
         let visibleRange = metrics.offset...(metrics.offset + metrics.unobscuredViewportWidth)
         guard itemFrame.minX < visibleRange.lowerBound - 0.5
                 || itemFrame.maxX > visibleRange.upperBound + 0.5 else {
+            setHorizontalOffset(metrics.offset, metrics: metrics)
             return true
         }
 
@@ -288,9 +354,12 @@ final class TabBarItemGeometryRegistry {
     }
 
     private func setHorizontalOffset(_ targetOffset: CGFloat, metrics: ScrollMetrics) {
-        guard abs(targetOffset - metrics.offset) > 0.5, let scrollView else { return }
+        let maximumOffset = max(0, metrics.documentWidth - metrics.viewportWidth)
+        let clampedOffset = min(max(targetOffset, 0), maximumOffset)
+        expectedProgrammaticOffset = clampedOffset
+        guard abs(clampedOffset - metrics.offset) > 0.5, let scrollView else { return }
         let clipView = scrollView.contentView
-        clipView.scroll(to: NSPoint(x: targetOffset, y: clipView.bounds.origin.y))
+        clipView.scroll(to: NSPoint(x: clampedOffset, y: clipView.bounds.origin.y))
         scrollView.reflectScrolledClipView(clipView)
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -17,6 +17,7 @@ final class TabBarItemGeometryRegistry {
         let offset: CGFloat
         let documentWidth: CGFloat
         let viewportWidth: CGFloat
+        let unobscuredViewportWidth: CGFloat
     }
 
     private enum ScrollIntent: Equatable {
@@ -32,6 +33,7 @@ final class TabBarItemGeometryRegistry {
     private var documentBoundsObserver: NSObjectProtocol?
     private var selectedTabId: UUID?
     private var pendingScrollIntent: ScrollIntent?
+    private var trailingObscuredWidth: CGFloat = 0
 
     deinit {
         if let scrollBoundsObserver {
@@ -119,6 +121,17 @@ final class TabBarItemGeometryRegistry {
         selectedTabId = tabId
         pendingScrollIntent = tabId.map(ScrollIntent.revealSelectedTab) ?? .leading
         reconcilePendingScrollIntent()
+    }
+
+    /// Updates the portion of the clip view covered by trailing foreground controls.
+    func setTrailingObscuredWidth(_ width: CGFloat) {
+        let normalizedWidth = max(0, width)
+        guard abs(normalizedWidth - trailingObscuredWidth) > 0.5 else { return }
+
+        trailingObscuredWidth = normalizedWidth
+        pendingScrollIntent = selectedTabId.map(ScrollIntent.revealSelectedTab) ?? .leading
+        reconcilePendingScrollIntent()
+        invalidateObservers()
     }
 
     /// Preserves a resize's current anchor while keeping the clip view inside its valid range.
@@ -216,7 +229,7 @@ final class TabBarItemGeometryRegistry {
               itemView.window === scrollView.window,
               isVisibleInHierarchy(itemView),
               let metrics = currentScrollMetrics(),
-              metrics.viewportWidth > 0 else {
+              metrics.unobscuredViewportWidth > 0 else {
             return false
         }
 
@@ -235,14 +248,14 @@ final class TabBarItemGeometryRegistry {
             return true
         }
 
-        let visibleRange = metrics.offset...(metrics.offset + metrics.viewportWidth)
+        let visibleRange = metrics.offset...(metrics.offset + metrics.unobscuredViewportWidth)
         guard itemFrame.minX < visibleRange.lowerBound - 0.5
                 || itemFrame.maxX > visibleRange.upperBound + 0.5 else {
             return true
         }
 
         let maximumOffset = max(0, metrics.documentWidth - metrics.viewportWidth)
-        let centeredOffset = itemFrame.midX - (metrics.viewportWidth / 2)
+        let centeredOffset = itemFrame.midX - (metrics.unobscuredViewportWidth / 2)
         let targetOffset = min(max(centeredOffset, 0), maximumOffset)
         setHorizontalOffset(targetOffset, metrics: metrics)
         return true
@@ -258,7 +271,8 @@ final class TabBarItemGeometryRegistry {
         return ScrollMetrics(
             offset: clipView.bounds.origin.x,
             documentWidth: documentWidth,
-            viewportWidth: clipView.bounds.width
+            viewportWidth: clipView.bounds.width,
+            unobscuredViewportWidth: max(0, clipView.bounds.width - trailingObscuredWidth)
         )
     }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
@@ -186,15 +186,11 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
                 gradientFrame: leftFadeFrame,
                 colors: [indicatorColor.withAlphaComponent(0), indicatorColor]
             )
-            // An action-lane fade removes tab content before foreground controls begin.
-            // Keep the indicator out of that region; ordinary scroll edges still fade it.
-            if mask.rightOcclusionWidth == 0 {
-                drawIndicatorFade(
-                    in: frame.intersection(rightFadeFrame),
-                    gradientFrame: rightFadeFrame,
-                    colors: [indicatorColor, indicatorColor.withAlphaComponent(0)]
-                )
-            }
+            drawIndicatorFade(
+                in: frame.intersection(rightFadeFrame),
+                gradientFrame: rightFadeFrame,
+                colors: [indicatorColor, indicatorColor.withAlphaComponent(0)]
+            )
         }
 
         private func drawIndicatorSegment(_ frame: NSRect, color: NSColor) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1125,6 +1125,7 @@ struct TabBarView: View {
                 .coordinateSpace(name: "tabScroll")
                 .onAppear {
                     containerWidth = containerGeo.size.width
+                    tabItemGeometryRegistry.setTrailingObscuredWidth(trailingTabContentInset)
                     tabItemGeometryRegistry.revealSelection(pane.selectedTabId)
                 }
                 .onChange(of: containerGeo.size.width) { _, newWidth in
@@ -1133,6 +1134,9 @@ struct TabBarView: View {
                 }
                 .onChange(of: pane.selectedTabId) { _, newTabId in
                     tabItemGeometryRegistry.revealSelection(newTabId)
+                }
+                .onChange(of: trailingTabContentInset) { _, newWidth in
+                    tabItemGeometryRegistry.setTrailingObscuredWidth(newWidth)
                 }
                 .frame(height: tabBarHeight)
                 .mask(combinedMask)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -137,175 +137,6 @@ private struct SplitButtonLaneWidthReader: View {
     }
 }
 
-@MainActor
-private final class TabBarScrollViewBridge {
-    private struct ScrollMetrics {
-        let offset: CGFloat
-        let documentWidth: CGFloat
-        let viewportWidth: CGFloat
-    }
-
-    private enum AsyncCorrection {
-        case fixedTarget
-        case clampToValidRange
-    }
-
-    weak var scrollView: NSScrollView?
-
-    func attach(_ scrollView: NSScrollView?) {
-        self.scrollView = scrollView
-        enforceLeadingEdgeIfContentFits(reason: "attach")
-    }
-
-    private func currentMetrics() -> ScrollMetrics? {
-        guard let scrollView else { return nil }
-
-        let clipView = scrollView.contentView
-        let documentWidth = max(
-            scrollView.documentView?.frame.width ?? 0,
-            scrollView.documentView?.bounds.width ?? 0
-        )
-        let viewportWidth = clipView.bounds.width
-        return ScrollMetrics(
-            offset: clipView.bounds.origin.x,
-            documentWidth: documentWidth,
-            viewportWidth: viewportWidth
-        )
-    }
-
-    func shouldPreferLeadingTarget(
-        selectedTabId: UUID?,
-        fallbackContentWidth: CGFloat,
-        fallbackContainerWidth: CGFloat
-    ) -> Bool {
-        guard selectedTabId != nil else { return true }
-
-        if let metrics = currentMetrics(), metrics.viewportWidth > 0 {
-            return TabBarStyling.shouldKeepLeadingAligned(
-                contentWidth: metrics.documentWidth,
-                containerWidth: metrics.viewportWidth
-            )
-        }
-
-        return TabBarStyling.shouldKeepLeadingAligned(
-            contentWidth: fallbackContentWidth,
-            containerWidth: fallbackContainerWidth
-        )
-    }
-
-    func enforceLeadingEdgeIfContentFits(reason: String) {
-        guard let metrics = currentMetrics(), metrics.viewportWidth > 0 else { return }
-        guard TabBarStyling.shouldKeepLeadingAligned(
-            contentWidth: metrics.documentWidth,
-            containerWidth: metrics.viewportWidth
-        ) else {
-            return
-        }
-
-        resetToLeadingEdgeIfNeeded(reason: reason)
-    }
-
-    func preserveCurrentOffsetAfterLayoutChange(reason: String) {
-        guard let metrics = currentMetrics(), metrics.viewportWidth > 0 else { return }
-        guard !TabBarStyling.shouldKeepLeadingAligned(
-            contentWidth: metrics.documentWidth,
-            containerWidth: metrics.viewportWidth
-        ) else {
-            resetToLeadingEdgeIfNeeded(reason: reason)
-            return
-        }
-
-        let maxOffset = max(0, metrics.documentWidth - metrics.viewportWidth)
-        let clampedOffset = min(max(metrics.offset, 0), maxOffset)
-        setHorizontalOffset(
-            clampedOffset,
-            reason: reason,
-            event: "tab.bar.clampOffset",
-            asyncEvent: "tab.bar.clampOffset.async",
-            metrics: metrics,
-            asyncCorrection: .clampToValidRange
-        )
-    }
-
-    func resetToLeadingEdgeIfNeeded(reason: String) {
-        guard let metrics = currentMetrics() else { return }
-
-        let currentOffset = metrics.offset
-        guard abs(currentOffset) > 0.5 else { return }
-
-        setHorizontalOffset(
-            0,
-            reason: reason,
-            event: "tab.bar.resetLeading",
-            asyncEvent: "tab.bar.resetLeading.async",
-            metrics: metrics,
-            asyncCorrection: .fixedTarget
-        )
-    }
-
-    private func setHorizontalOffset(
-        _ targetOffset: CGFloat,
-        reason: String,
-        event: String,
-        asyncEvent: String,
-        metrics: ScrollMetrics,
-        asyncCorrection: AsyncCorrection
-    ) {
-        guard abs(targetOffset - metrics.offset) > 0.5 else { return }
-        guard let scrollView else { return }
-
-#if DEBUG
-        dlog(
-            "\(event) reason=\(reason) " +
-            "offset=\(Int(metrics.offset.rounded())) " +
-            "target=\(Int(targetOffset.rounded())) " +
-            "doc=\(Int(metrics.documentWidth.rounded())) " +
-            "viewport=\(Int(metrics.viewportWidth.rounded()))"
-        )
-#endif
-        let clipView = scrollView.contentView
-        clipView.scroll(to: NSPoint(x: targetOffset, y: clipView.bounds.origin.y))
-        scrollView.reflectScrolledClipView(clipView)
-
-        // SwiftUI's ScrollView can briefly restore the stale offset during the same
-        // layout cycle. Re-apply the correction on the next turn to keep split-pane
-        // tab bars pinned or clamped once the geometry settles.
-        DispatchQueue.main.async { [weak scrollView] in
-            guard let scrollView else { return }
-            let clipView = scrollView.contentView
-            let asyncOffset = clipView.bounds.origin.x
-            let asyncDocumentWidth = max(
-                scrollView.documentView?.frame.width ?? 0,
-                scrollView.documentView?.bounds.width ?? 0
-            )
-            let asyncViewportWidth = clipView.bounds.width
-            let asyncTargetOffset: CGFloat
-
-            switch asyncCorrection {
-            case .fixedTarget:
-                asyncTargetOffset = targetOffset
-            case .clampToValidRange:
-                guard asyncViewportWidth > 0 else { return }
-                let asyncMaxOffset = max(0, asyncDocumentWidth - asyncViewportWidth)
-                asyncTargetOffset = min(max(asyncOffset, 0), asyncMaxOffset)
-            }
-
-            guard abs(asyncOffset - asyncTargetOffset) > 0.5 else { return }
-#if DEBUG
-            dlog(
-                "\(asyncEvent) reason=\(reason) " +
-                "offset=\(Int(asyncOffset.rounded())) " +
-                "target=\(Int(asyncTargetOffset.rounded())) " +
-                "doc=\(Int(asyncDocumentWidth.rounded())) " +
-                "viewport=\(Int(asyncViewportWidth.rounded()))"
-            )
-#endif
-            clipView.scroll(to: NSPoint(x: asyncTargetOffset, y: clipView.bounds.origin.y))
-            scrollView.reflectScrolledClipView(clipView)
-        }
-    }
-}
-
 enum TabBarStyling {
     struct SplitActionSystemImage: Equatable {
         let name: String
@@ -396,11 +227,6 @@ enum TabBarStyling {
         return tabFrames[selectedTabId]
     }
 
-    enum ScrollTarget: Equatable {
-        case leading
-        case selectedTab(UUID)
-    }
-
     static func separatorSegments(
         totalWidth: CGFloat,
         gap: ClosedRange<CGFloat>?
@@ -432,23 +258,6 @@ enum TabBarStyling {
         return isMinimalMode ? 0 : splitButtonsBackdropWidth(buttonCount: buttonCount)
     }
 
-    static func preferredScrollTarget(
-        selectedTabId: UUID?,
-        contentWidth: CGFloat,
-        containerWidth: CGFloat
-    ) -> ScrollTarget {
-        guard let selectedTabId else { return .leading }
-
-        // When the tab strip fits without horizontal scrolling, centering the selected tab
-        // can strand empty NSClipView space at the leading edge in split panes. Keep the
-        // content snapped to the leading edge until it actually overflows.
-        guard !shouldKeepLeadingAligned(contentWidth: contentWidth, containerWidth: containerWidth) else {
-            return .leading
-        }
-
-        return .selectedTab(selectedTabId)
-    }
-
     static func shouldKeepLeadingAligned(
         contentWidth: CGFloat,
         containerWidth: CGFloat
@@ -457,18 +266,6 @@ enum TabBarStyling {
         return contentWidth <= containerWidth + overflowThreshold
     }
 
-    static func shouldForceResetToLeading(
-        scrollOffset: CGFloat,
-        contentWidth: CGFloat,
-        containerWidth: CGFloat
-    ) -> Bool {
-        guard shouldKeepLeadingAligned(contentWidth: contentWidth, containerWidth: containerWidth) else {
-            return false
-        }
-
-        let overflowThreshold: CGFloat = 1
-        return abs(scrollOffset) > overflowThreshold
-    }
 }
 
 struct TabBarLayout: Equatable {
@@ -1020,7 +817,6 @@ struct TabBarView: View {
     @State private var splitButtonContentWidth: CGFloat = 0
     @State private var splitButtonViewportWidth: CGFloat = 0
     @State private var controlKeyMonitor = TabControlShortcutKeyMonitor()
-    @State private var scrollViewBridge = TabBarScrollViewBridge()
     @State private var tabItemGeometryRegistry = TabBarItemGeometryRegistry()
 
     private var canScrollLeft: Bool {
@@ -1119,10 +915,6 @@ struct TabBarView: View {
 
     private var trailingTabContentInset: CGFloat {
         tabBarLayout.trailingTabContentInset
-    }
-
-    private var leadingScrollAnchorId: String {
-        "tab-bar-leading-\(pane.id.id.uuidString)"
     }
 
     private var splitButtonScrollCoordinateSpaceName: String {
@@ -1249,42 +1041,6 @@ struct TabBarView: View {
         return true
     }
 
-    private func scrollToPreferredTarget(_ proxy: ScrollViewProxy, selectedTabId: UUID?) {
-        let target: TabBarStyling.ScrollTarget
-        if scrollViewBridge.shouldPreferLeadingTarget(
-            selectedTabId: selectedTabId,
-            fallbackContentWidth: contentWidth,
-            fallbackContainerWidth: containerWidth
-        ) {
-            target = .leading
-        } else if let selectedTabId {
-            target = .selectedTab(selectedTabId)
-        } else {
-            target = .leading
-        }
-
-        withTransaction(Transaction(animation: nil)) {
-            switch target {
-            case .leading:
-                proxy.scrollTo(leadingScrollAnchorId, anchor: .leading)
-            case .selectedTab(let tabId):
-                proxy.scrollTo(tabId, anchor: .center)
-            }
-        }
-
-        if target == .leading,
-           TabBarStyling.shouldForceResetToLeading(
-                scrollOffset: scrollOffset,
-                contentWidth: contentWidth,
-                containerWidth: containerWidth
-           ) {
-            scrollViewBridge.resetToLeadingEdgeIfNeeded(reason: "scrollToPreferredTarget")
-        } else if target == .leading {
-            scrollViewBridge.enforceLeadingEdgeIfContentFits(reason: "scrollToPreferredTarget")
-        }
-    }
-
-
     /// The horizontally-scrolling tab row hosted inside the tab strip's `ScrollView`.
     ///
     /// Extracted from `body` so the SwiftUI type-checker can resolve the surrounding
@@ -1293,10 +1049,6 @@ struct TabBarView: View {
     @ViewBuilder
     private var tabScrollContent: some View {
         HStack(spacing: TabBarMetrics.tabSpacing) {
-            Color.clear
-                .frame(width: 0, height: tabBarHeight)
-                .id(leadingScrollAnchorId)
-
             ForEach(visibleTabEntries, id: \.tab.id) { entry in
                 tabItem(for: entry.tab, at: entry.index)
                     .id(entry.tab.id)
@@ -1338,17 +1090,9 @@ struct TabBarView: View {
             }
             // Scrollable tabs with fade overlays
             GeometryReader { containerGeo in
-                ScrollViewReader { proxy in
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        tabScrollContent
-                    }
-                    .background(
-                        TabBarScrollViewResolver { scrollView in
-                            scrollViewBridge.attach(scrollView)
-                            tabItemGeometryRegistry.attachScrollView(scrollView)
-                        }
-                        .frame(width: 0, height: 0)
-                    )
+                ScrollView(.horizontal, showsIndicators: false) {
+                    tabScrollContent
+                }
                     // When the tab strip is shorter than the visible area, place a single
                     // drag zone over both the empty trailing space AND the 30pt inline
                     // dropZoneAfterTabs (extended leftward by 30pt). The inline zone's
@@ -1378,21 +1122,17 @@ struct TabBarView: View {
                             ))
                         }
                     }
-                    .coordinateSpace(name: "tabScroll")
-                    .onAppear {
-                        containerWidth = containerGeo.size.width
-                        scrollToPreferredTarget(proxy, selectedTabId: pane.selectedTabId)
-                    }
-                    .onChange(of: containerGeo.size.width) { _, newWidth in
-                        containerWidth = newWidth
-                        scrollViewBridge.preserveCurrentOffsetAfterLayoutChange(reason: "containerWidth")
-                    }
-                    .onChange(of: contentWidth) { _, _ in
-                        scrollViewBridge.preserveCurrentOffsetAfterLayoutChange(reason: "contentWidth")
-                    }
-                    .onChange(of: pane.selectedTabId) { _, newTabId in
-                        scrollToPreferredTarget(proxy, selectedTabId: newTabId)
-                    }
+                .coordinateSpace(name: "tabScroll")
+                .onAppear {
+                    containerWidth = containerGeo.size.width
+                    tabItemGeometryRegistry.revealSelection(pane.selectedTabId)
+                }
+                .onChange(of: containerGeo.size.width) { _, newWidth in
+                    containerWidth = newWidth
+                    tabItemGeometryRegistry.viewportLayoutDidChange()
+                }
+                .onChange(of: pane.selectedTabId) { _, newTabId in
+                    tabItemGeometryRegistry.revealSelection(newTabId)
                 }
                 .frame(height: tabBarHeight)
                 .mask(combinedMask)
@@ -3059,68 +2799,6 @@ struct TabBarDragZoneView: NSViewRepresentable {
             case "Minimize": window.miniaturize(nil)
             default: window.zoom(nil)
             }
-        }
-    }
-}
-
-private struct TabBarScrollViewResolver: NSViewRepresentable {
-    let onResolve: (NSScrollView?) -> Void
-
-    func makeNSView(context: Context) -> ResolverView {
-        let view = ResolverView()
-        view.onResolve = onResolve
-        return view
-    }
-
-    func updateNSView(_ nsView: ResolverView, context: Context) {
-        nsView.onResolve = onResolve
-        nsView.resolveScrollView()
-    }
-
-    final class ResolverView: NSView {
-        var onResolve: ((NSScrollView?) -> Void)?
-
-        override func viewDidMoveToSuperview() {
-            super.viewDidMoveToSuperview()
-            resolveScrollView()
-        }
-
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            resolveScrollView()
-        }
-
-        override func layout() {
-            super.layout()
-            resolveScrollView()
-        }
-
-        func resolveScrollView() {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                let scrollView = self.enclosingScrollView
-                self.makeScrollStackTransparent(scrollView)
-                onResolve?(scrollView)
-            }
-        }
-
-        private func makeScrollStackTransparent(_ scrollView: NSScrollView?) {
-            scrollView?.drawsBackground = false
-            scrollView?.backgroundColor = .clear
-            scrollView?.wantsLayer = true
-            scrollView?.layer?.backgroundColor = NSColor.clear.cgColor
-            scrollView?.layer?.isOpaque = false
-
-            let clipView = scrollView?.contentView
-            clipView?.drawsBackground = false
-            clipView?.backgroundColor = .clear
-            clipView?.wantsLayer = true
-            clipView?.layer?.backgroundColor = NSColor.clear.cgColor
-            clipView?.layer?.isOpaque = false
-
-            scrollView?.documentView?.wantsLayer = true
-            scrollView?.documentView?.layer?.backgroundColor = NSColor.clear.cgColor
-            scrollView?.documentView?.layer?.isOpaque = false
         }
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3119,7 +3119,7 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testSplitButtonBackdropOccludesTabChromeAtContentFadeStart() {
+    func testSplitButtonBackdropOccludesTabBodyAtContentFadeStart() {
         guard let saturation = renderedSplitButtonContentFadeStartSaturation() else {
             XCTFail("Expected rendered split button content fade colors")
             return
@@ -4449,9 +4449,9 @@ final class BonsplitTests: XCTestCase {
             let laneStartX = size.width - splitButtonLaneWidth
             let sampleRect = NSRect(
                 x: laneStartX - contentFadeWidth + 2,
-                y: 0,
+                y: TabBarMetrics.activeIndicatorHeight + 2,
                 width: 8,
-                height: 4
+                height: 8
             )
             return maximumSaturation(in: hostingView, sampleRect: sampleRect)
         }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -880,68 +880,6 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(layout.trailingTabContentInset, 0)
     }
 
-    func testTabBarKeepsNonOverflowingTabsLeadingAligned() {
-        let tabId = UUID()
-
-        XCTAssertEqual(
-            TabBarStyling.preferredScrollTarget(
-                selectedTabId: tabId,
-                contentWidth: 132,
-                containerWidth: 349
-            ),
-            .leading,
-            "When the tab strip fits in the pane, it should stay leading-aligned instead of creating a dead leading clip-view band"
-        )
-
-        XCTAssertEqual(
-            TabBarStyling.preferredScrollTarget(
-                selectedTabId: tabId,
-                contentWidth: 420,
-                containerWidth: 349
-            ),
-            .selectedTab(tabId),
-            "Overflowing tab strips should still auto-scroll the selected tab into view"
-        )
-    }
-
-    func testTabBarForcesLeadingResetWhenNonOverflowingStripStaysScrolled() {
-        XCTAssertTrue(
-            TabBarStyling.shouldForceResetToLeading(
-                scrollOffset: 28,
-                contentWidth: 180,
-                containerWidth: 349
-            ),
-            "A non-overflowing tab strip with a stale horizontal offset should be snapped back to x=0"
-        )
-
-        XCTAssertTrue(
-            TabBarStyling.shouldForceResetToLeading(
-                scrollOffset: -30,
-                contentWidth: 180,
-                containerWidth: 349
-            ),
-            "The leading reset must correct both left and right stale offsets"
-        )
-
-        XCTAssertFalse(
-            TabBarStyling.shouldForceResetToLeading(
-                scrollOffset: 0.2,
-                contentWidth: 180,
-                containerWidth: 349
-            ),
-            "Tiny floating-point drift should not trigger redundant clip-view resets"
-        )
-
-        XCTAssertFalse(
-            TabBarStyling.shouldForceResetToLeading(
-                scrollOffset: 28,
-                contentWidth: 420,
-                containerWidth: 349
-            ),
-            "Overflowing tab strips are allowed to stay horizontally scrolled"
-        )
-    }
-
     @MainActor
     func testTabBarHitRegionRegistryTracksVisibleWindowPoint() {
         let window = NSWindow(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -4215,6 +4215,10 @@ final class BonsplitTests: XCTestCase {
                 XCTFail("Expected tab bar scroll view for manual scroll regression")
                 return nil
             }
+            NotificationCenter.default.post(
+                name: NSScrollView.willStartLiveScrollNotification,
+                object: scrollView
+            )
             scrollView.contentView.scroll(to: NSPoint(x: 96, y: 0))
             scrollView.reflectScrolledClipView(scrollView.contentView)
             hostingView.layoutSubtreeIfNeeded()

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3129,14 +3129,22 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testSelectedTabIndicatorDoesNotBleedUnderSplitButtonBackdrop() {
+    func testSelectedTabIndicatorFadesWithTabContentBeforeSplitButtonBackdrop() {
         guard let brightnesses = renderedSelectedIndicatorBackdropBrightnesses() else {
             XCTFail("Expected rendered selected indicator backdrop colors")
             return
         }
 
-        XCTAssertLessThan(brightnesses.leading, 0.08)
-        XCTAssertLessThan(brightnesses.trailing, 0.08)
+        XCTAssertGreaterThan(
+            brightnesses.leading,
+            0.2,
+            "The indicator should remain visible where the selected tab begins fading under the action-lane chrome."
+        )
+        XCTAssertLessThan(
+            brightnesses.trailing,
+            brightnesses.leading - 0.1,
+            "The indicator should use the tab content's right-edge fade instead of stopping at a different x-position."
+        )
     }
 
     @MainActor

--- a/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
+++ b/Tests/BonsplitTests/TabBarLayoutFeedbackTests.swift
@@ -58,6 +58,10 @@ final class TabBarLayoutFeedbackTests: XCTestCase {
         )
         XCTAssertGreaterThan(maximumOffset, 0)
 
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification,
+            object: scrollView
+        )
         for step in 1...8 {
             let offset = maximumOffset * CGFloat(step) / 8
             scrollView.contentView.scroll(to: NSPoint(x: offset, y: 0))

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -5,6 +5,94 @@ import XCTest
 
 @MainActor
 final class TabBarResizeAnchorTests: XCTestCase {
+    func testSelectedOverflowTabTracksLiveGeometryAndFullyRevealsChrome() throws {
+        let harness = try makeTabBarHarness(
+            initialSize: NSSize(width: 520, height: TabBarMetrics.barHeight),
+            tabCount: 3,
+            selectedIndex: 0
+        )
+        defer { harness.window.orderOut(nil) }
+
+        let scrollView = try tabBarScrollView(in: harness.hostingView)
+        let chromeView = try XCTUnwrap(
+            descendants(
+                ofType: TabBarSelectionChromeView.ChromeNSView.self,
+                in: harness.hostingView
+            ).first
+        )
+        XCTAssertEqual(maxHorizontalOffset(in: scrollView), 0, accuracy: 0.5)
+        XCTAssertEqual(scrollView.contentView.bounds.origin.x, 0, accuracy: 0.5)
+
+        let newTab = TabItem(
+            title: "New browser tab",
+            icon: "globe",
+            kind: "browser"
+        )
+        harness.pane.addTab(newTab)
+
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            guard chromeView.selectedTabId == newTab.id,
+                  let selectedFrame = chromeView.geometryRegistry?.frame(
+                    for: newTab.id,
+                    in: chromeView
+                  ) else {
+                return false
+            }
+            return selectedFrame.minX >= chromeView.bounds.minX - 0.5
+                && selectedFrame.maxX <= chromeView.bounds.maxX + 0.5
+        }
+
+        let initialSelectedFrame = try XCTUnwrap(
+            chromeView.geometryRegistry?.frame(for: newTab.id, in: chromeView)
+        )
+        let newTabIndex = try XCTUnwrap(
+            harness.pane.tabs.firstIndex(where: { $0.id == newTab.id })
+        )
+        harness.pane.tabs[newTabIndex].title = String(repeating: "Long browser title ", count: 8)
+
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            guard let selectedFrame = chromeView.geometryRegistry?.frame(
+                for: newTab.id,
+                in: chromeView
+            ) else {
+                return false
+            }
+            return selectedFrame.width > initialSelectedFrame.width + 1
+                && selectedFrame.minX >= chromeView.bounds.minX - 0.5
+                && selectedFrame.maxX <= chromeView.bounds.maxX + 0.5
+        }
+
+        let selectedFrame = try XCTUnwrap(
+            chromeView.geometryRegistry?.frame(for: newTab.id, in: chromeView)
+        )
+        XCTAssertEqual(chromeView.selectedTabId, newTab.id)
+        XCTAssertGreaterThan(
+            selectedFrame.width,
+            initialSelectedFrame.width + 1,
+            "The regression requires the selected browser tab's live frame to grow."
+        )
+        XCTAssertGreaterThan(
+            maxHorizontalOffset(in: scrollView),
+            0,
+            "The test must transition the tab strip from fitting to overflowing."
+        )
+        XCTAssertGreaterThan(
+            scrollView.contentView.bounds.origin.x,
+            0,
+            "Selecting a newly inserted overflow tab must move the live AppKit viewport."
+        )
+        XCTAssertGreaterThanOrEqual(
+            selectedFrame.minX,
+            chromeView.bounds.minX - 0.5,
+            "The selected tab and its selection chrome must not be clipped at the leading edge."
+        )
+        XCTAssertLessThanOrEqual(
+            selectedFrame.maxX,
+            chromeView.bounds.maxX + 0.5,
+            "The selected tab and its selection chrome must not be clipped at the trailing edge."
+        )
+    }
+
     func testViewportResizeKeepsLeadingAnchoredWhenTabStripWasLeadingAligned() throws {
         let harness = try makeTabBarHarness(
             initialSize: NSSize(width: 900, height: TabBarMetrics.barHeight),
@@ -112,6 +200,7 @@ final class TabBarResizeAnchorTests: XCTestCase {
     private struct TabBarHarness {
         let window: NSWindow
         let hostingView: NSView
+        let pane: PaneState
     }
 
     private func makeTabBarHarness(
@@ -154,7 +243,7 @@ final class TabBarResizeAnchorTests: XCTestCase {
             tabBarScrollViews(in: hostingView).count == 1
         }
 
-        return TabBarHarness(window: window, hostingView: hostingView)
+        return TabBarHarness(window: window, hostingView: hostingView, pane: pane)
     }
 
     private func settleLayout(

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -386,6 +386,10 @@ final class TabBarResizeAnchorTests: XCTestCase {
         DispatchQueue.main.async {
             let validOffset = self.maxHorizontalOffset(in: scrollView) / 2
             laterValidOffset = validOffset
+            NotificationCenter.default.post(
+                name: NSScrollView.willStartLiveScrollNotification,
+                object: scrollView
+            )
             scrollView.contentView.scroll(to: NSPoint(x: validOffset, y: 0))
             scrollView.reflectScrolledClipView(scrollView.contentView)
             laterScrollApplied.fulfill()

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -138,6 +138,82 @@ final class TabBarResizeAnchorTests: XCTestCase {
         )
     }
 
+    func testSelectingTabBehindActionLaneRevealsItsCloseAffordance() throws {
+        let harness = try makeTabBarHarness(
+            initialSize: NSSize(width: 520, height: TabBarMetrics.barHeight),
+            tabCount: 4,
+            selectedIndex: 0,
+            showSplitButtons: true
+        )
+        defer { harness.window.orderOut(nil) }
+
+        let scrollView = try tabBarScrollView(in: harness.hostingView)
+        let chromeView = try XCTUnwrap(
+            descendants(
+                ofType: TabBarSelectionChromeView.ChromeNSView.self,
+                in: harness.hostingView
+            ).first
+        )
+        let targetTab = try XCTUnwrap(harness.pane.tabs.last)
+        let actionLaneWidth = TabBarStyling.splitButtonsBackdropWidth(
+            buttonCount: BonsplitConfiguration.SplitActionButton.defaults.count
+        )
+        let unobscuredMaxX = chromeView.bounds.maxX - actionLaneWidth
+
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            guard maxHorizontalOffset(in: scrollView) > 0,
+                  let targetFrame = chromeView.geometryRegistry?.frame(
+                    for: targetTab.id,
+                    in: chromeView
+                  ) else {
+                return false
+            }
+            return targetFrame.maxX > unobscuredMaxX + 1
+                && targetFrame.maxX <= chromeView.bounds.maxX + 0.5
+        }
+
+        let obscuredFrame = try XCTUnwrap(
+            chromeView.geometryRegistry?.frame(for: targetTab.id, in: chromeView)
+        )
+        XCTAssertGreaterThan(
+            obscuredFrame.maxX,
+            unobscuredMaxX + 1,
+            "The regression requires the target tab's trailing close affordance to begin behind the action lane."
+        )
+        XCTAssertLessThanOrEqual(
+            obscuredFrame.maxX,
+            chromeView.bounds.maxX + 0.5,
+            "The target must still be inside the raw clip view so the test distinguishes occlusion from ordinary clipping."
+        )
+        let initialOffset = scrollView.contentView.bounds.origin.x
+
+        harness.pane.selectTab(targetTab.id)
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            guard chromeView.selectedTabId == targetTab.id,
+                  let selectedFrame = chromeView.geometryRegistry?.frame(
+                    for: targetTab.id,
+                    in: chromeView
+                  ) else {
+                return false
+            }
+            return selectedFrame.maxX <= unobscuredMaxX + 0.5
+        }
+
+        let selectedFrame = try XCTUnwrap(
+            chromeView.geometryRegistry?.frame(for: targetTab.id, in: chromeView)
+        )
+        XCTAssertGreaterThan(
+            scrollView.contentView.bounds.origin.x,
+            initialOffset + 0.5,
+            "Selecting a tab under the action lane must shift the strip to expose its trailing controls."
+        )
+        XCTAssertLessThanOrEqual(
+            selectedFrame.maxX,
+            unobscuredMaxX + 0.5,
+            "The selected tab, including its close affordance, must end before the action lane begins."
+        )
+    }
+
     func testViewportResizeKeepsLeadingAnchoredWhenTabStripWasLeadingAligned() throws {
         let harness = try makeTabBarHarness(
             initialSize: NSSize(width: 900, height: TabBarMetrics.barHeight),
@@ -280,7 +356,8 @@ final class TabBarResizeAnchorTests: XCTestCase {
     private func makeTabBarHarness(
         initialSize: NSSize,
         tabCount: Int,
-        selectedIndex: Int
+        selectedIndex: Int,
+        showSplitButtons: Bool = false
     ) throws -> TabBarHarness {
         let controller = BonsplitController(configuration: BonsplitConfiguration(appearance: .default))
         controller.tabShortcutHintsEnabled = false
@@ -293,7 +370,7 @@ final class TabBarResizeAnchorTests: XCTestCase {
         pane.selectedTabId = tabs[selectedIndex].id
 
         let hostingView = NSHostingView(
-            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: false)
+            rootView: TabBarView(pane: pane, isFocused: true, showSplitButtons: showSplitButtons)
                 .environment(controller)
                 .environment(controller.internalController)
         )
@@ -344,14 +421,19 @@ final class TabBarResizeAnchorTests: XCTestCase {
         line: UInt = #line
     ) throws -> NSScrollView {
         let matches = tabBarScrollViews(in: root)
+        let widestWidth = matches.map(\.frame.width).max()
+        let widestMatches = matches.filter { scrollView in
+            guard let widestWidth else { return false }
+            return abs(scrollView.frame.width - widestWidth) <= 0.5
+        }
         XCTAssertEqual(
-            matches.count,
+            widestMatches.count,
             1,
             "The harness should expose exactly one tab-bar-sized scroll view.",
             file: file,
             line: line
         )
-        return try XCTUnwrap(matches.first, file: file, line: line)
+        return try XCTUnwrap(widestMatches.first, file: file, line: line)
     }
 
     private func tabBarScrollViews(in root: NSView) -> [NSScrollView] {

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -93,6 +93,51 @@ final class TabBarResizeAnchorTests: XCTestCase {
         )
     }
 
+    func testSelectedTabStaysRevealedWhenEarlierTabGrowthMovesItsLiveFrame() throws {
+        let harness = try makeTabBarHarness(
+            initialSize: NSSize(width: 520, height: TabBarMetrics.barHeight),
+            tabCount: 4,
+            selectedIndex: 3
+        )
+        defer { harness.window.orderOut(nil) }
+
+        let scrollView = try tabBarScrollView(in: harness.hostingView)
+        let chromeView = try XCTUnwrap(
+            descendants(
+                ofType: TabBarSelectionChromeView.ChromeNSView.self,
+                in: harness.hostingView
+            ).first
+        )
+        let selectedTabId = try XCTUnwrap(harness.pane.selectedTabId)
+        XCTAssertEqual(maxHorizontalOffset(in: scrollView), 0, accuracy: 0.5)
+
+        harness.pane.tabs[0].title = String(repeating: "Long earlier title ", count: 8)
+
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            guard maxHorizontalOffset(in: scrollView) > 0,
+                  let selectedFrame = chromeView.geometryRegistry?.frame(
+                    for: selectedTabId,
+                    in: chromeView
+                  ) else {
+                return false
+            }
+            return scrollView.contentView.bounds.origin.x > 0
+                && selectedFrame.minX >= chromeView.bounds.minX - 0.5
+                && selectedFrame.maxX <= chromeView.bounds.maxX + 0.5
+        }
+
+        let selectedFrame = try XCTUnwrap(
+            chromeView.geometryRegistry?.frame(for: selectedTabId, in: chromeView)
+        )
+        XCTAssertGreaterThan(scrollView.contentView.bounds.origin.x, 0)
+        XCTAssertGreaterThanOrEqual(selectedFrame.minX, chromeView.bounds.minX - 0.5)
+        XCTAssertLessThanOrEqual(
+            selectedFrame.maxX,
+            chromeView.bounds.maxX + 0.5,
+            "A sibling layout change must keep scrolling and selection chrome on the same live frame."
+        )
+    }
+
     func testViewportResizeKeepsLeadingAnchoredWhenTabStripWasLeadingAligned() throws {
         let harness = try makeTabBarHarness(
             initialSize: NSSize(width: 900, height: TabBarMetrics.barHeight),
@@ -153,7 +198,36 @@ final class TabBarResizeAnchorTests: XCTestCase {
         )
     }
 
-    func testAsyncClampRetryDoesNotUndoLaterValidOffset() async throws {
+    func testContentShrinkReturnsFittingStripToLeadingEdge() throws {
+        let harness = try makeTabBarHarness(
+            initialSize: NSSize(width: 360, height: TabBarMetrics.barHeight),
+            tabCount: 8,
+            selectedIndex: 0
+        )
+        defer { harness.window.orderOut(nil) }
+
+        let scrollView = try tabBarScrollView(in: harness.hostingView)
+        let initialMaxOffset = maxHorizontalOffset(in: scrollView)
+        XCTAssertGreaterThan(initialMaxOffset, 0)
+        scrollView.contentView.scroll(to: NSPoint(x: initialMaxOffset, y: 0))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        harness.pane.tabs = Array(harness.pane.tabs.prefix(2))
+        settleLayout(in: harness.window, hostingView: harness.hostingView) {
+            maxHorizontalOffset(in: scrollView) <= 0.5
+                && abs(scrollView.contentView.bounds.origin.x) <= 0.5
+        }
+
+        XCTAssertEqual(maxHorizontalOffset(in: scrollView), 0, accuracy: 0.5)
+        XCTAssertEqual(
+            scrollView.contentView.bounds.origin.x,
+            0,
+            accuracy: 0.5,
+            "A strip that stops overflowing must not retain a stale clip-view offset."
+        )
+    }
+
+    func testViewportResizeDoesNotUndoLaterValidOffset() async throws {
         let harness = try makeTabBarHarness(
             initialSize: NSSize(width: 240, height: TabBarMetrics.barHeight),
             tabCount: 8,

--- a/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
+++ b/Tests/BonsplitTests/TabBarResizeAnchorTests.swift
@@ -5,6 +5,69 @@ import XCTest
 
 @MainActor
 final class TabBarResizeAnchorTests: XCTestCase {
+    func testPendingSelectionReconcilesWhenScrollViewAttaches() throws {
+        let harness = try makeGeometryRegistryHarness()
+        defer { harness.window.orderOut(nil) }
+
+        harness.registry.register(harness.selectedView, for: harness.selectedTabId)
+        harness.registry.revealSelection(harness.selectedTabId)
+        XCTAssertEqual(harness.scrollView.contentView.bounds.origin.x, 0, accuracy: 0.5)
+
+        harness.registry.attachScrollView(harness.scrollView)
+
+        XCTAssertGreaterThan(
+            harness.scrollView.contentView.bounds.origin.x,
+            0,
+            "Attaching live AppKit geometry must resume a selected-tab reveal that was pending before the scroll view existed."
+        )
+    }
+
+    func testProgrammaticRevealSurvivesLaterBoundsOriginRestoration() throws {
+        let harness = try makeGeometryRegistryHarness()
+        defer { harness.window.orderOut(nil) }
+
+        harness.registry.attachScrollView(harness.scrollView)
+        harness.registry.register(harness.selectedView, for: harness.selectedTabId)
+        harness.registry.revealSelection(harness.selectedTabId)
+        let revealedOffset = harness.scrollView.contentView.bounds.origin.x
+        XCTAssertGreaterThan(revealedOffset, 0)
+
+        harness.scrollView.contentView.scroll(to: .zero)
+        harness.scrollView.reflectScrolledClipView(harness.scrollView.contentView)
+
+        XCTAssertEqual(
+            harness.scrollView.contentView.bounds.origin.x,
+            revealedOffset,
+            accuracy: 0.5,
+            "A later SwiftUI bounds-origin restoration must not overwrite the registry's selected-tab reveal."
+        )
+    }
+
+    func testLiveUserScrollRelinquishesProgrammaticOffsetOwnership() throws {
+        let harness = try makeGeometryRegistryHarness()
+        defer { harness.window.orderOut(nil) }
+
+        harness.registry.attachScrollView(harness.scrollView)
+        harness.registry.register(harness.selectedView, for: harness.selectedTabId)
+        harness.registry.revealSelection(harness.selectedTabId)
+        XCTAssertGreaterThan(harness.scrollView.contentView.bounds.origin.x, 0)
+
+        NotificationCenter.default.post(
+            name: NSScrollView.willStartLiveScrollNotification,
+            object: harness.scrollView
+        )
+        let userOffset: CGFloat = 120
+        harness.scrollView.contentView.scroll(to: NSPoint(x: userOffset, y: 0))
+        harness.scrollView.reflectScrolledClipView(harness.scrollView.contentView)
+
+        XCTAssertEqual(
+            harness.scrollView.contentView.bounds.origin.x,
+            userOffset,
+            accuracy: 0.5,
+            "An intentional live user scroll must replace any earlier programmatic reveal target."
+        )
+    }
+
     func testSelectedOverflowTabTracksLiveGeometryAndFullyRevealsChrome() throws {
         let harness = try makeTabBarHarness(
             initialSize: NSSize(width: 520, height: TabBarMetrics.barHeight),
@@ -351,6 +414,47 @@ final class TabBarResizeAnchorTests: XCTestCase {
         let window: NSWindow
         let hostingView: NSView
         let pane: PaneState
+    }
+
+    private struct GeometryRegistryHarness {
+        let window: NSWindow
+        let scrollView: NSScrollView
+        let selectedView: NSView
+        let selectedTabId: UUID
+        let registry: TabBarItemGeometryRegistry
+    }
+
+    private func makeGeometryRegistryHarness() throws -> GeometryRegistryHarness {
+        let viewportSize = NSSize(width: 200, height: TabBarMetrics.barHeight)
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: viewportSize),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = try XCTUnwrap(window.contentView)
+        let scrollView = NSScrollView(frame: NSRect(origin: .zero, size: viewportSize))
+        let documentView = NSView(
+            frame: NSRect(x: 0, y: 0, width: 600, height: viewportSize.height)
+        )
+        let selectedView = NSView(
+            frame: NSRect(x: 480, y: 0, width: 100, height: viewportSize.height)
+        )
+        let selectedTabId = UUID()
+        let registry = TabBarItemGeometryRegistry()
+
+        documentView.addSubview(selectedView)
+        scrollView.documentView = documentView
+        contentView.addSubview(scrollView)
+        window.makeKeyAndOrderFront(nil)
+
+        return GeometryRegistryHarness(
+            window: window,
+            scrollView: scrollView,
+            selectedView: selectedView,
+            selectedTabId: selectedTabId,
+            registry: registry
+        )
     }
 
     private func makeTabBarHarness(


### PR DESCRIPTION
## Summary
- make the MainActor AppKit geometry registry the single owner of live tab frames, selected-tab reveal scrolling, and selection chrome geometry
- define selection visibility against the unobscured viewport so the right action lane cannot hide the selected tab title or close button
- restore the shared right-edge fade used by both tab content and the blue active indicator
- remove the competing SwiftUI ScrollViewProxy, clip-view bridge, and queued correction path
- preserve leading alignment and clamp offsets when content or the viewport shrinks
- preserve programmatic reveal ownership through layout-driven clip-view bounds changes, while relinquishing it when live user scrolling begins

## Regression coverage
- 9da2852 adds the original overflow-selection regression before the geometry-authority fix
- 3dcae1b adds a failing action-lane test proving a tab can be inside the raw clip view while its close affordance is hidden
- 848bd04 adds a failing rendered-pixel test proving the indicator hard-stops before the tab-content fade
- 033997e adds failing lifecycle tests for late scroll-view attachment and SwiftUI restoring a stale clip offset
- f647ae3 preserves pending reveal intent through attachment/layout and makes the lifecycle regressions pass
- verifies selected-tab growth, earlier-sibling growth, action-lane visibility, indicator fade alignment, resize clamping, fitting-content leading reset, and user-scroll ownership handoff

## Verification
- arch -arm64 swift test: 197 tests passed

Paired cmux PR: https://github.com/manaflow-ai/cmux/pull/8071

Related: manaflow-ai/cmux#8069