### PR TITLE
Name the default fork destination in tab menus

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -691,7 +691,6 @@ struct TabContextMenuState {
     let canMoveToNewWorkspace: Bool
     let canMoveToLeftPane: Bool
     let canMoveToRightPane: Bool
-    var canForkConversation: Bool
     let forkConversationDefaultAction: TabContextAction
     let isZoomed: Bool
     let isFullWidthTabMode: Bool
@@ -720,7 +719,6 @@ struct TabContextMenuState {
         canMoveToNewWorkspace: Bool,
         canMoveToLeftPane: Bool,
         canMoveToRightPane: Bool,
-        canForkConversation: Bool,
         forkConversationDefaultAction: TabContextAction,
         isZoomed: Bool,
         isFullWidthTabMode: Bool = false,
@@ -740,7 +738,6 @@ struct TabContextMenuState {
         self.canMoveToNewWorkspace = canMoveToNewWorkspace
         self.canMoveToLeftPane = canMoveToLeftPane
         self.canMoveToRightPane = canMoveToRightPane
-        self.canForkConversation = canForkConversation
         self.forkConversationDefaultAction = forkConversationDefaultAction
         self.isZoomed = isZoomed
         self.isFullWidthTabMode = isFullWidthTabMode
@@ -783,7 +780,6 @@ struct TabContextMenuState {
             canMoveToNewWorkspace: controller.allTabIds.count > 1,
             canMoveToLeftPane: controller.adjacentPane(to: pane.id, direction: .left) != nil,
             canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
-            canForkConversation: controller.tabContextForkConversationAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false,
             forkConversationDefaultAction: controller.tabContextForkConversationDefaultActionProvider?(TabID(id: tab.id), pane.id) ?? .defaultForkConversationDestination,
             isZoomed: splitViewController.zoomedPaneId == pane.id,
             isFullWidthTabMode: pane.isFullWidthTabMode,
@@ -1245,8 +1241,8 @@ struct TabBarView: View {
             moveDestinationsProvider: {
                 controller.tabContextMoveDestinationsProvider?(TabID(id: tab.id), pane.id) ?? []
             },
-            forkConversationOpenAvailabilityProvider: {
-                controller.tabContextForkConversationOpenAvailabilityProvider?(TabID(id: tab.id), pane.id)
+            forkConversationAvailabilityProvider: {
+                controller.tabContextForkConversationAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? .hidden
             },
             onSelect: {
                 // Tab selection must be instant. Animating this transaction causes the pane

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1449,7 +1449,7 @@ enum TabContextMenuBuilder {
         if state.canForkConversation {
             menu.addItem(.separator())
             addAction(
-                title: localized("tabContext.forkConversation", defaultValue: "Fork Conversation"),
+                title: forkConversationDefaultTitle(for: state.forkConversationDefaultAction),
                 action: .forkConversation,
                 enabled: forkConversationEnabled,
                 state: state,
@@ -1697,6 +1697,47 @@ enum TabContextMenuBuilder {
         item.submenu = submenu
         item.isEnabled = enabled
         return item
+    }
+
+    private static func forkConversationDefaultTitle(for action: TabContextAction) -> String {
+        switch action {
+        case .forkConversationLeft:
+            return localized(
+                "tabContext.forkConversation.default.left",
+                defaultValue: "Fork Conversation to the Left"
+            )
+        case .forkConversationTop:
+            return localized(
+                "tabContext.forkConversation.default.top",
+                defaultValue: "Fork Conversation to the Top"
+            )
+        case .forkConversationBottom:
+            return localized(
+                "tabContext.forkConversation.default.bottom",
+                defaultValue: "Fork Conversation to the Bottom"
+            )
+        case .forkConversationNewTab:
+            return localized(
+                "tabContext.forkConversation.default.newTab",
+                defaultValue: "Fork Conversation to New Tab"
+            )
+        case .forkConversationNewWorkspace:
+            return localized(
+                "tabContext.forkConversation.default.newWorkspace",
+                defaultValue: "Fork Conversation to New Workspace"
+            )
+        case .forkConversationRight,
+             .forkConversation:
+            return localized(
+                "tabContext.forkConversation.default.right",
+                defaultValue: "Fork Conversation to the Right"
+            )
+        default:
+            return localized(
+                "tabContext.forkConversation.default.right",
+                defaultValue: "Fork Conversation to the Right"
+            )
+        }
     }
 
     @discardableResult

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -285,7 +285,7 @@ struct TabItemView: View {
     let allowsContextMenu: Bool
     let contextMenuState: TabContextMenuState
     let moveDestinationsProvider: () -> [TabContextMoveDestination]
-    let forkConversationOpenAvailabilityProvider: () -> Bool?
+    let forkConversationAvailabilityProvider: () -> TabContextForkConversationAvailability
     let onSelect: () -> Void
     let onClose: (TabCloseRequestSource) -> Void
     let onZoomToggle: () -> Void
@@ -351,7 +351,7 @@ struct TabItemView: View {
                         tabId: tab.id,
                         state: contextMenuState,
                         moveDestinationsProvider: moveDestinationsProvider,
-                        forkConversationOpenAvailabilityProvider: forkConversationOpenAvailabilityProvider
+                        forkConversationAvailabilityProvider: forkConversationAvailabilityProvider
                     ),
                     onContextAction: onContextAction,
                     onMoveDestination: onMoveDestination
@@ -1347,7 +1347,7 @@ struct TabContextMenuSnapshot {
     let tabId: UUID
     let state: TabContextMenuState
     let moveDestinationsProvider: () -> [TabContextMoveDestination]
-    let forkConversationOpenAvailabilityProvider: () -> Bool?
+    let forkConversationAvailabilityProvider: () -> TabContextForkConversationAvailability
 }
 
 final class TabContextMenuActionTarget: NSObject {
@@ -1373,10 +1373,9 @@ enum TabContextMenuBuilder {
         snapshot: TabContextMenuSnapshot,
         target: TabContextMenuActionTarget
     ) -> NSMenu {
-        var state = snapshot.state
-        let canForkConversationAtOpen = snapshot.forkConversationOpenAvailabilityProvider()
-        let forkConversationEnabled = canForkConversationAtOpen ?? state.canForkConversation
-        state.canForkConversation = state.canForkConversation || forkConversationEnabled
+        let state = snapshot.state
+        let forkConversationAvailability = snapshot.forkConversationAvailabilityProvider()
+        let forkConversationEnabled = forkConversationAvailability == .available
         let menu = NSMenu()
         menu.autoenablesItems = false
 
@@ -1446,7 +1445,7 @@ enum TabContextMenuBuilder {
             )
         }
 
-        if state.canForkConversation {
+        if forkConversationAvailability != .hidden {
             menu.addItem(.separator())
             addAction(
                 title: forkConversationDefaultTitle(for: state.forkConversationDefaultAction),

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -77,13 +77,9 @@ public final class BonsplitController {
     /// Host-provided destinations for the tab context menu's Move Tab submenu.
     @ObservationIgnored public var tabContextMoveDestinationsProvider: ((TabID, PaneID) -> [TabContextMoveDestination])?
 
-    /// Host-provided synchronous check that decides whether the tab context menu should
-    /// surface a "Fork Conversation" action for the tab (e.g. an active forkable agent
-    /// session). Return `true` to enable the item, `false` (or omit the provider) to hide it.
-    @ObservationIgnored public var tabContextForkConversationAvailabilityProvider: ((TabID, PaneID) -> Bool)?
-
-    /// Host-provided check evaluated only when the tab context menu is opening.
-    @ObservationIgnored public var tabContextForkConversationOpenAvailabilityProvider: ((TabID, PaneID) -> Bool)?
+    /// Host-provided state evaluated when the tab context menu opens. Refreshing actions
+    /// remain visible but disabled; hidden actions are omitted.
+    @ObservationIgnored public var tabContextForkConversationAvailabilityProvider: ((TabID, PaneID) -> TabContextForkConversationAvailability)?
 
     /// Host-provided default destination for the tab context menu's primary "Fork
     /// Conversation" action. Return a destination-specific fork action; invalid values

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+/// Presentation state for a host-provided Fork Conversation tab action.
+public enum TabContextForkConversationAvailability: Sendable {
+    case hidden
+    case refreshing
+    case available
+}
+
 /// Context menu actions that can be triggered from a tab item.
 public enum TabContextAction: String, CaseIterable, Sendable {
     case rename

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -26,6 +26,12 @@
 "tabContext.markTabAsRead" = "Mark Tab as Read";
 "tabContext.markTabAsUnread" = "Mark Tab as Unread";
 "tabContext.forkConversation" = "Fork Conversation";
+"tabContext.forkConversation.default.right" = "Fork Conversation to the Right";
+"tabContext.forkConversation.default.left" = "Fork Conversation to the Left";
+"tabContext.forkConversation.default.top" = "Fork Conversation to the Top";
+"tabContext.forkConversation.default.bottom" = "Fork Conversation to the Bottom";
+"tabContext.forkConversation.default.newTab" = "Fork Conversation to New Tab";
+"tabContext.forkConversation.default.newWorkspace" = "Fork Conversation to New Workspace";
 "tabContext.forkConversationTo" = "Fork Conversation To";
 "tabContext.forkConversation.right" = "Right Split";
 "tabContext.forkConversation.left" = "Left Split";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -26,6 +26,12 @@
 "tabContext.markTabAsRead" = "タブを既読にする";
 "tabContext.markTabAsUnread" = "タブを未読にする";
 "tabContext.forkConversation" = "会話をフォーク";
+"tabContext.forkConversation.default.right" = "会話を右にフォーク";
+"tabContext.forkConversation.default.left" = "会話を左にフォーク";
+"tabContext.forkConversation.default.top" = "会話を上にフォーク";
+"tabContext.forkConversation.default.bottom" = "会話を下にフォーク";
+"tabContext.forkConversation.default.newTab" = "会話を新しいタブにフォーク";
+"tabContext.forkConversation.default.newWorkspace" = "会話を新しいワークスペースにフォーク";
 "tabContext.forkConversationTo" = "会話のフォーク先";
 "tabContext.forkConversation.right" = "右分割";
 "tabContext.forkConversation.left" = "左分割";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1831,7 +1831,6 @@ final class BonsplitTests: XCTestCase {
             canMoveToNewWorkspace: true,
             canMoveToLeftPane: false,
             canMoveToRightPane: true,
-            canForkConversation: false,
             forkConversationDefaultAction: .forkConversationRight,
             isZoomed: false,
             hasSplits: true,
@@ -1847,7 +1846,7 @@ final class BonsplitTests: XCTestCase {
                     TabContextMoveDestination(id: "workspace:abc", title: "Workspace A", isEnabled: false)
                 ]
             },
-            forkConversationOpenAvailabilityProvider: { nil }
+            forkConversationAvailabilityProvider: { .hidden }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1888,14 +1887,13 @@ final class BonsplitTests: XCTestCase {
                 canMoveToNewWorkspace: false,
                 canMoveToLeftPane: false,
                 canMoveToRightPane: false,
-                canForkConversation: false,
                 forkConversationDefaultAction: .forkConversationRight,
                 isZoomed: false,
                 hasSplits: false,
                 shortcuts: [:]
             ),
             moveDestinationsProvider: { [] },
-            forkConversationOpenAvailabilityProvider: { nil }
+            forkConversationAvailabilityProvider: { .hidden }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1923,14 +1921,13 @@ final class BonsplitTests: XCTestCase {
                 canMoveToNewWorkspace: false,
                 canMoveToLeftPane: false,
                 canMoveToRightPane: false,
-                canForkConversation: false,
                 forkConversationDefaultAction: .forkConversationRight,
                 isZoomed: false,
                 hasSplits: false,
                 shortcuts: [:]
             ),
             moveDestinationsProvider: { [] },
-            forkConversationOpenAvailabilityProvider: { nil }
+            forkConversationAvailabilityProvider: { .hidden }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1959,7 +1956,6 @@ final class BonsplitTests: XCTestCase {
                 canMoveToNewWorkspace: false,
                 canMoveToLeftPane: false,
                 canMoveToRightPane: false,
-                canForkConversation: false,
                 forkConversationDefaultAction: .forkConversationRight,
                 isZoomed: false,
                 isFullWidthTabMode: false,
@@ -1967,7 +1963,7 @@ final class BonsplitTests: XCTestCase {
                 shortcuts: [:]
             ),
             moveDestinationsProvider: { [] },
-            forkConversationOpenAvailabilityProvider: { nil }
+            forkConversationAvailabilityProvider: { .hidden }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -1996,7 +1992,6 @@ final class BonsplitTests: XCTestCase {
                 canMoveToNewWorkspace: false,
                 canMoveToLeftPane: false,
                 canMoveToRightPane: false,
-                canForkConversation: false,
                 forkConversationDefaultAction: .forkConversationRight,
                 isZoomed: false,
                 isFullWidthTabMode: true,
@@ -2004,7 +1999,7 @@ final class BonsplitTests: XCTestCase {
                 shortcuts: [:]
             ),
             moveDestinationsProvider: { [] },
-            forkConversationOpenAvailabilityProvider: { nil }
+            forkConversationAvailabilityProvider: { .hidden }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -2031,7 +2026,6 @@ final class BonsplitTests: XCTestCase {
             canMoveToNewWorkspace: false,
             canMoveToLeftPane: false,
             canMoveToRightPane: false,
-            canForkConversation: true,
             forkConversationDefaultAction: .forkConversationLeft,
             isZoomed: false,
             hasSplits: false,
@@ -2041,7 +2035,7 @@ final class BonsplitTests: XCTestCase {
             tabId: UUID(),
             state: state,
             moveDestinationsProvider: { [] },
-            forkConversationOpenAvailabilityProvider: { nil }
+            forkConversationAvailabilityProvider: { .available }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -2078,7 +2072,6 @@ final class BonsplitTests: XCTestCase {
             canMoveToNewWorkspace: false,
             canMoveToLeftPane: false,
             canMoveToRightPane: false,
-            canForkConversation: false,
             forkConversationDefaultAction: .forkConversationLeft,
             isZoomed: false,
             hasSplits: false,
@@ -2088,7 +2081,7 @@ final class BonsplitTests: XCTestCase {
             tabId: UUID(),
             state: state,
             moveDestinationsProvider: { [] },
-            forkConversationOpenAvailabilityProvider: { false }
+            forkConversationAvailabilityProvider: { .refreshing }
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
@@ -2120,7 +2113,6 @@ final class BonsplitTests: XCTestCase {
                 canMoveToNewWorkspace: false,
                 canMoveToLeftPane: false,
                 canMoveToRightPane: false,
-                canForkConversation: false,
                 forkConversationDefaultAction: .forkConversationRight,
                 isZoomed: false,
                 hasSplits: false,
@@ -2134,7 +2126,7 @@ final class BonsplitTests: XCTestCase {
                 tabId: UUID(),
                 state: makeState(canDisconnectRemote: false),
                 moveDestinationsProvider: { [] },
-                forkConversationOpenAvailabilityProvider: { true }
+                forkConversationAvailabilityProvider: { .available }
             ),
             target: target
         )
@@ -2145,7 +2137,7 @@ final class BonsplitTests: XCTestCase {
                 tabId: UUID(),
                 state: makeState(canDisconnectRemote: true),
                 moveDestinationsProvider: { [] },
-                forkConversationOpenAvailabilityProvider: { true }
+                forkConversationAvailabilityProvider: { .available }
             ),
             target: target
         )

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2045,7 +2045,7 @@ final class BonsplitTests: XCTestCase {
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
-        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation" })
+        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation to the Left" })
         target.performContextAction(forkItem)
         XCTAssertEqual(selectedAction, .forkConversation)
 
@@ -2092,7 +2092,7 @@ final class BonsplitTests: XCTestCase {
         )
 
         let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
-        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation" })
+        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation to the Left" })
         let forkSubmenuItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation To" })
         let destinationItems = try XCTUnwrap(forkSubmenuItem.submenu?.items.filter { !$0.isSeparatorItem })
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2078,7 +2078,7 @@ final class BonsplitTests: XCTestCase {
             canMoveToNewWorkspace: false,
             canMoveToLeftPane: false,
             canMoveToRightPane: false,
-            canForkConversation: true,
+            canForkConversation: false,
             forkConversationDefaultAction: .forkConversationLeft,
             isZoomed: false,
             hasSplits: false,


### PR DESCRIPTION
The primary tab context-menu action now names its configured destination, such as “Fork Conversation to the Right”. The existing destination submenu remains available.

Tests: `swift test --filter 'BonsplitTests.testTabContextMenuBuilderCreatesForkConversationSubmenu|BonsplitTests.testTabContextMenuBuilderKeepsForkConversationVisibleWhenOpenAvailabilityIsRefreshing'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786700606&installation_id=133855650&pr_number=184&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F184&signature=4df59c882c8379651b780b0dc4b1b098dbc6897113a196e17be02abe92c16bf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the configured default fork destination in the tab context menu’s primary action (e.g., “Fork Conversation to the Right”). Replace the fork availability APIs with a hidden/refreshing/available state so the item can stay visible but disabled while loading; submenu unchanged and en/ja labels added.

<sup>Written for commit e099cf47788b6fba66468aa7b6d7c6b81ea5b9d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

