### PR TITLE
Avoid MainActor executor crashes in tab hit testing

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarItemGeometryRegistry.swift
@@ -111,7 +111,7 @@ final class TabBarItemGeometryRegistry {
             object: clipView,
             queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated {
+            Task { @MainActor [weak self] in
                 self?.scrollBoundsDidChange()
             }
         }
@@ -120,7 +120,7 @@ final class TabBarItemGeometryRegistry {
             object: scrollView,
             queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated {
+            Task { @MainActor [weak self] in
                 self?.userWillScroll()
             }
         }
@@ -266,7 +266,7 @@ final class TabBarItemGeometryRegistry {
             object: documentView,
             queue: .main
         ) { [weak self] _ in
-            MainActor.assumeIsolated {
+            Task { @MainActor [weak self] in
                 self?.documentGeometryDidChange()
             }
         }
@@ -413,7 +413,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
     }
 
     final class RegionNSView: NSView, BonsplitTabItemHitRegionProviding {
-        nonisolated(unsafe) private var hitBounds: NSRect = .zero
+        private var hitBounds: NSRect = .zero
         private var tabId: UUID?
         private weak var geometryRegistry: TabBarItemGeometryRegistry?
         private var containerFrameObserver: NSObjectProtocol?
@@ -481,7 +481,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
             notifyGeometryDidChange()
         }
 
-        nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
+        func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
             hitBounds
                 .insetBy(
                     dx: -BonsplitTabItemHitTesting.horizontalSlop,
@@ -529,7 +529,7 @@ struct TabItemHitRegionView: NSViewRepresentable {
                 object: containerView,
                 queue: .main
             ) { [weak self] _ in
-                MainActor.assumeIsolated {
+                Task { @MainActor [weak self] in
                     self?.notifyGeometryDidChange()
                 }
             }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -48,6 +48,7 @@ public enum BonsplitTabBarHitRegionRegistry {
 }
 
 public protocol BonsplitTabItemHitRegionProviding: AnyObject {
+    @MainActor
     func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool
 }
 
@@ -83,6 +84,7 @@ public enum BonsplitTabItemHitRegionRegistry {
         return true
     }
 
+    @MainActor
     public static func containsWindowPoint(_ windowPoint: CGPoint, in window: NSWindow) -> Bool {
         for view in snapshot() {
             guard view.window === window,
@@ -2313,15 +2315,13 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             }
         }
 
-        nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
-            MainActor.assumeIsolated {
-                let frames = geometryRegistry?.frames(for: tabIds, in: self).values.map { $0 } ?? []
-                return BonsplitTabItemHitTesting.containsTabLaneHit(
-                    localPoint: localPoint,
-                    tabFrames: frames,
-                    bounds: bounds
-                )
-            }
+        func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
+            let frames = geometryRegistry?.frames(for: tabIds, in: self).values.map { $0 } ?? []
+            return BonsplitTabItemHitTesting.containsTabLaneHit(
+                localPoint: localPoint,
+                tabFrames: frames,
+                bounds: bounds
+            )
         }
 
         override func updateTrackingAreas() {


### PR DESCRIPTION
## Summary
- make tab hit-region queries explicitly main-actor isolated instead of calling MainActor.assumeIsolated on every mouse event
- deliver geometry notification updates through main-actor tasks
- remove the unsafe nonisolated hit-bounds storage

## Why
On macOS 26.4.x, MainActor.assumeIsolated can fault inside the Swift executor runtime even when AppKit invokes the callback on the main thread. The tab hit-test path runs for ordinary pointer events, making tagged cmux builds crash during normal use.

## Verification
- swift build
- parent cmux tagged dogfood build and focus/tab stress will follow before merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786920005&installation_id=133855650&pr_number=190&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F190&signature=614eea90c40bc049b7bcb305d320a64df7b4d3e16d00a57fdf5ba8abbcd66e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in tab hit testing on macOS 26.4 by running hit-region queries and geometry updates on the main actor. This removes reliance on `MainActor.assumeIsolated` and prevents executor faults during pointer events.

- **Bug Fixes**
  - Marked `BonsplitTabItemHitRegionProviding.containsBonsplitTabItemHit` and `BonsplitTabItemHitRegionRegistry.containsWindowPoint` as `@MainActor`.
  - Replaced `MainActor.assumeIsolated` with `Task { @MainActor ... }` for scroll and geometry notifications.
  - Removed `nonisolated(unsafe)` hit-bounds storage; access is now main-actor isolated.
  - Simplified tab-lane hit testing to read geometry directly on the main actor.

<sup>Written for commit bb022b4dd98cea603cfbf824d791020fc7a5ba95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tab bar hit testing and notification handling for more reliable UI interactions.
  - Ensured geometry updates and hit-testing operations execute safely on the main thread.
  - Reduced the risk of inconsistent tab selection or interaction results during UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->