### PR TITLE
Add configurable pane tab icon tint

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -64,6 +64,14 @@ enum TabBarColors {
         return NSColor(bonsplitHex: value)
     }
 
+    private static func configuredColor(
+        _ value: String?,
+        fallback: @autoclosure () -> NSColor
+    ) -> NSColor {
+        guard let value, let color = NSColor(bonsplitHex: value) else { return fallback() }
+        return color
+    }
+
     private static func effectiveBackgroundColor(
         for appearance: BonsplitConfiguration.Appearance,
         fallback fallbackColor: NSColor
@@ -281,20 +289,40 @@ enum TabBarColors {
     }
 
     static func dropIndicator(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        _ = appearance
-        return dropIndicator
+        let fallback = configuredColor(appearance.chromeColors.accentHex, fallback: .controlAccentColor)
+        return Color(nsColor: configuredColor(appearance.chromeColors.dropTargetHex, fallback: fallback))
     }
 
     static func activeIndicator(saturation: Double) -> Color {
         Color(nsColor: nsColorActiveIndicator(saturation: saturation))
     }
 
+    static func activeIndicator(
+        for appearance: BonsplitConfiguration.Appearance,
+        saturation: Double
+    ) -> Color {
+        Color(nsColor: nsColorActiveIndicator(for: appearance, saturation: saturation))
+    }
+
     static func nsColorActiveIndicator(saturation: Double) -> NSColor {
         NSColor.controlAccentColor.bonsplitSaturating(by: saturation)
     }
 
+    static func nsColorActiveIndicator(
+        for appearance: BonsplitConfiguration.Appearance,
+        saturation: Double
+    ) -> NSColor {
+        configuredColor(appearance.chromeColors.accentHex, fallback: .controlAccentColor)
+            .bonsplitSaturating(by: saturation)
+    }
+
     static var focusRing: Color {
         Color.accentColor.opacity(0.5)
+    }
+
+    static func focusRing(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        Color(nsColor: configuredColor(appearance.chromeColors.accentHex, fallback: .controlAccentColor))
+            .opacity(0.5)
     }
 
     static var dirtyIndicator: Color {
@@ -311,8 +339,7 @@ enum TabBarColors {
     }
 
     static func notificationBadge(for appearance: BonsplitConfiguration.Appearance) -> Color {
-        _ = appearance
-        return notificationBadge
+        Color(nsColor: configuredColor(appearance.chromeColors.notificationHex, fallback: .systemBlue))
     }
 
     // MARK: - Shadows

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -227,6 +227,19 @@ enum TabBarColors {
         effectiveTextColor(for: appearance, secondary: true)
     }
 
+    static func nsColorTabIcon(
+        for appearance: BonsplitConfiguration.Appearance,
+        isSelected: Bool
+    ) -> NSColor {
+        if let iconHex = appearance.chromeColors.iconHex,
+           let color = NSColor(bonsplitHex: iconHex) {
+            return isSelected ? color : color.withAlphaComponent(color.alphaComponent * 0.72)
+        }
+        return isSelected
+            ? nsColorActiveText(for: appearance)
+            : nsColorInactiveText(for: appearance)
+    }
+
     static func splitActionIcon(for appearance: BonsplitConfiguration.Appearance, isPressed: Bool) -> Color {
         Color(nsColor: nsColorSplitActionIcon(for: appearance, isPressed: isPressed))
     }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -51,19 +51,18 @@ enum PaneDropLifecycle {
 private struct PaneDropPlaceholderOverlay: View {
     let zone: DropZone?
     let size: CGSize
+    let dropTargetColor: Color
 
-    private let placeholderColor = Color.accentColor.opacity(0.25)
-    private let borderColor = Color.accentColor
     private let padding: CGFloat = 4
 
     var body: some View {
         let frame = overlayFrame(for: zone, in: size)
 
         RoundedRectangle(cornerRadius: 8)
-            .fill(placeholderColor)
+            .fill(dropTargetColor.opacity(0.25))
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(borderColor, lineWidth: 2)
+                    .stroke(dropTargetColor, lineWidth: 2)
             )
             .frame(width: frame.width, height: frame.height)
             .offset(x: frame.minX, y: frame.minY)
@@ -114,15 +113,18 @@ private struct PaneDropPlaceholderOverlay: View {
 
 struct PaneDropInteractionContainer<Content: View, DropLayer: View>: View {
     let activeDropZone: DropZone?
+    let dropTargetColor: Color
     let content: Content
     let dropLayer: (CGSize) -> DropLayer
 
     init(
         activeDropZone: DropZone?,
+        dropTargetColor: Color = .accentColor,
         @ViewBuilder content: () -> Content,
         @ViewBuilder dropLayer: @escaping (CGSize) -> DropLayer
     ) {
         self.activeDropZone = activeDropZone
+        self.dropTargetColor = dropTargetColor
         self.content = content()
         self.dropLayer = dropLayer
     }
@@ -137,7 +139,11 @@ struct PaneDropInteractionContainer<Content: View, DropLayer: View>: View {
                     dropLayer(size)
                 }
                 .overlay(alignment: .topLeading) {
-                    PaneDropPlaceholderOverlay(zone: activeDropZone, size: size)
+                    PaneDropPlaceholderOverlay(
+                        zone: activeDropZone,
+                        size: size,
+                        dropTargetColor: dropTargetColor
+                    )
                         .allowsHitTesting(false)
                 }
         }
@@ -215,7 +221,10 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var contentAreaWithDropZones: some View {
-        PaneDropInteractionContainer(activeDropZone: activeDropZone) {
+        PaneDropInteractionContainer(
+            activeDropZone: activeDropZone,
+            dropTargetColor: TabBarColors.dropIndicator(for: bonsplitController.configuration.appearance)
+        ) {
             contentArea
         } dropLayer: { size in
             // Drop zones layer (above content, receives drops and taps)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -979,7 +979,10 @@ struct TabBarView: View {
         TabBarSelectionChromeView(
             selectedTabId: pane.selectedTabId,
             geometryRegistry: tabItemGeometryRegistry,
-            indicatorColor: TabBarColors.nsColorActiveIndicator(saturation: tabBarSaturation),
+            indicatorColor: TabBarColors.nsColorActiveIndicator(
+                for: appearance,
+                saturation: tabBarSaturation
+            ),
             separatorColor: TabBarColors.nsColorSeparator(for: appearance),
             mask: selectionChromeMask
         )

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -690,9 +690,10 @@ struct TabItemView: View {
     @ViewBuilder
     private var leadingIcon: some View {
         let iconSlotSize = scaledIconSize
-        let iconTintColor = isSelected
-            ? TabBarColors.nsColorActiveText(for: appearance)
-            : TabBarColors.nsColorInactiveText(for: appearance)
+        let iconTintColor = TabBarColors.nsColorTabIcon(
+            for: appearance,
+            isSelected: isSelected
+        )
         let iconTint = Color(nsColor: iconTintColor)
         let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { NSImage(data: $0) }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -493,13 +493,26 @@ extension BonsplitConfiguration {
             /// Raster favicons and asset icons retain their original colors.
             public var iconHex: String?
 
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for active selection chrome and focus rings.
+            public var accentHex: String?
+
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for drag insertion indicators and pane drop targets.
+            /// When unset, Bonsplit falls back to `accentHex`, then the system accent color.
+            public var dropTargetHex: String?
+
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for notification badges.
+            public var notificationHex: String?
+
             public init(
                 backgroundHex: String? = nil,
                 tabBarBackgroundHex: String? = nil,
                 splitButtonBackdropHex: String? = nil,
                 paneBackgroundHex: String? = nil,
                 borderHex: String? = nil,
-                iconHex: String? = nil
+                iconHex: String? = nil,
+                accentHex: String? = nil,
+                dropTargetHex: String? = nil,
+                notificationHex: String? = nil
             ) {
                 self.backgroundHex = backgroundHex
                 self.tabBarBackgroundHex = tabBarBackgroundHex
@@ -507,6 +520,9 @@ extension BonsplitConfiguration {
                 self.paneBackgroundHex = paneBackgroundHex
                 self.borderHex = borderHex
                 self.iconHex = iconHex
+                self.accentHex = accentHex
+                self.dropTargetHex = dropTargetHex
+                self.notificationHex = notificationHex
             }
         }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -489,18 +489,24 @@ extension BonsplitConfiguration {
             /// When unset, Bonsplit derives separators from the chrome background.
             public var borderHex: String?
 
+            /// Optional hex color (`#RRGGBB` or `#RRGGBBAA`) for SF Symbol tab icons.
+            /// Raster favicons and asset icons retain their original colors.
+            public var iconHex: String?
+
             public init(
                 backgroundHex: String? = nil,
                 tabBarBackgroundHex: String? = nil,
                 splitButtonBackdropHex: String? = nil,
                 paneBackgroundHex: String? = nil,
-                borderHex: String? = nil
+                borderHex: String? = nil,
+                iconHex: String? = nil
             ) {
                 self.backgroundHex = backgroundHex
                 self.tabBarBackgroundHex = tabBarBackgroundHex
                 self.splitButtonBackdropHex = splitButtonBackdropHex
                 self.paneBackgroundHex = paneBackgroundHex
                 self.borderHex = borderHex
+                self.iconHex = iconHex
             }
         }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1434,6 +1434,19 @@ final class BonsplitTests: XCTestCase {
         XCTAssertGreaterThan(pressedAlpha, idleAlpha)
     }
 
+    func testTabIconColorUsesConfiguredTintAndDimsInactiveIcons() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(iconHex: "#8844CC")
+        )
+        let active = TabBarColors.nsColorTabIcon(for: appearance, isSelected: true).usingColorSpace(.sRGB)!
+        let inactive = TabBarColors.nsColorTabIcon(for: appearance, isSelected: false).usingColorSpace(.sRGB)!
+
+        XCTAssertEqual(active.redComponent, 0x88 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(active.greenComponent, 0x44 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(active.blueComponent, 0xCC / 255.0, accuracy: 0.001)
+        XCTAssertEqual(inactive.alphaComponent, active.alphaComponent * 0.72, accuracy: 0.001)
+    }
+
     @MainActor
     func testMoveTabNoopAfterItself() {
         let t0 = TabItem(title: "0")

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1447,6 +1447,30 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(inactive.alphaComponent, active.alphaComponent * 0.72, accuracy: 0.001)
     }
 
+    func testInteractionColorsUseConfiguredSemanticRoles() {
+        let appearance = BonsplitConfiguration.Appearance(
+            chromeColors: .init(
+                accentHex: "#7C3AED",
+                dropTargetHex: "#F59E0B",
+                notificationHex: "#22D3EE"
+            )
+        )
+        let active = TabBarColors.nsColorActiveIndicator(for: appearance, saturation: 1)
+            .usingColorSpace(.sRGB)!
+        let drop = NSColor(TabBarColors.dropIndicator(for: appearance)).usingColorSpace(.sRGB)!
+        let notification = NSColor(TabBarColors.notificationBadge(for: appearance)).usingColorSpace(.sRGB)!
+
+        XCTAssertEqual(active.redComponent, 0x7C / 255.0, accuracy: 0.001)
+        XCTAssertEqual(active.greenComponent, 0x3A / 255.0, accuracy: 0.001)
+        XCTAssertEqual(active.blueComponent, 0xED / 255.0, accuracy: 0.001)
+        XCTAssertEqual(drop.redComponent, 0xF5 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(drop.greenComponent, 0x9E / 255.0, accuracy: 0.001)
+        XCTAssertEqual(drop.blueComponent, 0x0B / 255.0, accuracy: 0.001)
+        XCTAssertEqual(notification.redComponent, 0x22 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(notification.greenComponent, 0xD3 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(notification.blueComponent, 0xEE / 255.0, accuracy: 0.001)
+    }
+
     @MainActor
     func testMoveTabNoopAfterItself() {
         let t0 = TabItem(title: "0")


### PR DESCRIPTION
Adds an optional `iconHex` chrome color for SF Symbol tab icons. Raster favicons and asset icons retain their original colors. Inactive symbols use a derived 72% alpha.\n\nTest: `swift test --filter testTabIconColorUsesConfiguredTintAndDimsInactiveIcons`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786877673&installation_id=133855650&pr_number=189&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F189&signature=1854f04d897e7346006f7838533ebf7034bbc8ea13e76e06f187a38580481b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional chrome color overrides: `iconHex` for SF Symbol tab icons, `accentHex` for selection/focus, `dropTargetHex` for drag targets, and `notificationHex` for badges. Inactive icons auto-dim to 72%; raster favicons keep original colors.

- **New Features**
  - Extended `BonsplitConfiguration.Appearance.ChromeColors` with `iconHex`, `accentHex`, `dropTargetHex`, `notificationHex` (`#RRGGBB` or `#RRGGBBAA`).
  - SF Symbol tabs use `iconHex`; falls back to active/inactive text colors when unset. Selection chrome and focus rings use `accentHex`; drop targets use `dropTargetHex` (fallback `accentHex` → system); badges use `notificationHex`.
  - Added tests for icon tinting/dimming and semantic interaction colors.

<sup>Written for commit d8303cbe64770a4a1d1149b4520cc783a7f5ec23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom tab icon colors.
  * Inactive tab icons now automatically appear dimmed when a custom icon color is configured.
  * Existing active and inactive text colors remain the default when no custom color is provided.

* **Tests**
  * Added coverage for custom tinting and inactive icon dimming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->