### PR TITLE
Wait for a layout pass before giving up on the initial divider position

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -364,6 +364,13 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         // alive through its own property — a leak for any split torn down before a
         // layout pass arrives.
         func applyInitialDividerPosition(_ splitView: ThemedSplitView) {
+            // Every entry point here captured THIS split's state: the initial
+            // main-queue probe and each retry parked on afterNextLayout. The
+            // coordinator-reuse reset clears the parked hook, but it cannot
+            // cancel an async probe already in flight — and that probe would
+            // apply the dead split's position AND mark the reused coordinator's
+            // NEW lifecycle applied. Identity, not the applied flag, decides.
+            guard context.coordinator.splitState.id == splitState.id else { return }
             if context.coordinator.didApplyInitialDividerPosition {
                 return
             }

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -3,7 +3,10 @@ import AppKit
 
 private var splitContainerProgrammaticSyncDepth = 0
 
-private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
+/// Internal rather than private so the test target can drive `layout()` directly and
+/// prove the initial divider position waits for a layout pass. See
+/// SplitEntryLayoutEdgeTests.
+class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
     var customDividerColor: NSColor?
 
     /// Identity for external drag coordination (see BonsplitManagedSplitView).

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -403,14 +403,26 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 }
 
                 // Twelve laid-out passes with no width is a split view that cannot
-                // size, not a race. Unhide the pane so it is not lost, and leave the
-                // position unapplied so a later pass with real geometry still sets it
-                // — claiming otherwise is what made this permanent.
-                if animationOrigin != nil, shouldAnimate {
+                // size, not a race. Show the pane rather than lose it, abandon the
+                // entry animation, and keep observing layouts.
+                //
+                // Keep observing, but do NOT reset the counter: the count is what
+                // makes this reach the fallback exactly once, and resetting it would
+                // re-run this whole block every twelve passes. Observation is not the
+                // old budget by another name — the old retry span twelve runloop turns
+                // and then stopped forever, whereas layouts only happen when something
+                // changes, so a view nobody lays out costs nothing and a view that
+                // gains a size gets its position. `didApplyInitialDividerPosition`
+                // ends the observation on the first success.
+                //
+                // Deliberately NOT setting `didApplyInitialDividerPosition` here:
+                // recording a position as applied when it never was is what made a
+                // wrong extent permanent.
+                if shouldAnimate {
                     splitView.arrangedSubviews[newPaneIndex].isHidden = false
                     context.coordinator.isAnimating = false
                 }
-                context.coordinator.initialDividerApplyAttempts = 0
+                context.coordinator.entryAnimationAbandoned = true
                 splitView.afterNextLayout = { [weak splitView] in
                     guard let splitView else { return }
                     applyInitialDividerPosition(splitView)
@@ -418,7 +430,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 #if DEBUG
                 dlog(
                     "split.entry.fallback split=\(splitDebugToken) orientation=\(orientationToken) " +
-                    "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) layouts=12 rearmed=1"
+                    "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) " +
+                    "layouts=\(context.coordinator.initialDividerApplyAttempts) " +
+                    "shown=1 animationAbandoned=1 stillObserving=1"
                 )
 #endif
                 return
@@ -453,7 +467,11 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 let targetPosition = availableSize * targetDividerPosition
                 splitState.dividerPosition = targetDividerPosition
 
-                if shouldAnimate {
+                // `entryAnimationAbandoned` overrides the captured `shouldAnimate`: the
+                // fallback already showed this pane, so sliding it in from an edge now
+                // would be a snap on screen, and the animation path withholds the
+                // delegate updates the model needs. Place it and be done.
+                if shouldAnimate, !context.coordinator.entryAnimationAbandoned {
                     // Position at edge while new pane is hidden
                     let startPosition: CGFloat = animationOrigin == .fromFirst ? 0 : availableSize
 #if DEBUG
@@ -745,8 +763,19 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         var isAnimating = false
         var didApplyInitialDividerPosition = false
         /// Initial divider placement can run before NSSplitView has a real size.
-        /// Retry a few turns so entry animations are not dropped on first layout.
+        /// Counts LAYOUT passes it has waited through, not runloop turns: only a
+        /// layout can hand the view a size, so turns are the wrong clock.
         var initialDividerApplyAttempts = 0
+        /// Set once the entry animation has been abandoned because the pane had to
+        /// be shown before a size ever arrived.
+        ///
+        /// After that the pane is on screen, so a late apply must place the divider
+        /// outright. Rewinding it to an edge to slide it in would be a visible snap,
+        /// and the animation path suppresses the delegate updates the model needs.
+        /// The animation's own inputs cannot answer this: `animationOrigin` is read
+        /// into a local and cleared on the first pass, so by the time a late apply
+        /// runs the local still says "animate" while the pane is already visible.
+        var entryAnimationAbandoned = false
         var onGeometryChange: ((_ isDragging: Bool) -> Void)?
         /// Answers whether a divider drag session is live anywhere in this
         /// tree. Consulted before every imposed apply: mid-drag the user owns

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -394,47 +394,40 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     )
                 }
 #endif
-                if context.coordinator.initialDividerApplyAttempts < 12 {
-                    splitView.afterNextLayout = { [weak splitView] in
-                        guard let splitView else { return }
-                        applyInitialDividerPosition(splitView)
-                    }
-                    return
-                }
-
-                // Twelve laid-out passes with no width is a split view that cannot
-                // size, not a race. Show the pane rather than lose it, abandon the
-                // entry animation, and keep observing layouts.
+                // Twelve attempts with no width — the initial probe plus eleven
+                // parked on real layouts — is a split view that cannot size, not a
+                // race. On EXACTLY the twelfth, show the pane rather than lose it
+                // and abandon the entry animation; past twelve, this guard is
+                // entered again on every zero-sized layout, and the fallback work
+                // must not repeat — only the observation re-arms.
                 //
-                // Keep observing, but do NOT reset the counter: the count is what
-                // makes this reach the fallback exactly once, and resetting it would
-                // re-run this whole block every twelve passes. Observation is not the
-                // old budget by another name — the old retry span twelve runloop turns
-                // and then stopped forever, whereas layouts only happen when something
-                // changes, so a view nobody lays out costs nothing and a view that
-                // gains a size gets its position. `didApplyInitialDividerPosition`
-                // ends the observation on the first success.
-                //
-                // Deliberately NOT setting `didApplyInitialDividerPosition` here:
+                // Observation is not the old budget by another name: the old retry
+                // span twelve runloop turns and then stopped forever, whereas
+                // layouts only happen when something changes, so a view nobody
+                // lays out costs nothing and a view that gains a size gets its
+                // position. `didApplyInitialDividerPosition` ends the observation
+                // on the first success — and it is deliberately NOT set here:
                 // recording a position as applied when it never was is what made a
                 // wrong extent permanent.
-                if shouldAnimate {
-                    splitView.arrangedSubviews[newPaneIndex].isHidden = false
-                    context.coordinator.isAnimating = false
+                if context.coordinator.initialDividerApplyAttempts == 12 {
+                    if shouldAnimate {
+                        splitView.arrangedSubviews[newPaneIndex].isHidden = false
+                        context.coordinator.isAnimating = false
+                    }
+                    context.coordinator.entryAnimationAbandoned = true
+#if DEBUG
+                    dlog(
+                        "split.entry.fallback split=\(splitDebugToken) orientation=\(orientationToken) " +
+                        "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) " +
+                        "attempts=\(context.coordinator.initialDividerApplyAttempts) " +
+                        "shown=1 animationAbandoned=1 stillObserving=1"
+                    )
+#endif
                 }
-                context.coordinator.entryAnimationAbandoned = true
                 splitView.afterNextLayout = { [weak splitView] in
                     guard let splitView else { return }
                     applyInitialDividerPosition(splitView)
                 }
-#if DEBUG
-                dlog(
-                    "split.entry.fallback split=\(splitDebugToken) orientation=\(orientationToken) " +
-                    "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) " +
-                    "layouts=\(context.coordinator.initialDividerApplyAttempts) " +
-                    "shown=1 animationAbandoned=1 stillObserving=1"
-                )
-#endif
                 return
             }
 
@@ -518,11 +511,24 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     // No animation - just set the position immediately
                     context.coordinator.setPositionSafely(targetPosition, in: splitView, layout: false)
                     context.coordinator.lastAppliedPosition = targetDividerPosition
+                    // An entry that PLANNED to animate hid its pane in makeNSView
+                    // and set isAnimating; reaching this branch means the animation
+                    // will never run (abandoned — by this entry's fallback, or by a
+                    // stale flag), so the only unhide lives in the animated path.
+                    // Show the pane and release the delegate suppression here, or
+                    // it stays hidden with isAnimating stuck true.
+                    if shouldAnimate {
+                        splitView.arrangedSubviews.indices.forEach {
+                            splitView.arrangedSubviews[$0].isHidden = false
+                        }
+                        context.coordinator.isAnimating = false
+                    }
 #if DEBUG
                     dlog(
                         "split.entry.noAnimation split=\(splitDebugToken) orientation=\(orientationToken) " +
                         "origin=\(animationOriginToken) targetPx=\(Int(targetPosition.rounded())) " +
-                        "enableAnimations=\(enableAnimations ? 1 : 0)"
+                        "enableAnimations=\(enableAnimations ? 1 : 0) " +
+                        "abandoned=\(context.coordinator.entryAnimationAbandoned ? 1 : 0)"
                     )
 #endif
                 }
@@ -763,8 +769,10 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         var isAnimating = false
         var didApplyInitialDividerPosition = false
         /// Initial divider placement can run before NSSplitView has a real size.
-        /// Counts LAYOUT passes it has waited through, not runloop turns: only a
-        /// layout can hand the view a size, so turns are the wrong clock.
+        /// Counts zero-sized ATTEMPTS: the initial async probe from `makeNSView`,
+        /// then one per layout pass the retry parked on. Layouts are the clock for
+        /// every attempt after the first — only a layout can hand the view a size,
+        /// so runloop turns are the wrong thing to count.
         var initialDividerApplyAttempts = 0
         /// Set once the entry animation has been abandoned because the pane had to
         /// be shown before a size ever arrived.
@@ -849,6 +857,15 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 initialDividerApplyAttempts = 0
                 isAnimating = false
                 isDragging = false
+                // The abandonment belongs to the OLD split's entry. Left set, a
+                // later entry through this reused coordinator hides its pane for
+                // the animation, takes the plain path because of the stale flag,
+                // and nothing ever unhides it.
+                entryAnimationAbandoned = false
+                // A parked entry attempt captured the old split's state; letting a
+                // later layout run it would apply the dead split's position to the
+                // reused view and mark the NEW lifecycle applied.
+                (splitView as? ThemedSplitView)?.afterNextLayout = nil
                 firstNodeType = newState.first.nodeType
                 secondNodeType = newState.second.nodeType
                 return

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -47,6 +47,22 @@ private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
         customDividerThickness ?? super.dividerThickness
     }
 
+    /// Ran once after AppKit's next layout pass, then cleared.
+    ///
+    /// Work that needs a real `bounds` has to wait for a layout, and hopping the
+    /// runloop is not waiting for one: a `DispatchQueue.main.async` chain can run
+    /// to exhaustion inside the same layout, seeing the same empty bounds every
+    /// time. This is the edge that actually changes the answer. Cleared before the
+    /// hook runs, so the hook may re-arm it for the following pass.
+    var afterNextLayout: (() -> Void)?
+
+    override func layout() {
+        super.layout()
+        guard let hook = afterNextLayout else { return }
+        afterNextLayout = nil
+        hook()
+    }
+
     /// When the host injects divider cursors, replace AppKit's built-in
     /// divider cursor rects (added by super) with the custom cursor over
     /// each divider's expanded effective rect.
@@ -339,7 +355,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         }
 
         // Apply the initial divider position once after initial layout scheduling.
-        func applyInitialDividerPosition() {
+        //
+        // Takes the split view rather than capturing it: the retry below parks this
+        // on the view itself, and a closure that captured it would keep the view
+        // alive through its own property — a leak for any split torn down before a
+        // layout pass arrives.
+        func applyInitialDividerPosition(_ splitView: ThemedSplitView) {
             if context.coordinator.didApplyInitialDividerPosition {
                 return
             }
@@ -350,8 +371,15 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             let availableSize = max(totalSize - splitView.dividerThickness, 0)
 
             guard availableSize > 0 else {
-                // makeNSView can run before NSSplitView has a real frame; retry on the
-                // next runloop so we still get the intended entry animation.
+                // makeNSView can run before NSSplitView has a real frame, and only a
+                // layout pass gives it one. Waiting on the runloop instead spent this
+                // whole budget inside a single layout — twelve async hops in 13ms, each
+                // reading the same empty bounds — so no attempt could ever have
+                // succeeded, and the fallback then recorded the position as applied
+                // when it never was. A pane kept its entry default for the rest of the
+                // session: nothing re-derives a position this coordinator believes it
+                // already set, and no divider imposition can move a pane whose sibling
+                // has since closed. Wait for layout, and count layouts.
                 context.coordinator.initialDividerApplyAttempts += 1
 #if DEBUG
                 let attempt = context.coordinator.initialDividerApplyAttempts
@@ -359,27 +387,35 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     dlog(
                         "split.entry.wait split=\(splitDebugToken) orientation=\(orientationToken) " +
                         "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) " +
-                        "attempt=\(attempt) total=\(Int(totalSize.rounded())) available=\(Int(availableSize.rounded()))"
+                        "layout=\(attempt) total=\(Int(totalSize.rounded())) available=\(Int(availableSize.rounded()))"
                     )
                 }
 #endif
                 if context.coordinator.initialDividerApplyAttempts < 12 {
-                    DispatchQueue.main.async {
-                        applyInitialDividerPosition()
+                    splitView.afterNextLayout = { [weak splitView] in
+                        guard let splitView else { return }
+                        applyInitialDividerPosition(splitView)
                     }
                     return
                 }
 
-                // Safety fallback: don't leave the new pane hidden forever.
-                context.coordinator.didApplyInitialDividerPosition = true
+                // Twelve laid-out passes with no width is a split view that cannot
+                // size, not a race. Unhide the pane so it is not lost, and leave the
+                // position unapplied so a later pass with real geometry still sets it
+                // — claiming otherwise is what made this permanent.
                 if animationOrigin != nil, shouldAnimate {
                     splitView.arrangedSubviews[newPaneIndex].isHidden = false
                     context.coordinator.isAnimating = false
                 }
+                context.coordinator.initialDividerApplyAttempts = 0
+                splitView.afterNextLayout = { [weak splitView] in
+                    guard let splitView else { return }
+                    applyInitialDividerPosition(splitView)
+                }
 #if DEBUG
                 dlog(
                     "split.entry.fallback split=\(splitDebugToken) orientation=\(orientationToken) " +
-                    "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) attempts=\(context.coordinator.initialDividerApplyAttempts)"
+                    "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) layouts=12 rearmed=1"
                 )
 #endif
                 return
@@ -476,8 +512,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             }
         }
 
-        DispatchQueue.main.async {
-            applyInitialDividerPosition()
+        DispatchQueue.main.async { [weak splitView] in
+            guard let splitView else { return }
+            applyInitialDividerPosition(splitView)
         }
 
         return splitView

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -427,7 +427,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                         "split.entry.fallback split=\(splitDebugToken) orientation=\(orientationToken) " +
                         "origin=\(animationOriginToken) animate=\(shouldAnimate ? 1 : 0) " +
                         "attempts=\(context.coordinator.initialDividerApplyAttempts) " +
-                        "shown=1 animationAbandoned=1 stillObserving=1"
+                        "shown=\(shouldAnimate ? 1 : 0) animationAbandoned=1 stillObserving=1"
                     )
 #endif
                 }

--- a/Tests/BonsplitTests/InitialDividerNestedZeroSizedMountTests.swift
+++ b/Tests/BonsplitTests/InitialDividerNestedZeroSizedMountTests.swift
@@ -1,0 +1,148 @@
+import AppKit
+@testable import Bonsplit
+import SwiftUI
+import XCTest
+
+/// End-to-end shape for the layout-edge retry: a nested split mounted at zero size.
+///
+/// A `BonsplitView` can be added to a window before its host has a real frame —
+/// docking a panel does exactly this — and sit at zero size for a few runloop
+/// turns before the first real resize arrives. The old retry counted those turns
+/// as attempts, so both dividers burned their budget reading an empty bounds and
+/// the fallback recorded the seeded positions as applied. After expansion the
+/// outer divider self-repaired on the first real resize, but that repair holds
+/// the resize synchronization depth while it recursively lays out its children,
+/// so the nested divider never got its own repair: the view stayed at 50/50
+/// while the model carried the seeded fraction.
+///
+/// The assertions therefore read actual `NSSplitView.arrangedSubviews` frames.
+/// The model (and anything derived from it, like snapshot fractions) still holds
+/// the seeded values on broken code — only the real frames show the defect.
+@MainActor
+final class InitialDividerNestedZeroSizedMountTests: XCTestCase {
+    func testNestedSeededFractionsSurviveZeroSizedMountThenFirstRealLayout() throws {
+        var appearance = BonsplitConfiguration.Appearance.default
+        appearance.minimumPaneWidth = 48
+        appearance.minimumPaneHeight = 48
+        appearance.enableAnimations = false
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(
+                dividerPositionRange: 0.1...0.9,
+                appearance: appearance
+            )
+        )
+
+        // Three stacked panes: outer divider at 0.20, nested divider at 0.375.
+        _ = controller.createTab(title: "A")
+        let top = try XCTUnwrap(controller.focusedPaneId)
+        let middle = try XCTUnwrap(
+            controller.splitPane(top, orientation: .vertical, initialDividerPosition: 0.2)
+        )
+        XCTAssertNotNil(
+            controller.splitPane(middle, orientation: .vertical, initialDividerPosition: 0.375)
+        )
+
+        let host = NSHostingView(
+            rootView: BonsplitView(controller: controller) { _, _ in
+                Color.clear
+            } emptyPane: { _ in
+                Color.clear
+            }
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 1000),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        defer { window.orderOut(nil) }
+        let content = try XCTUnwrap(window.contentView)
+
+        // Mount at zero size and wait until both splits actually exist before
+        // starting the dwell, so the retries are provably armed while the
+        // bounds are still empty.
+        host.frame = .zero
+        content.addSubview(host)
+        window.makeKeyAndOrderFront(nil)
+        content.layoutSubtreeIfNeeded()
+        let mountDeadline = Date().addingTimeInterval(1.0)
+        while Date() < mountDeadline, !bothSplitsMounted(in: host) {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+            content.layoutSubtreeIfNeeded()
+        }
+        let mounted = allSplitViews(in: host)
+        XCTAssertEqual(mounted.count, 2, "Both splits should be mounted")
+        for split in mounted {
+            XCTAssertEqual(split.arrangedSubviews.count, 2)
+            XCTAssertEqual(
+                split.bounds.height, 0, accuracy: 0.01,
+                "The dwell must start while the split still has no usable height"
+            )
+        }
+
+        // Dwell at zero size. This is the window in which the old retry spent
+        // its whole budget on empty bounds (twelve turns inside 13ms), so
+        // 150ms of runloop turns exhausts it many times over.
+        RunLoop.main.run(until: Date().addingTimeInterval(0.15))
+        content.layoutSubtreeIfNeeded()
+
+        // First real resize: the host gets its actual frame and AppKit lays out.
+        host.frame = content.bounds
+        content.layoutSubtreeIfNeeded()
+        host.layoutSubtreeIfNeeded()
+
+        // Wait (bounded) for both dividers to land, then assert real frames.
+        let deadline = Date().addingTimeInterval(1.0)
+        while Date() < deadline, !nestedFractionsMatch(in: host) {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            content.layoutSubtreeIfNeeded()
+        }
+
+        let splits = allSplitViews(in: host).sorted { $0.bounds.height > $1.bounds.height }
+        XCTAssertEqual(splits.count, 2)
+        let outer = try XCTUnwrap(splits.first)
+        let inner = try XCTUnwrap(splits.last)
+        XCTAssertEqual(
+            outer.arrangedSubviews[0].frame.height
+                / (outer.bounds.height - outer.dividerThickness),
+            0.2,
+            accuracy: 0.02,
+            "Outer divider must land on its seeded fraction"
+        )
+        XCTAssertEqual(
+            inner.arrangedSubviews[0].frame.height
+                / (inner.bounds.height - inner.dividerThickness),
+            0.375,
+            accuracy: 0.02,
+            "Nested divider must land on its seeded fraction, not the 50/50 entry "
+                + "default it is stranded at when the outer repair swallows its layout"
+        )
+    }
+
+    private func bothSplitsMounted(in root: NSView) -> Bool {
+        let splits = allSplitViews(in: root)
+        return splits.count == 2 && splits.allSatisfy { $0.arrangedSubviews.count == 2 }
+    }
+
+    private func nestedFractionsMatch(in root: NSView) -> Bool {
+        let splits = allSplitViews(in: root).sorted { $0.bounds.height > $1.bounds.height }
+        guard splits.count == 2,
+              let outer = splits.first, let inner = splits.last,
+              outer.bounds.height > outer.dividerThickness,
+              inner.bounds.height > inner.dividerThickness,
+              !outer.arrangedSubviews.isEmpty, !inner.arrangedSubviews.isEmpty
+        else { return false }
+        let outerFraction = outer.arrangedSubviews[0].frame.height
+            / (outer.bounds.height - outer.dividerThickness)
+        let innerFraction = inner.arrangedSubviews[0].frame.height
+            / (inner.bounds.height - inner.dividerThickness)
+        return abs(outerFraction - 0.2) <= 0.02 && abs(innerFraction - 0.375) <= 0.02
+    }
+
+    private func allSplitViews(in root: NSView) -> [NSSplitView] {
+        var result: [NSSplitView] = []
+        if let split = root as? NSSplitView { result.append(split) }
+        for child in root.subviews {
+            result += allSplitViews(in: child)
+        }
+        return result
+    }
+}

--- a/Tests/BonsplitTests/SplitEntryLayoutEdgeTests.swift
+++ b/Tests/BonsplitTests/SplitEntryLayoutEdgeTests.swift
@@ -1,0 +1,112 @@
+import AppKit
+@testable import Bonsplit
+import XCTest
+
+/// The initial divider position needs a real `bounds`, and only an AppKit layout
+/// pass supplies one. These tests pin the edge it waits on.
+///
+/// The retry used to hop `DispatchQueue.main.async` — the next runloop turn, which
+/// is not a layout pass. Every attempt read the same empty bounds, the budget was
+/// spent without one real chance, and the fallback then recorded the position as
+/// applied when it never was. Nothing re-derives a position the coordinator
+/// believes it already set, so the pane kept its entry default for good.
+@MainActor
+final class SplitEntryLayoutEdgeTests: XCTestCase {
+    /// A runloop turn is not a layout pass.
+    ///
+    /// This is the property the old code violated: it retried on a clock that ticks
+    /// whether or not AppKit has laid anything out, so a chain of retries could run
+    /// to exhaustion inside a single layout. Draining the main queue must NOT run
+    /// work parked for the layout edge.
+    func testWorkParkedForLayoutDoesNotRunOnAMereRunloopTurn() throws {
+        let splitView = ThemedSplitView(frame: .zero)
+        var ran = 0
+        splitView.afterNextLayout = { ran += 1 }
+
+        // Spin the runloop hard — the old retry's entire budget was twelve of these
+        // inside 13ms. None of them is a layout.
+        for _ in 0..<12 {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.001))
+        }
+
+        XCTAssertEqual(
+            ran, 0,
+            "Work parked for the layout edge must not fire on a runloop turn: that is "
+                + "exactly how twelve retries burned in 13ms without one real attempt."
+        )
+    }
+
+    /// The layout pass is the edge that changes the answer.
+    func testWorkParkedForLayoutRunsOnTheNextLayoutPass() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        defer { window.orderOut(nil) }
+        let content = try XCTUnwrap(window.contentView)
+        let splitView = ThemedSplitView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        content.addSubview(splitView)
+
+        var ran = 0
+        var availableAtRun: CGFloat = -1
+        splitView.afterNextLayout = {
+            ran += 1
+            availableAtRun = splitView.bounds.width
+        }
+
+        splitView.needsLayout = true
+        splitView.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(ran, 1, "The layout pass must run work parked for it.")
+        XCTAssertGreaterThan(
+            availableAtRun, 0,
+            "The hook must observe a real bounds — that is the whole reason it waits "
+                + "for layout rather than a runloop turn."
+        )
+    }
+
+    /// Cleared before it runs, so the hook can re-arm itself for the following pass.
+    ///
+    /// The retry re-arms when the view still has no width. If `layout()` cleared the
+    /// hook after invoking it, that re-arm would be wiped out and the position would
+    /// never be applied.
+    func testHookIsClearedBeforeItRunsSoItCanRearmForTheFollowingPass() throws {
+        let splitView = ThemedSplitView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        var runs = 0
+        func arm() {
+            splitView.afterNextLayout = {
+                runs += 1
+                if runs < 3 { arm() }   // re-arm from inside the hook, as the retry does
+            }
+        }
+        arm()
+
+        for _ in 0..<3 {
+            splitView.needsLayout = true
+            splitView.layoutSubtreeIfNeeded()
+        }
+
+        XCTAssertEqual(
+            runs, 3,
+            "A hook that re-arms itself must survive: clearing after the call would "
+                + "discard the re-arm and strand the divider unapplied."
+        )
+    }
+
+    /// One layout, one attempt — the budget must measure layouts, not turns.
+    func testOneLayoutPassRunsTheHookExactlyOnce() throws {
+        let splitView = ThemedSplitView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        var ran = 0
+        splitView.afterNextLayout = { ran += 1 }
+
+        splitView.needsLayout = true
+        splitView.layoutSubtreeIfNeeded()
+        splitView.needsLayout = true
+        splitView.layoutSubtreeIfNeeded()
+
+        XCTAssertEqual(
+            ran, 1,
+            "A one-shot hook must not re-fire on later layouts it did not arm for."
+        )
+    }
+}


### PR DESCRIPTION
A new split pane can keep its entry default position for the rest of the session.

`applyInitialDividerPosition` needs a real `bounds` to compute anything, and `makeNSView`
can run before AppKit has laid the split view out. The retry hopped
`DispatchQueue.main.async` — a runloop turn, which carries no guarantee that a layout has
happened in between. A chain of those can run to exhaustion inside a single layout, every
attempt reading the same empty bounds. Observed in a host app's layout fuzz: all twelve
attempts completed inside 13ms.

```
split.entry.wait split=C6721 orientation=horizontal attempt=4  total=0 available=0
split.entry.wait split=C6721 orientation=horizontal attempt=8  total=0 available=0
split.entry.wait split=C6721 orientation=horizontal attempt=12 total=0 available=0
split.entry.fallback split=C6721 attempts=12
```

The fallback then set `didApplyInitialDividerPosition = true`, recording the position as
applied when it never was. Nothing re-derives a position the coordinator believes it has
already set, so the pane keeps its entry default. Once a sibling closes there is no divider
left to move, so no later imposition corrects it either.

## The change

`ThemedSplitView` gains an `afterNextLayout` hook, invoked from a `layout()` override and
cleared before it runs so the hook can re-arm for the following pass. The retry parks
itself there, so each attempt after the initial probe waits on a layout rather than a
runloop turn.

On the twelfth zero-sized attempt — the initial probe plus eleven parked on real layouts —
the pane is shown rather than lost, the entry animation is abandoned, and the position is
left unapplied. The fallback work runs on exactly that attempt; later zero-sized layouts
only re-arm the observation. Observing past the fallback is deliberate: a layout only
happens when something changes, so a view nobody lays out costs nothing, and a view that
later gains a width gets its position. `didApplyInitialDividerPosition` ends the
observation on the first success.

Abandonment is recorded on the coordinator (`entryAnimationAbandoned`) because the
animation's own inputs cannot answer it late: `shouldAnimate` is a local captured before
the first attempt and `animationOrigin` is cleared on the first pass. The late apply then
places the divider outright — rewinding a visible pane to an edge to slide it in is a snap
on screen, and the animation path withholds delegate updates.

SwiftUI reuses the coordinator across split identities, so the identity-change reset also
clears the abandonment flag and cancels any parked retry — a parked closure captured the
dead split's state and could apply its position to the reused view. The plain entry path
defensively unhides whenever an entry that planned to animate lands there, covering both a
genuine abandonment and any stale-state route to that branch.

`applyInitialDividerPosition` takes the split view as a parameter rather than capturing it:
the retry parks a closure on the view itself, and a captured reference would make the view
retain itself through its own property.

## What this does not cover

A pane left at a stale width after its sibling closes has a different cause: the logical
tree collapses correctly (`bonsplitTreeMatches` returns true) while the AppKit
`SplitArrangedContainerView` hierarchy keeps the old arrangement, so a host positioning
content from the anchor tracks a stale one. Not addressed here.

## Tests

`Tests/BonsplitTests/SplitEntryLayoutEdgeTests.swift` — four tests over the hook: it does
not run on a runloop turn; it runs on the next layout pass; it is cleared before it runs so
a self-re-arming hook survives; one layout runs it once.

`ThemedSplitView` widens from `private` to `internal` so the test target can drive
`layout()`.

```
$ swift test
Executed 205 tests, with 0 failures (0 unexpected) in 8.665 seconds
```

Coverage limits: the tests pin the hook's contract, not the retry or fallback logic, which
live inside `makeNSView` and need a SwiftUI `Context` a unit test cannot build. The
fallback's single-shot behavior, the abandonment lifecycle, and the coordinator-reuse
reset rest on review and a green suite. Testing them directly means extracting the retry
decision into an internal state machine — a refactor for whoever owns this area.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-view divider positioning when layout information is temporarily unavailable.
  * Prevented stale layout actions and incorrect entry animations when split views are reused or updated.
  * Ensured panes become visible correctly when the entry animation cannot proceed.

* **Tests**
  * Added coverage for layout-timed actions, including delayed execution, one-shot behavior, and re-arming during layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The regression test pins the shape that actually escapes the old retry end to end. A BonsplitView docked before its host has a frame sits at zero size for a few runloop turns; the old retry counted those turns as attempts, so both seeded dividers burned their budget on empty bounds and the fallback marked them applied. After the first real resize the outer divider self-repairs, but that repair holds the resize synchronization depth while it recursively lays out its children, so the nested divider stays at the 50/50 entry default while the model still carries the seeded fraction. The test mounts three stacked panes (fractions 0.20 and 0.375) at zero size, expands the host, and asserts the actual NSSplitView arrangedSubviews frames — model fractions stay correct even on broken code, so only real frames catch it. It fails on main with the nested pane at 0.5 and passes on this branch.
