### PR TITLE
Make fork destination titles exhaustive

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1731,7 +1731,28 @@ enum TabContextMenuBuilder {
                 "tabContext.forkConversation.default.right",
                 defaultValue: "Fork Conversation to the Right"
             )
-        default:
+        case .rename,
+             .clearName,
+             .copyIdentifiers,
+             .closeToLeft,
+             .closeToRight,
+             .closeOthers,
+             .move,
+             .moveToNewWorkspace,
+             .moveToLeftPane,
+             .moveToRightPane,
+             .newTerminalToRight,
+             .newBrowserToRight,
+             .reload,
+             .duplicate,
+             .toggleAudioMute,
+             .togglePin,
+             .markAsRead,
+             .markAsUnread,
+             .toggleZoom,
+             .toggleFullWidthTab,
+             .disconnectRemote:
+            assertionFailure("Non-fork action cannot be the default fork destination: \(action)")
             return localized(
                 "tabContext.forkConversation.default.right",
                 defaultValue: "Fork Conversation to the Right"


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/bonsplit/pull/184.

Lists every non-fork action explicitly so new `TabContextAction` cases cannot silently inherit the right-side fork label.

Validation: `swift test` (197 tests passed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786702588&installation_id=133855650&pr_number=185&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F185&signature=84d95145ad9a029f31713e3a47a175fa727b44e35429ade7bf47bccb47b6ff3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enumerates all non-fork TabContextAction cases when choosing fork destination titles so they no longer inherit the default "Fork Conversation to the Right" label. Adds an assertion to catch misuse, preventing future actions from silently getting the fork label.

<sup>Written for commit f538d8ad2e5e2cd2d530b957560002d62084e324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

