### PR TITLE
Add stable pane IDs and divider interaction policy

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -5,6 +5,11 @@ import SwiftUI
 @Observable
 @MainActor
 final class SplitViewController {
+    private struct PaneIndexes {
+        var panes: [PaneID: PaneState]
+        var tabOwners: [UUID: PaneID]
+    }
+
     /// The public wrapper that owns this controller, for identity lookups
     /// from managed AppKit views (see `BonsplitManagedSplitView`).
     weak var publicController: BonsplitController?
@@ -13,8 +18,7 @@ final class SplitViewController {
     private(set) var rootNode: SplitNode
 
     /// Live indexes for host queries that must not walk the split tree.
-    @ObservationIgnored private var paneStatesById: [PaneID: PaneState]
-    @ObservationIgnored private var paneIdsByTabId: [UUID: PaneID]
+    @ObservationIgnored private var paneIndexes: PaneIndexes
 
     /// Currently zoomed pane. When set, rendering should only show this pane.
     var zoomedPaneId: PaneID?
@@ -117,32 +121,31 @@ final class SplitViewController {
 
         let indexes = Self.makeIndexes(for: resolvedRoot)
         self.rootNode = resolvedRoot
-        self.paneStatesById = indexes.panes
-        self.paneIdsByTabId = indexes.tabOwners
+        self.paneIndexes = indexes
         self.focusedPaneId = initialFocusedPaneId
     }
 
     // MARK: - Indexed State
 
     func paneState(for paneId: PaneID) -> PaneState? {
-        paneStatesById[paneId]
+        paneIndexes.panes[paneId]
     }
 
     func paneId(containing tabId: UUID) -> PaneID? {
-        paneIdsByTabId[tabId]
+        paneIndexes.tabOwners[tabId]
     }
 
     func selectedTabId(inPane paneId: PaneID) -> UUID? {
-        paneStatesById[paneId]?.selectedTabId
+        paneIndexes.panes[paneId]?.selectedTabId
     }
 
     var paneCount: Int {
-        paneStatesById.count
+        paneIndexes.panes.count
     }
 
     private static func makeIndexes(
         for rootNode: SplitNode
-    ) -> (panes: [PaneID: PaneState], tabOwners: [UUID: PaneID]) {
+    ) -> PaneIndexes {
         var panes: [PaneID: PaneState] = [:]
         var tabOwners: [UUID: PaneID] = [:]
         var pendingNodes = [rootNode]
@@ -160,32 +163,48 @@ final class SplitViewController {
             }
         }
 
-        return (panes, tabOwners)
+        return PaneIndexes(panes: panes, tabOwners: tabOwners)
     }
 
     private func registerPane(_ pane: PaneState) {
-        if let replacedPane = paneStatesById.updateValue(pane, forKey: pane.id) {
-            for tab in replacedPane.tabs where paneIdsByTabId[tab.id] == pane.id {
-                paneIdsByTabId.removeValue(forKey: tab.id)
+        if let replacedPane = paneIndexes.panes.updateValue(pane, forKey: pane.id) {
+            for tab in replacedPane.tabs where paneIndexes.tabOwners[tab.id] == pane.id {
+                paneIndexes.tabOwners.removeValue(forKey: tab.id)
             }
         }
         for tab in pane.tabs {
-            paneIdsByTabId[tab.id] = pane.id
+            paneIndexes.tabOwners[tab.id] = pane.id
         }
     }
 
     private func unregisterPane(_ paneId: PaneID) {
-        guard let pane = paneStatesById.removeValue(forKey: paneId) else { return }
-        for tab in pane.tabs where paneIdsByTabId[tab.id] == paneId {
-            paneIdsByTabId.removeValue(forKey: tab.id)
+        guard let pane = paneIndexes.panes.removeValue(forKey: paneId) else { return }
+        for tab in pane.tabs where paneIndexes.tabOwners[tab.id] == paneId {
+            paneIndexes.tabOwners.removeValue(forKey: tab.id)
         }
+    }
+
+    /// Install a tree whose nodes and presentation state were completely
+    /// prepared by the caller. Index construction also finishes before any
+    /// live state changes. Main-actor isolation then makes the single index
+    /// replacement and single root replacement indivisible to callers.
+    func installAuthoritativeTree(
+        _ rootNode: SplitNode,
+        focusedPaneId: PaneID?,
+        zoomedPaneId: PaneID?
+    ) {
+        let indexes = Self.makeIndexes(for: rootNode)
+        paneIndexes = indexes
+        self.focusedPaneId = focusedPaneId
+        self.zoomedPaneId = zoomedPaneId
+        self.rootNode = rootNode
     }
 
     // MARK: - Focus Management
 
     /// Set focus to a specific pane
     func focusPane(_ paneId: PaneID) {
-        guard paneStatesById[paneId] != nil else { return }
+        guard paneIndexes.panes[paneId] != nil else { return }
 #if DEBUG
         dlog("focus.bonsplit pane=\(paneId.id.uuidString.prefix(5))")
 #endif
@@ -195,11 +214,11 @@ final class SplitViewController {
     /// Get the currently focused pane state
     var focusedPane: PaneState? {
         guard let focusedPaneId else { return nil }
-        return paneStatesById[focusedPaneId]
+        return paneIndexes.panes[focusedPaneId]
     }
 
     var zoomedNode: SplitNode? {
-        guard let zoomedPaneId, let pane = paneStatesById[zoomedPaneId] else { return nil }
+        guard let zoomedPaneId, let pane = paneIndexes.panes[zoomedPaneId] else { return nil }
         return .pane(pane)
     }
 
@@ -212,7 +231,7 @@ final class SplitViewController {
 
     @discardableResult
     func togglePaneZoom(_ paneId: PaneID) -> Bool {
-        guard paneStatesById[paneId] != nil else { return false }
+        guard paneIndexes.panes[paneId] != nil else { return false }
 
         if zoomedPaneId == paneId {
             zoomedPaneId = nil
@@ -220,7 +239,7 @@ final class SplitViewController {
         }
 
         // Match Ghostty behavior: a single-pane layout can't be zoomed.
-        guard paneStatesById.count > 1 else { return false }
+        guard paneIndexes.panes.count > 1 else { return false }
         zoomedPaneId = paneId
         focusedPaneId = paneId
         return true
@@ -236,7 +255,7 @@ final class SplitViewController {
         initialDividerPosition: CGFloat? = nil,
         newPaneID: PaneID? = nil
     ) {
-        guard paneStatesById[paneId] != nil else { return }
+        guard paneIndexes.panes[paneId] != nil else { return }
         clearPaneZoom()
         var createdPane: PaneState?
         rootNode = splitNodeRecursively(
@@ -327,7 +346,7 @@ final class SplitViewController {
         initialDividerPosition: CGFloat? = nil,
         newPaneID: PaneID? = nil
     ) {
-        guard paneStatesById[paneId] != nil else { return }
+        guard paneIndexes.panes[paneId] != nil else { return }
         clearPaneZoom()
         var createdPane: PaneState?
         rootNode = splitNodeWithTabRecursively(
@@ -426,7 +445,7 @@ final class SplitViewController {
     /// Close a pane and collapse the split
     func closePane(_ paneId: PaneID) {
         // Don't close the last pane
-        guard paneStatesById.count > 1, paneStatesById[paneId] != nil else { return }
+        guard paneIndexes.panes.count > 1, paneIndexes.panes[paneId] != nil else { return }
 
         let (newRoot, siblingPaneId) = closePaneRecursively(node: rootNode, targetPaneId: paneId)
 
@@ -442,7 +461,7 @@ final class SplitViewController {
             focusedPaneId = firstPane
         }
 
-        if let zoomedPaneId, paneStatesById[zoomedPaneId] == nil {
+        if let zoomedPaneId, paneIndexes.panes[zoomedPaneId] == nil {
             self.zoomedPaneId = nil
         }
     }
@@ -494,20 +513,20 @@ final class SplitViewController {
     func addTab(_ tab: TabItem, toPane paneId: PaneID? = nil, atIndex index: Int? = nil) {
         let targetPaneId = paneId ?? focusedPaneId
         guard let targetPaneId,
-              let pane = paneStatesById[targetPaneId] else { return }
+              let pane = paneIndexes.panes[targetPaneId] else { return }
 
         if let index {
             pane.insertTab(tab, at: index)
         } else {
             pane.addTab(tab)
         }
-        paneIdsByTabId[tab.id] = targetPaneId
+        paneIndexes.tabOwners[tab.id] = targetPaneId
     }
 
     /// Move a tab from one pane to another
     func moveTab(_ tab: TabItem, from sourcePaneId: PaneID, to targetPaneId: PaneID, atIndex index: Int? = nil) {
-        guard let sourcePane = paneStatesById[sourcePaneId],
-              let targetPane = paneStatesById[targetPaneId] else { return }
+        guard let sourcePane = paneIndexes.panes[sourcePaneId],
+              let targetPane = paneIndexes.panes[targetPaneId] else { return }
 
         if sourcePaneId == targetPaneId {
             guard let sourceIndex = sourcePane.tabs.firstIndex(where: { $0.id == tab.id }) else { return }
@@ -527,13 +546,13 @@ final class SplitViewController {
         } else {
             targetPane.addTab(tab)
         }
-        paneIdsByTabId[tab.id] = targetPaneId
+        paneIndexes.tabOwners[tab.id] = targetPaneId
 
         // Focus target pane
         focusPane(targetPaneId)
 
         // If source pane is now empty and not the only pane, close it
-        if sourcePane.tabs.isEmpty && paneStatesById.count > 1 {
+        if sourcePane.tabs.isEmpty && paneIndexes.panes.count > 1 {
             closePane(sourcePaneId)
         }
     }
@@ -542,21 +561,21 @@ final class SplitViewController {
     /// Callers that leave an empty pane decide whether to close or refill it.
     @discardableResult
     func removeTab(_ tabId: UUID, fromPane paneId: PaneID) -> TabItem? {
-        guard let pane = paneStatesById[paneId],
+        guard let pane = paneIndexes.panes[paneId],
               let removedTab = pane.removeTab(tabId) else { return nil }
-        if paneIdsByTabId[tabId] == paneId {
-            paneIdsByTabId.removeValue(forKey: tabId)
+        if paneIndexes.tabOwners[tabId] == paneId {
+            paneIndexes.tabOwners.removeValue(forKey: tabId)
         }
         return removedTab
     }
 
     /// Close a tab in a specific pane
     func closeTab(_ tabId: UUID, inPane paneId: PaneID) {
-        guard let pane = paneStatesById[paneId],
+        guard let pane = paneIndexes.panes[paneId],
               removeTab(tabId, fromPane: paneId) != nil else { return }
 
         // If pane is now empty and not the only pane, close it
-        if pane.tabs.isEmpty && paneStatesById.count > 1 {
+        if pane.tabs.isEmpty && paneIndexes.panes.count > 1 {
             closePane(paneId)
         }
     }

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -101,7 +101,7 @@ final class SplitViewController {
         }
     }
 
-    init(rootNode: SplitNode? = nil) {
+    init(rootNode: SplitNode? = nil, initialPaneID: PaneID? = nil) {
         let resolvedRoot: SplitNode
         let initialFocusedPaneId: PaneID?
         if let rootNode {
@@ -110,7 +110,7 @@ final class SplitViewController {
         } else {
             // Initialize with a single pane containing a welcome tab
             let welcomeTab = TabItem(title: "Welcome", icon: "star")
-            let initialPane = PaneState(tabs: [welcomeTab])
+            let initialPane = PaneState(id: initialPaneID ?? PaneID(), tabs: [welcomeTab])
             resolvedRoot = .pane(initialPane)
             initialFocusedPaneId = initialPane.id
         }
@@ -233,7 +233,8 @@ final class SplitViewController {
         _ paneId: PaneID,
         orientation: SplitOrientation,
         with newTab: TabItem? = nil,
-        initialDividerPosition: CGFloat? = nil
+        initialDividerPosition: CGFloat? = nil,
+        newPaneID: PaneID? = nil
     ) {
         guard paneStatesById[paneId] != nil else { return }
         clearPaneZoom()
@@ -244,6 +245,7 @@ final class SplitViewController {
             orientation: orientation,
             newTab: newTab,
             initialDividerPosition: initialDividerPosition,
+            newPaneID: newPaneID,
             createdPane: &createdPane
         )
         if let createdPane {
@@ -257,6 +259,7 @@ final class SplitViewController {
         orientation: SplitOrientation,
         newTab: TabItem?,
         initialDividerPosition: CGFloat?,
+        newPaneID: PaneID?,
         createdPane: inout PaneState?
     ) -> SplitNode {
         switch node {
@@ -265,9 +268,9 @@ final class SplitViewController {
                 // Create new pane - empty if no tab provided (gives developer full control)
                 let newPane: PaneState
                 if let tab = newTab {
-                    newPane = PaneState(tabs: [tab])
+                    newPane = PaneState(id: newPaneID ?? PaneID(), tabs: [tab])
                 } else {
-                    newPane = PaneState(tabs: [])
+                    newPane = PaneState(id: newPaneID ?? PaneID(), tabs: [])
                 }
 
                 // Start with divider at the edge so there's no flash before animation
@@ -297,6 +300,7 @@ final class SplitViewController {
                 orientation: orientation,
                 newTab: newTab,
                 initialDividerPosition: initialDividerPosition,
+                newPaneID: newPaneID,
                 createdPane: &createdPane
             )
             if createdPane == nil {
@@ -306,6 +310,7 @@ final class SplitViewController {
                     orientation: orientation,
                     newTab: newTab,
                     initialDividerPosition: initialDividerPosition,
+                    newPaneID: newPaneID,
                     createdPane: &createdPane
                 )
             }
@@ -319,7 +324,8 @@ final class SplitViewController {
         orientation: SplitOrientation,
         tab: TabItem,
         insertFirst: Bool,
-        initialDividerPosition: CGFloat? = nil
+        initialDividerPosition: CGFloat? = nil,
+        newPaneID: PaneID? = nil
     ) {
         guard paneStatesById[paneId] != nil else { return }
         clearPaneZoom()
@@ -331,6 +337,7 @@ final class SplitViewController {
             tab: tab,
             insertFirst: insertFirst,
             initialDividerPosition: initialDividerPosition,
+            newPaneID: newPaneID,
             createdPane: &createdPane
         )
         if let createdPane {
@@ -345,13 +352,14 @@ final class SplitViewController {
         tab: TabItem,
         insertFirst: Bool,
         initialDividerPosition: CGFloat?,
+        newPaneID: PaneID?,
         createdPane: inout PaneState?
     ) -> SplitNode {
         switch node {
         case .pane(let paneState):
             if paneState.id == targetPaneId {
                 // Create new pane with the tab
-                let newPane = PaneState(tabs: [tab])
+                let newPane = PaneState(id: newPaneID ?? PaneID(), tabs: [tab])
 
                 // Start with divider at the edge so there's no flash before animation
                 let splitState: SplitState
@@ -391,6 +399,7 @@ final class SplitViewController {
                 tab: tab,
                 insertFirst: insertFirst,
                 initialDividerPosition: initialDividerPosition,
+                newPaneID: newPaneID,
                 createdPane: &createdPane
             )
             if createdPane == nil {
@@ -401,6 +410,7 @@ final class SplitViewController {
                     tab: tab,
                     insertFirst: insertFirst,
                     initialDividerPosition: initialDividerPosition,
+                    newPaneID: newPaneID,
                     createdPane: &createdPane
                 )
             }

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -3,8 +3,14 @@ import AppKit
 
 private var splitContainerProgrammaticSyncDepth = 0
 
-private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
+class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
     var customDividerColor: NSColor?
+    var isDividerInteractionEnabled = true {
+        didSet {
+            guard oldValue != isDividerInteractionEnabled else { return }
+            window?.invalidateCursorRects(for: self)
+        }
+    }
 
     /// Identity for external drag coordination (see BonsplitManagedSplitView).
     weak var stampedInternalController: SplitViewController?
@@ -51,6 +57,7 @@ private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
     /// divider cursor rects (added by super) with the custom cursor over
     /// each divider's expanded effective rect.
     override func resetCursorRects() {
+        guard isDividerInteractionEnabled else { return }
         let custom = isVertical ? BonsplitDividerCursors.vertical : BonsplitDividerCursors.horizontal
         guard let custom else {
             super.resetCursorRects()
@@ -107,6 +114,7 @@ private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
     var onDividerDragSession: ((Bool) -> Void)?
 
     override func mouseDown(with event: NSEvent) {
+        guard isDividerInteractionEnabled else { return }
         // Any mouseDown that reaches the split view itself is a divider
         // interaction: arranged subviews cover all pane content, so content
         // clicks never route here, and reconstructing AppKit's exact
@@ -200,6 +208,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
     let controller: SplitViewController
     let appearance: BonsplitConfiguration.Appearance
     let dividerPositionRange: ClosedRange<CGFloat>
+    let allowDividerResizing: Bool
     let contentBuilder: (TabItem, PaneID) -> Content
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     var showSplitButtons: Bool = true
@@ -246,6 +255,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         splitView.customDividerColor = TabBarColors.nsColorSeparator(for: appearance)
         splitView.customDividerThickness = TabBarMetrics.resolvedDividerThickness(appearance.dividerThickness)
         splitView.customDividerHitExpansion = appearance.dividerHitExpansion
+        splitView.isDividerInteractionEnabled = allowDividerResizing
         splitView.stampedInternalController = controller
         splitView.stampedSplitId = splitState.id
         splitView.isVertical = splitState.orientation == .horizontal
@@ -508,6 +518,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         let dividerThicknessChanged = (splitView as? ThemedSplitView)?.customDividerThickness != resolvedThickness
         (splitView as? ThemedSplitView)?.customDividerThickness = resolvedThickness
         (splitView as? ThemedSplitView)?.customDividerHitExpansion = appearance.dividerHitExpansion
+        (splitView as? ThemedSplitView)?.isDividerInteractionEnabled = allowDividerResizing
         (splitView as? ThemedSplitView)?.stampedInternalController = controller
         (splitView as? ThemedSplitView)?.stampedSplitId = splitState.id
         // Re-install alongside the identity stamps above so a reused
@@ -681,6 +692,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 controller: controller,
                 appearance: appearance,
                 dividerPositionRange: dividerPositionRange,
+                allowDividerResizing: allowDividerResizing,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,

--- a/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitNodeView.swift
@@ -10,6 +10,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
     let dividerPositionRange: ClosedRange<CGFloat>
+    let allowDividerResizing: Bool
     var showSplitButtons: Bool = true
     var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
@@ -36,6 +37,7 @@ struct SplitNodeView<Content: View, EmptyContent: View>: View {
                 controller: controller,
                 appearance: appearance,
                 dividerPositionRange: dividerPositionRange,
+                allowDividerResizing: allowDividerResizing,
                 contentBuilder: contentBuilder,
                 emptyPaneBuilder: emptyPaneBuilder,
                 showSplitButtons: showSplitButtons,

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -8,6 +8,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
     let emptyPaneBuilder: (PaneID) -> EmptyContent
     let appearance: BonsplitConfiguration.Appearance
     let dividerPositionRange: ClosedRange<CGFloat>
+    let allowDividerResizing: Bool
     var showSplitButtons: Bool = true
     var tabBarVisibility: TabBarVisibility = .always
     var contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch
@@ -47,6 +48,7 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
             emptyPaneBuilder: emptyPaneBuilder,
             appearance: appearance,
             dividerPositionRange: dividerPositionRange,
+            allowDividerResizing: allowDividerResizing,
             showSplitButtons: showSplitButtons,
             tabBarVisibility: tabBarVisibility,
             contentViewLifecycle: contentViewLifecycle,

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -62,6 +62,9 @@ public struct BonsplitConfiguration: Sendable {
     /// Whether to allow moving tabs between panes
     public var allowCrossPaneTabMove: Bool
 
+    /// Whether split dividers accept pointer-driven resizing.
+    public var allowDividerResizing: Bool
+
     /// Whether tabs install and present their standard context menu.
     public var allowsTabContextMenu: Bool
 
@@ -102,7 +105,8 @@ public struct BonsplitConfiguration: Sendable {
         allowSplits: false,
         allowCloseTabs: false,
         allowTabReordering: false,
-        allowCrossPaneTabMove: false
+        allowCrossPaneTabMove: false,
+        allowDividerResizing: false
     )
 
     // MARK: - Initializer
@@ -113,6 +117,7 @@ public struct BonsplitConfiguration: Sendable {
         allowCloseLastPane: Bool = false,
         allowTabReordering: Bool = true,
         allowCrossPaneTabMove: Bool = true,
+        allowDividerResizing: Bool = true,
         allowsTabContextMenu: Bool = true,
         autoCloseEmptyPanes: Bool = true,
         contentViewLifecycle: ContentViewLifecycle = .recreateOnSwitch,
@@ -126,6 +131,7 @@ public struct BonsplitConfiguration: Sendable {
         self.allowCloseLastPane = allowCloseLastPane
         self.allowTabReordering = allowTabReordering
         self.allowCrossPaneTabMove = allowCrossPaneTabMove
+        self.allowDividerResizing = allowDividerResizing
         self.allowsTabContextMenu = allowsTabContextMenu
         self.autoCloseEmptyPanes = autoCloseEmptyPanes
         self.contentViewLifecycle = contentViewLifecycle

--- a/Sources/Bonsplit/Public/BonsplitController+AuthoritativeTree.swift
+++ b/Sources/Bonsplit/Public/BonsplitController+AuthoritativeTree.swift
@@ -1,0 +1,310 @@
+import Foundation
+
+private struct ValidatedAuthoritativeTree {
+    let paneIDs: Set<PaneID>
+    let paneOrder: [PaneID]
+}
+
+private struct AuthoritativeTreeValidationAccumulator {
+    var paneIDs: Set<PaneID> = []
+    var paneOrder: [PaneID] = []
+    var splitIDs: Set<UUID> = []
+    var nodeIDs: Set<UUID> = []
+    var tabIDs: Set<TabID> = []
+}
+
+public extension BonsplitController {
+    /// Validate an authoritative tree against the controller's exact current
+    /// tab set without mutating any Bonsplit state.
+    func validateAuthoritativeTree(_ tree: BonsplitAuthoritativeTree) throws {
+        let currentTabs = try currentAuthoritativeTabs()
+        _ = try validatedAuthoritativeTree(
+            tree,
+            exactTabIDs: Set(currentTabs.keys.map(TabID.init(id:)))
+        )
+    }
+
+    /// Validate an authoritative tree against a caller-supplied exact tab set.
+    ///
+    /// This overload lets a host validate every destination tree before it
+    /// transfers tabs between controllers. `applyAuthoritativeTree(_:)` still
+    /// requires the destination controller to own exactly this set at apply
+    /// time.
+    func validateAuthoritativeTree(
+        _ tree: BonsplitAuthoritativeTree,
+        exactTabIDs: Set<TabID>
+    ) throws {
+        _ = try validatedAuthoritativeTree(tree, exactTabIDs: exactTabIDs)
+    }
+
+    /// Atomically replace the split topology using tabs already owned by this
+    /// controller.
+    ///
+    /// Validation and construction complete before live state changes. A
+    /// successful structural or presentation-state change emits exactly one
+    /// geometry notification and no create, close, move, split, selection, or
+    /// focus delegate callbacks. An exact no-op preserves node identity,
+    /// returns `false`, and emits nothing.
+    @discardableResult
+    func applyAuthoritativeTree(_ tree: BonsplitAuthoritativeTree) throws -> Bool {
+        let currentTabs = try currentAuthoritativeTabs()
+        let validation = try validatedAuthoritativeTree(
+            tree,
+            exactTabIDs: Set(currentTabs.keys.map(TabID.init(id:)))
+        )
+
+        let root = buildAuthoritativeNode(tree.root, currentTabs: currentTabs)
+        let focusedPaneID = resolveAuthoritativeFocus(
+            tree.focusedPane,
+            paneIDs: validation.paneIDs,
+            firstPaneID: validation.paneOrder.first
+        )
+        let zoomedPaneID = resolveAuthoritativeZoom(
+            tree.zoomedPane,
+            paneIDs: validation.paneIDs
+        )
+
+        if sameNodeIdentity(root, internalController.rootNode),
+           focusedPaneID == internalController.focusedPaneId,
+           zoomedPaneID == internalController.zoomedPaneId {
+            return false
+        }
+
+        internalController.installAuthoritativeTree(
+            root,
+            focusedPaneId: focusedPaneID,
+            zoomedPaneId: zoomedPaneID
+        )
+        notifyGeometryChange(force: true)
+        return true
+    }
+
+    private func validatedAuthoritativeTree(
+        _ tree: BonsplitAuthoritativeTree,
+        exactTabIDs: Set<TabID>
+    ) throws -> ValidatedAuthoritativeTree {
+        var accumulator = AuthoritativeTreeValidationAccumulator()
+        try validateAuthoritativeNode(tree.root, accumulator: &accumulator)
+
+        let missing = exactTabIDs.subtracting(accumulator.tabIDs).sortedByUUID
+        let unexpected = accumulator.tabIDs.subtracting(exactTabIDs).sortedByUUID
+        if !missing.isEmpty || !unexpected.isEmpty {
+            throw BonsplitAuthoritativeTreeError.tabSetMismatch(
+                missing: missing,
+                unexpected: unexpected
+            )
+        }
+
+        switch tree.focusedPane {
+        case .preserve, .none:
+            break
+        case .pane(let pane) where !accumulator.paneIDs.contains(pane):
+            throw BonsplitAuthoritativeTreeError.invalidFocusedPane(pane)
+        case .pane:
+            break
+        }
+
+        switch tree.zoomedPane {
+        case .preserve, .none:
+            break
+        case .pane(let pane) where !accumulator.paneIDs.contains(pane):
+            throw BonsplitAuthoritativeTreeError.invalidZoomedPane(pane)
+        case .pane(let pane) where accumulator.paneIDs.count < 2:
+            throw BonsplitAuthoritativeTreeError.zoomRequiresMultiplePanes(pane)
+        case .pane:
+            break
+        }
+
+        return ValidatedAuthoritativeTree(
+            paneIDs: accumulator.paneIDs,
+            paneOrder: accumulator.paneOrder
+        )
+    }
+
+    private func validateAuthoritativeNode(
+        _ node: BonsplitAuthoritativeTree.Node,
+        accumulator: inout AuthoritativeTreeValidationAccumulator
+    ) throws {
+        switch node {
+        case .pane(let pane):
+            guard pane.id.id != Self.zeroAuthoritativeUUID else {
+                throw BonsplitAuthoritativeTreeError.emptyPaneID
+            }
+            guard accumulator.paneIDs.insert(pane.id).inserted else {
+                throw BonsplitAuthoritativeTreeError.duplicatePane(pane.id)
+            }
+            guard accumulator.nodeIDs.insert(pane.id.id).inserted else {
+                throw BonsplitAuthoritativeTreeError.duplicateNodeIdentity(pane.id.id)
+            }
+            guard !pane.tabs.isEmpty else {
+                throw BonsplitAuthoritativeTreeError.paneHasNoTabs(pane.id)
+            }
+            accumulator.paneOrder.append(pane.id)
+            var paneTabs: Set<TabID> = []
+            for tab in pane.tabs {
+                guard tab.uuid != Self.zeroAuthoritativeUUID else {
+                    throw BonsplitAuthoritativeTreeError.emptyTabID
+                }
+                guard paneTabs.insert(tab).inserted,
+                      accumulator.tabIDs.insert(tab).inserted else {
+                    throw BonsplitAuthoritativeTreeError.duplicateTab(tab)
+                }
+            }
+            if case .tab(let selected) = pane.selection,
+               !paneTabs.contains(selected) {
+                throw BonsplitAuthoritativeTreeError.invalidSelectedTab(
+                    pane: pane.id,
+                    tab: selected
+                )
+            }
+
+        case .split(let split):
+            guard split.id != Self.zeroAuthoritativeUUID else {
+                throw BonsplitAuthoritativeTreeError.emptySplitID
+            }
+            guard accumulator.splitIDs.insert(split.id).inserted else {
+                throw BonsplitAuthoritativeTreeError.duplicateSplit(split.id)
+            }
+            guard accumulator.nodeIDs.insert(split.id).inserted else {
+                throw BonsplitAuthoritativeTreeError.duplicateNodeIdentity(split.id)
+            }
+            guard split.ratio.isFinite,
+                  split.ratio > 0,
+                  split.ratio < 1 else {
+                throw BonsplitAuthoritativeTreeError.invalidSplitRatio(
+                    split: split.id,
+                    ratio: split.ratio
+                )
+            }
+            try validateAuthoritativeNode(split.first, accumulator: &accumulator)
+            try validateAuthoritativeNode(split.second, accumulator: &accumulator)
+        }
+    }
+
+    private func currentAuthoritativeTabs() throws -> [UUID: TabItem] {
+        var tabs: [UUID: TabItem] = [:]
+        for pane in internalController.rootNode.allPanes {
+            for tab in pane.tabs {
+                if tabs.updateValue(tab, forKey: tab.id) != nil {
+                    throw BonsplitAuthoritativeTreeError.duplicateCurrentTab(TabID(id: tab.id))
+                }
+            }
+        }
+        return tabs
+    }
+
+    private func buildAuthoritativeNode(
+        _ node: BonsplitAuthoritativeTree.Node,
+        currentTabs: [UUID: TabItem]
+    ) -> SplitNode {
+        switch node {
+        case .pane(let requested):
+            let existing = internalController.paneState(for: requested.id)
+            let tabs = requested.tabs.map { currentTabs[$0.id]! }
+            let tabIDs = Set(requested.tabs.map(\.id))
+            let selectedTabID: UUID
+            switch requested.selection {
+            case .preserve:
+                selectedTabID = existing?.selectedTabId.flatMap { tabIDs.contains($0) ? $0 : nil }
+                    ?? tabs[0].id
+            case .tab(let selected):
+                selectedTabID = selected.id
+            }
+            let isFullWidthTabMode: Bool
+            switch requested.fullWidthTabMode {
+            case .preserve:
+                isFullWidthTabMode = existing?.isFullWidthTabMode ?? false
+            case .value(let value):
+                isFullWidthTabMode = value
+            }
+
+            if let existing,
+               existing.tabs.map(\.id) == tabs.map(\.id),
+               existing.selectedTabId == selectedTabID,
+               existing.isFullWidthTabMode == isFullWidthTabMode {
+                return .pane(existing)
+            }
+            return .pane(PaneState(
+                id: requested.id,
+                tabs: tabs,
+                selectedTabId: selectedTabID,
+                isFullWidthTabMode: isFullWidthTabMode
+            ))
+
+        case .split(let requested):
+            let first = buildAuthoritativeNode(requested.first, currentTabs: currentTabs)
+            let second = buildAuthoritativeNode(requested.second, currentTabs: currentTabs)
+            if let existing = internalController.findSplit(requested.id),
+               existing.orientation == requested.orientation,
+               Double(existing.dividerPosition) == requested.ratio,
+               sameNodeIdentity(existing.first, first),
+               sameNodeIdentity(existing.second, second) {
+                return .split(existing)
+            }
+            return .split(SplitState(
+                id: requested.id,
+                orientation: requested.orientation,
+                first: first,
+                second: second,
+                dividerPosition: CGFloat(requested.ratio)
+            ))
+        }
+    }
+
+    private func resolveAuthoritativeFocus(
+        _ reference: BonsplitAuthoritativeTree.PaneReference,
+        paneIDs: Set<PaneID>,
+        firstPaneID: PaneID?
+    ) -> PaneID? {
+        switch reference {
+        case .preserve:
+            if let focused = internalController.focusedPaneId,
+               paneIDs.contains(focused) {
+                return focused
+            }
+            return firstPaneID
+        case .none:
+            return nil
+        case .pane(let pane):
+            return pane
+        }
+    }
+
+    private func resolveAuthoritativeZoom(
+        _ reference: BonsplitAuthoritativeTree.PaneReference,
+        paneIDs: Set<PaneID>
+    ) -> PaneID? {
+        switch reference {
+        case .preserve:
+            guard paneIDs.count > 1,
+                  let zoomed = internalController.zoomedPaneId,
+                  paneIDs.contains(zoomed) else { return nil }
+            return zoomed
+        case .none:
+            return nil
+        case .pane(let pane):
+            return pane
+        }
+    }
+
+    private func sameNodeIdentity(_ first: SplitNode, _ second: SplitNode) -> Bool {
+        switch (first, second) {
+        case (.pane(let lhs), .pane(let rhs)):
+            return lhs === rhs
+        case (.split(let lhs), .split(let rhs)):
+            return lhs === rhs
+        default:
+            return false
+        }
+    }
+
+    private static let zeroAuthoritativeUUID = UUID(uuid: (
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    ))
+}
+
+private extension Set where Element == TabID {
+    var sortedByUUID: [TabID] {
+        sorted { $0.uuid.uuidString < $1.uuid.uuidString }
+    }
+}

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -1136,9 +1136,8 @@ public final class BonsplitController {
     /// - Parameters:
     ///   - isDragging: Whether the change is due to active divider dragging
     ///   - force: Deliver even inside the external-update suppression window.
-    ///     Only the drag-end path passes true: its notification is the one
-    ///     the delegate contract guarantees, so the anti-echo gate must not
-    ///     swallow it.
+    ///     Drag-end and authoritative tree replacement pass true because each
+    ///     operation guarantees one final geometry notification.
     internal func notifyGeometryChange(isDragging: Bool = false, force: Bool = false) {
         guard force || !internalController.isExternalUpdateInProgress else { return }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -111,9 +111,12 @@ public final class BonsplitController {
     // MARK: - Initialization
 
     /// Create a new controller with the specified configuration
-    public init(configuration: BonsplitConfiguration = .default) {
+    public init(
+        configuration: BonsplitConfiguration = .default,
+        initialPaneID: PaneID? = nil
+    ) {
         self.configuration = configuration
-        self.internalController = SplitViewController()
+        self.internalController = SplitViewController(initialPaneID: initialPaneID)
         internalController.publicController = self
         internalController.onDividerDragSessionChange = { [weak self] active in
             guard let self else { return }
@@ -507,7 +510,8 @@ public final class BonsplitController {
         _ paneId: PaneID? = nil,
         orientation: SplitOrientation,
         withTab tab: Tab? = nil,
-        initialDividerPosition: CGFloat? = nil
+        initialDividerPosition: CGFloat? = nil,
+        newPaneID: PaneID? = nil
     ) -> PaneID? {
         guard configuration.allowSplits else { return nil }
 
@@ -547,7 +551,8 @@ public final class BonsplitController {
             PaneID(id: targetPaneId.id),
             orientation: orientation,
             with: internalTab,
-            initialDividerPosition: dividerPosition
+            initialDividerPosition: dividerPosition,
+            newPaneID: newPaneID
         )
 
         // Find new pane (will be focused after split)
@@ -578,7 +583,8 @@ public final class BonsplitController {
         orientation: SplitOrientation,
         withTab tab: Tab,
         insertFirst: Bool,
-        initialDividerPosition: CGFloat? = nil
+        initialDividerPosition: CGFloat? = nil,
+        newPaneID: PaneID? = nil
     ) -> PaneID? {
         guard configuration.allowSplits else { return nil }
 
@@ -614,7 +620,8 @@ public final class BonsplitController {
             orientation: orientation,
             tab: internalTab,
             insertFirst: insertFirst,
-            initialDividerPosition: dividerPosition
+            initialDividerPosition: dividerPosition,
+            newPaneID: newPaneID
         )
 
         let newPaneId = focusedPaneId!
@@ -654,7 +661,8 @@ public final class BonsplitController {
         _ paneId: PaneID? = nil,
         orientation: SplitOrientation,
         movingTab tabId: TabID,
-        insertFirst: Bool
+        insertFirst: Bool,
+        newPaneID: PaneID? = nil
     ) -> PaneID? {
         guard configuration.allowSplits,
               configuration.allowCrossPaneTabMove else { return nil }
@@ -699,7 +707,8 @@ public final class BonsplitController {
             orientation: orientation,
             tab: tabItem,
             insertFirst: insertFirst,
-            initialDividerPosition: normalizedInitialDividerPosition(nil)
+            initialDividerPosition: normalizedInitialDividerPosition(nil),
+            newPaneID: newPaneID
         )
 
         let newPaneId = focusedPaneId!

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -172,6 +172,7 @@ public final class BonsplitController {
     @discardableResult
     public func createTab(
         title: String,
+        tabID: TabID? = nil,
         hasCustomTitle: Bool = false,
         icon: String? = "doc.text",
         iconImageData: Data? = nil,
@@ -186,7 +187,8 @@ public final class BonsplitController {
         showsRemoteIndicator: Bool = false,
         inPane pane: PaneID? = nil
     ) -> TabID? {
-        let tabId = TabID()
+        let tabId = tabID ?? TabID()
+        guard tab(tabId) == nil else { return nil }
         let tab = Tab(
             id: tabId,
             title: title,

--- a/Sources/Bonsplit/Public/BonsplitView.swift
+++ b/Sources/Bonsplit/Public/BonsplitView.swift
@@ -47,6 +47,7 @@ public struct BonsplitView<Content: View, EmptyContent: View>: View {
             },
             appearance: controller.configuration.appearance,
             dividerPositionRange: controller.configuration.dividerPositionRange,
+            allowDividerResizing: controller.configuration.allowDividerResizing,
             showSplitButtons: controller.configuration.allowSplits && controller.configuration.appearance.showSplitButtons,
             tabBarVisibility: controller.configuration.tabBarVisibility,
             contentViewLifecycle: controller.configuration.contentViewLifecycle,

--- a/Sources/Bonsplit/Public/Types/BonsplitAuthoritativeTree.swift
+++ b/Sources/Bonsplit/Public/Types/BonsplitAuthoritativeTree.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// A complete, host-owned split-tree description.
+///
+/// Applying this value only rearranges tabs that already exist in the
+/// controller. Tab metadata remains owned by Bonsplit and is preserved across
+/// the replacement. Presentation-local state defaults to `.preserve` so a
+/// canonical topology update does not unexpectedly change the user's focus,
+/// selection, zoom, or full-width-tab mode.
+public struct BonsplitAuthoritativeTree: Sendable, Equatable {
+    public let root: Node
+    public let focusedPane: PaneReference
+    public let zoomedPane: PaneReference
+
+    public init(
+        root: Node,
+        focusedPane: PaneReference = .preserve,
+        zoomedPane: PaneReference = .preserve
+    ) {
+        self.root = root
+        self.focusedPane = focusedPane
+        self.zoomedPane = zoomedPane
+    }
+
+    /// One node in the authoritative binary split tree.
+    public indirect enum Node: Sendable, Equatable {
+        case pane(Pane)
+        case split(Split)
+    }
+
+    /// A pane and the exact order of the tabs it owns.
+    public struct Pane: Sendable, Equatable {
+        public let id: PaneID
+        public let tabs: [TabID]
+        public let selection: TabSelection
+        public let fullWidthTabMode: BooleanState
+
+        public init(
+            id: PaneID,
+            tabs: [TabID],
+            selection: TabSelection = .preserve,
+            fullWidthTabMode: BooleanState = .preserve
+        ) {
+            self.id = id
+            self.tabs = tabs
+            self.selection = selection
+            self.fullWidthTabMode = fullWidthTabMode
+        }
+    }
+
+    /// A branch in the authoritative binary split tree.
+    public struct Split: Sendable, Equatable {
+        public let id: UUID
+        public let orientation: SplitOrientation
+        public let ratio: Double
+        public let first: Node
+        public let second: Node
+
+        public init(
+            id: UUID,
+            orientation: SplitOrientation,
+            ratio: Double,
+            first: Node,
+            second: Node
+        ) {
+            self.id = id
+            self.orientation = orientation
+            self.ratio = ratio
+            self.first = first
+            self.second = second
+        }
+    }
+
+    /// How an authoritative apply resolves a pane reference.
+    public enum PaneReference: Sendable, Equatable {
+        /// Keep the current reference when that pane survives. Focus falls
+        /// back to the first pane; zoom clears when its pane disappears.
+        case preserve
+        /// Clear the reference.
+        case none
+        /// Set the reference to a pane in the new tree.
+        case pane(PaneID)
+    }
+
+    /// How an authoritative apply resolves one pane's selected tab.
+    public enum TabSelection: Sendable, Equatable {
+        /// Keep the current selection when that tab remains in this pane,
+        /// otherwise select the pane's first tab.
+        case preserve
+        /// Select a tab that belongs to this pane in the new tree.
+        case tab(TabID)
+    }
+
+    /// How an authoritative apply resolves one pane's Boolean view state.
+    public enum BooleanState: Sendable, Equatable {
+        case preserve
+        case value(Bool)
+    }
+}
+
+/// Validation failures produced before an authoritative tree can mutate a
+/// controller. Every failure leaves the existing tree and presentation state
+/// untouched.
+public enum BonsplitAuthoritativeTreeError: Error, Sendable, Equatable {
+    case emptyPaneID
+    case emptySplitID
+    case emptyTabID
+    case paneHasNoTabs(PaneID)
+    case duplicatePane(PaneID)
+    case duplicateSplit(UUID)
+    case duplicateTab(TabID)
+    case duplicateCurrentTab(TabID)
+    case duplicateNodeIdentity(UUID)
+    case invalidSplitRatio(split: UUID, ratio: Double)
+    case invalidSelectedTab(pane: PaneID, tab: TabID)
+    case invalidFocusedPane(PaneID)
+    case invalidZoomedPane(PaneID)
+    case zoomRequiresMultiplePanes(PaneID)
+    case tabSetMismatch(missing: [TabID], unexpected: [TabID])
+}
+
+extension BonsplitAuthoritativeTreeError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .emptyPaneID:
+            return "authoritative pane IDs must be nonzero"
+        case .emptySplitID:
+            return "authoritative split IDs must be nonzero"
+        case .emptyTabID:
+            return "authoritative tab IDs must be nonzero"
+        case .paneHasNoTabs(let pane):
+            return "authoritative pane \(pane) has no tabs"
+        case .duplicatePane(let pane):
+            return "authoritative pane \(pane) appears more than once"
+        case .duplicateSplit(let split):
+            return "authoritative split \(split) appears more than once"
+        case .duplicateTab(let tab):
+            return "authoritative tab \(tab.uuid) appears more than once"
+        case .duplicateCurrentTab(let tab):
+            return "current tab \(tab.uuid) appears more than once"
+        case .duplicateNodeIdentity(let id):
+            return "authoritative pane and split share node identity \(id)"
+        case .invalidSplitRatio(let split, let ratio):
+            return "authoritative split \(split) has invalid ratio \(ratio)"
+        case .invalidSelectedTab(let pane, let tab):
+            return "authoritative selected tab \(tab.uuid) is outside pane \(pane)"
+        case .invalidFocusedPane(let pane):
+            return "authoritative focused pane \(pane) is absent"
+        case .invalidZoomedPane(let pane):
+            return "authoritative zoomed pane \(pane) is absent"
+        case .zoomRequiresMultiplePanes(let pane):
+            return "authoritative zoomed pane \(pane) requires a multi-pane tree"
+        case .tabSetMismatch(let missing, let unexpected):
+            let missingIDs = missing.map { $0.uuid.uuidString }.joined(separator: ",")
+            let unexpectedIDs = unexpected.map { $0.uuid.uuidString }.joined(separator: ",")
+            return "authoritative tab set mismatch (missing: [\(missingIDs)], unexpected: [\(unexpectedIDs)])"
+        }
+    }
+}

--- a/Sources/Bonsplit/Public/Types/SplitOrientation.swift
+++ b/Sources/Bonsplit/Public/Types/SplitOrientation.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Orientation for splitting panes
-public enum SplitOrientation: String, Codable, Sendable {
+public enum SplitOrientation: String, Codable, Sendable, Equatable {
     /// Side-by-side split (left | right)
     case horizontal
     /// Stacked split (top / bottom)

--- a/Tests/BonsplitTests/AuthoritativeTreeTests.swift
+++ b/Tests/BonsplitTests/AuthoritativeTreeTests.swift
@@ -1,0 +1,509 @@
+import XCTest
+@testable import Bonsplit
+
+final class AuthoritativeTreeTests: XCTestCase {
+    @MainActor
+    private final class DelegateSpy: BonsplitDelegate {
+        private(set) var geometryNotifications = 0
+        private(set) var mutationCallbacks: [String] = []
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            shouldCreateTab tab: Tab,
+            inPane pane: PaneID
+        ) -> Bool {
+            mutationCallbacks.append("should-create-tab")
+            return true
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            shouldCloseTab tab: Tab,
+            inPane pane: PaneID
+        ) -> Bool {
+            mutationCallbacks.append("should-close-tab")
+            return true
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            didCreateTab tab: Tab,
+            inPane pane: PaneID
+        ) {
+            mutationCallbacks.append("did-create-tab")
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            didCloseTab tabId: TabID,
+            fromPane pane: PaneID
+        ) {
+            mutationCallbacks.append("did-close-tab")
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            didSelectTab tab: Tab,
+            inPane pane: PaneID
+        ) {
+            mutationCallbacks.append("did-select-tab")
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            didMoveTab tab: Tab,
+            fromPane source: PaneID,
+            toPane destination: PaneID
+        ) {
+            mutationCallbacks.append("did-move-tab")
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            didReorderTabsInPane pane: PaneID,
+            orderedTabIds: [TabID]
+        ) {
+            mutationCallbacks.append("did-reorder-tabs")
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            shouldSplitPane pane: PaneID,
+            orientation: SplitOrientation
+        ) -> Bool {
+            mutationCallbacks.append("should-split-pane")
+            return true
+        }
+
+        func splitTabBar(_ controller: BonsplitController, shouldClosePane pane: PaneID) -> Bool {
+            mutationCallbacks.append("should-close-pane")
+            return true
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            didSplitPane originalPane: PaneID,
+            newPane: PaneID,
+            orientation: SplitOrientation
+        ) {
+            mutationCallbacks.append("did-split-pane")
+        }
+
+        func splitTabBar(_ controller: BonsplitController, didClosePane paneId: PaneID) {
+            mutationCallbacks.append("did-close-pane")
+        }
+
+        func splitTabBar(_ controller: BonsplitController, didFocusPane pane: PaneID) {
+            mutationCallbacks.append("did-focus-pane")
+        }
+
+        func splitTabBar(
+            _ controller: BonsplitController,
+            didChangeGeometry snapshot: LayoutSnapshot
+        ) {
+            geometryNotifications += 1
+        }
+    }
+
+    @MainActor
+    func testApplyBuildsArbitraryTreePreservesMetadataAndSkipsMutationDelegates() throws {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let originalPane = try XCTUnwrap(controller.focusedPaneId)
+        let welcome = try XCTUnwrap(controller.tabs(inPane: originalPane).first?.id)
+        let alpha = try XCTUnwrap(controller.createTab(title: "Alpha"))
+        let beta = try XCTUnwrap(controller.createTab(title: "Beta"))
+        let gamma = try XCTUnwrap(controller.createTab(title: "Gamma"))
+        controller.updateTab(alpha, title: "Alpha metadata", isDirty: true, isPinned: true)
+        XCTAssertTrue(controller.setFullWidthTabMode(true, inPane: originalPane))
+
+        let secondPane = PaneID()
+        let thirdPane = PaneID()
+        let rootSplit = UUID()
+        let nestedSplit = UUID()
+        let tree = BonsplitAuthoritativeTree(
+            root: .split(.init(
+                id: rootSplit,
+                orientation: .vertical,
+                ratio: 0.6,
+                first: .pane(.init(id: thirdPane, tabs: [gamma])),
+                second: .split(.init(
+                    id: nestedSplit,
+                    orientation: .horizontal,
+                    ratio: 0.3,
+                    first: .pane(.init(id: originalPane, tabs: [beta, welcome])),
+                    second: .pane(.init(
+                        id: secondPane,
+                        tabs: [alpha],
+                        selection: .tab(alpha),
+                        fullWidthTabMode: .value(true)
+                    ))
+                ))
+            )),
+            focusedPane: .pane(thirdPane),
+            zoomedPane: .pane(secondPane)
+        )
+        requiresSendable(tree)
+
+        let delegate = DelegateSpy()
+        controller.delegate = delegate
+        try controller.validateAuthoritativeTree(tree)
+        XCTAssertTrue(try controller.applyAuthoritativeTree(tree))
+
+        XCTAssertEqual(controller.allPaneIds, [thirdPane, originalPane, secondPane])
+        XCTAssertEqual(controller.tabs(inPane: thirdPane).map(\.id), [gamma])
+        XCTAssertEqual(controller.tabs(inPane: originalPane).map(\.id), [beta, welcome])
+        XCTAssertEqual(controller.tabs(inPane: secondPane).map(\.id), [alpha])
+        XCTAssertEqual(controller.paneId(containing: alpha), secondPane)
+        XCTAssertEqual(controller.selectedTabId(inPane: originalPane), beta)
+        XCTAssertEqual(controller.selectedTabId(inPane: secondPane), alpha)
+        XCTAssertEqual(controller.focusedPaneId, thirdPane)
+        XCTAssertEqual(controller.zoomedPaneId, secondPane)
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: originalPane))
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: secondPane))
+        XCTAssertEqual(controller.tab(alpha)?.title, "Alpha metadata")
+        XCTAssertEqual(controller.tab(alpha)?.isDirty, true)
+        XCTAssertEqual(controller.tab(alpha)?.isPinned, true)
+        XCTAssertEqual(delegate.geometryNotifications, 1)
+        XCTAssertEqual(delegate.mutationCallbacks, [])
+
+        guard case .split(let root) = controller.internalController.rootNode,
+              case .split(let nested) = root.second else {
+            return XCTFail("expected nested authoritative split tree")
+        }
+        XCTAssertEqual(root.id, rootSplit)
+        XCTAssertEqual(root.orientation, .vertical)
+        XCTAssertEqual(root.dividerPosition, 0.6, accuracy: 0.000_001)
+        XCTAssertEqual(nested.id, nestedSplit)
+        XCTAssertEqual(nested.orientation, .horizontal)
+        XCTAssertEqual(nested.dividerPosition, 0.3, accuracy: 0.000_001)
+
+        let rootIdentity = root
+        let nestedIdentity = nested
+        let originalPaneIdentity = try XCTUnwrap(
+            controller.internalController.paneState(for: originalPane)
+        )
+        XCTAssertFalse(try controller.applyAuthoritativeTree(tree))
+        guard case .split(let unchangedRoot) = controller.internalController.rootNode,
+              case .split(let unchangedNested) = unchangedRoot.second else {
+            return XCTFail("expected unchanged nested split tree")
+        }
+        XCTAssertTrue(rootIdentity === unchangedRoot)
+        XCTAssertTrue(nestedIdentity === unchangedNested)
+        XCTAssertTrue(
+            originalPaneIdentity === controller.internalController.paneState(for: originalPane)
+        )
+        XCTAssertEqual(delegate.geometryNotifications, 1)
+        XCTAssertEqual(delegate.mutationCallbacks, [])
+    }
+
+    @MainActor
+    func testValidationFailureIsAtomic() throws {
+        let controller = BonsplitController()
+        let pane = try XCTUnwrap(controller.focusedPaneId)
+        let tab = try XCTUnwrap(controller.tabs(inPane: pane).first?.id)
+        let rootBefore = controller.internalController.rootNode
+        let paneBefore = try XCTUnwrap(controller.internalController.paneState(for: pane))
+        let focusBefore = controller.focusedPaneId
+        let selectionBefore = controller.selectedTabId(inPane: pane)
+        let delegate = DelegateSpy()
+        controller.delegate = delegate
+
+        let invalid = BonsplitAuthoritativeTree(
+            root: .split(.init(
+                id: UUID(),
+                orientation: .horizontal,
+                ratio: .nan,
+                first: .pane(.init(id: pane, tabs: [tab])),
+                second: .pane(.init(id: PaneID(), tabs: [tab]))
+            ))
+        )
+
+        XCTAssertThrowsError(try controller.validateAuthoritativeTree(invalid))
+        XCTAssertThrowsError(try controller.applyAuthoritativeTree(invalid))
+        XCTAssertTrue(sameRootIdentity(rootBefore, controller.internalController.rootNode))
+        XCTAssertTrue(paneBefore === controller.internalController.paneState(for: pane))
+        XCTAssertEqual(controller.allPaneIds, [pane])
+        XCTAssertEqual(controller.allTabIds, [tab])
+        XCTAssertEqual(controller.focusedPaneId, focusBefore)
+        XCTAssertEqual(controller.selectedTabId(inPane: pane), selectionBefore)
+        XCTAssertEqual(delegate.geometryNotifications, 0)
+        XCTAssertEqual(delegate.mutationCallbacks, [])
+    }
+
+    @MainActor
+    func testValidatorRejectsEveryReferenceAndIdentityInvariant() throws {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let pane = try XCTUnwrap(controller.focusedPaneId)
+        let first = try XCTUnwrap(controller.tabs(inPane: pane).first?.id)
+        let second = try XCTUnwrap(controller.createTab(title: "Second"))
+        let third = try XCTUnwrap(controller.createTab(title: "Third"))
+        let currentTabs: Set<TabID> = [first, second, third]
+        let otherPane = PaneID()
+
+        assertValidationError(
+            .paneHasNoTabs(pane),
+            controller: controller,
+            tree: .init(root: .pane(.init(id: pane, tabs: []))),
+            exactTabIDs: []
+        )
+        assertValidationError(
+            .duplicatePane(pane),
+            controller: controller,
+            tree: .init(root: .split(.init(
+                id: UUID(),
+                orientation: .horizontal,
+                ratio: 0.5,
+                first: .pane(.init(id: pane, tabs: [first])),
+                second: .pane(.init(id: pane, tabs: [second, third]))
+            ))),
+            exactTabIDs: currentTabs
+        )
+        assertValidationError(
+            .duplicateTab(first),
+            controller: controller,
+            tree: .init(root: .split(.init(
+                id: UUID(),
+                orientation: .horizontal,
+                ratio: 0.5,
+                first: .pane(.init(id: pane, tabs: [first, second])),
+                second: .pane(.init(id: otherPane, tabs: [first, third]))
+            ))),
+            exactTabIDs: currentTabs
+        )
+
+        let duplicateSplit = UUID()
+        assertValidationError(
+            .duplicateSplit(duplicateSplit),
+            controller: controller,
+            tree: .init(root: .split(.init(
+                id: duplicateSplit,
+                orientation: .horizontal,
+                ratio: 0.5,
+                first: .pane(.init(id: pane, tabs: [first])),
+                second: .split(.init(
+                    id: duplicateSplit,
+                    orientation: .vertical,
+                    ratio: 0.5,
+                    first: .pane(.init(id: otherPane, tabs: [second])),
+                    second: .pane(.init(id: PaneID(), tabs: [third]))
+                ))
+            ))),
+            exactTabIDs: currentTabs
+        )
+
+        let invalidRatioSplit = UUID()
+        assertValidationError(
+            .invalidSplitRatio(split: invalidRatioSplit, ratio: 1),
+            controller: controller,
+            tree: .init(root: .split(.init(
+                id: invalidRatioSplit,
+                orientation: .horizontal,
+                ratio: 1,
+                first: .pane(.init(id: pane, tabs: [first])),
+                second: .pane(.init(id: otherPane, tabs: [second, third]))
+            ))),
+            exactTabIDs: currentTabs
+        )
+
+        let absentTab = TabID()
+        assertValidationError(
+            .invalidSelectedTab(pane: pane, tab: absentTab),
+            controller: controller,
+            tree: .init(root: .pane(.init(
+                id: pane,
+                tabs: [first, second, third],
+                selection: .tab(absentTab)
+            ))),
+            exactTabIDs: currentTabs
+        )
+
+        let absentPane = PaneID()
+        assertValidationError(
+            .invalidFocusedPane(absentPane),
+            controller: controller,
+            tree: .init(
+                root: .pane(.init(id: pane, tabs: [first, second, third])),
+                focusedPane: .pane(absentPane)
+            ),
+            exactTabIDs: currentTabs
+        )
+        assertValidationError(
+            .invalidZoomedPane(absentPane),
+            controller: controller,
+            tree: .init(
+                root: .pane(.init(id: pane, tabs: [first, second, third])),
+                zoomedPane: .pane(absentPane)
+            ),
+            exactTabIDs: currentTabs
+        )
+        assertValidationError(
+            .zoomRequiresMultiplePanes(pane),
+            controller: controller,
+            tree: .init(
+                root: .pane(.init(id: pane, tabs: [first, second, third])),
+                zoomedPane: .pane(pane)
+            ),
+            exactTabIDs: currentTabs
+        )
+
+        let unexpected = TabID()
+        assertValidationError(
+            .tabSetMismatch(missing: [third], unexpected: [unexpected]),
+            controller: controller,
+            tree: .init(root: .pane(.init(id: pane, tabs: [first, second, unexpected]))),
+            exactTabIDs: currentTabs
+        )
+    }
+
+    @MainActor
+    func testExpectedTabSetOverloadSupportsPretransferValidation() throws {
+        let controller = BonsplitController()
+        let pane = try XCTUnwrap(controller.focusedPaneId)
+        let current = try XCTUnwrap(controller.tabs(inPane: pane).first?.id)
+        let incoming = TabID()
+        let destination = BonsplitAuthoritativeTree(
+            root: .pane(.init(id: pane, tabs: [current, incoming]))
+        )
+
+        XCTAssertNoThrow(try controller.validateAuthoritativeTree(
+            destination,
+            exactTabIDs: [current, incoming]
+        ))
+        XCTAssertThrowsError(try controller.validateAuthoritativeTree(destination))
+        XCTAssertThrowsError(try controller.applyAuthoritativeTree(destination))
+        XCTAssertEqual(controller.tabs(inPane: pane).map(\.id), [current])
+    }
+
+    @MainActor
+    func testDefaultPoliciesPreserveSurvivingPresentationStateAcrossRebuild() throws {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let firstPane = try XCTUnwrap(controller.focusedPaneId)
+        let welcome = try XCTUnwrap(controller.tabs(inPane: firstPane).first?.id)
+        let selected = try XCTUnwrap(controller.createTab(title: "Selected"))
+        let secondTab = Tab(title: "Second pane")
+        let secondPane = try XCTUnwrap(controller.splitPane(
+            firstPane,
+            orientation: .horizontal,
+            withTab: secondTab
+        ))
+        controller.selectTab(selected)
+        XCTAssertTrue(controller.setFullWidthTabMode(true, inPane: firstPane))
+        controller.focusPane(secondPane)
+        XCTAssertTrue(controller.togglePaneZoom(inPane: secondPane))
+
+        let replacement = BonsplitAuthoritativeTree(root: .split(.init(
+            id: UUID(),
+            orientation: .vertical,
+            ratio: 0.4,
+            first: .pane(.init(id: secondPane, tabs: [secondTab.id])),
+            second: .pane(.init(id: firstPane, tabs: [selected, welcome]))
+        )))
+
+        XCTAssertTrue(try controller.applyAuthoritativeTree(replacement))
+        XCTAssertEqual(controller.tabs(inPane: firstPane).map(\.id), [selected, welcome])
+        XCTAssertEqual(controller.selectedTabId(inPane: firstPane), selected)
+        XCTAssertTrue(controller.isFullWidthTabMode(inPane: firstPane))
+        XCTAssertEqual(controller.focusedPaneId, secondPane)
+        XCTAssertEqual(controller.zoomedPaneId, secondPane)
+    }
+
+    @MainActor
+    func testValidatorRejectsEmptyAndCrossKindNodeIdentities() throws {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let pane = try XCTUnwrap(controller.focusedPaneId)
+        let first = try XCTUnwrap(controller.tabs(inPane: pane).first?.id)
+        let second = try XCTUnwrap(controller.createTab(title: "Second"))
+        let currentTabs: Set<TabID> = [first, second]
+        let zero = UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+
+        assertValidationError(
+            .emptyPaneID,
+            controller: controller,
+            tree: .init(root: .pane(.init(
+                id: PaneID(id: zero),
+                tabs: [first, second]
+            ))),
+            exactTabIDs: currentTabs
+        )
+        assertValidationError(
+            .emptyTabID,
+            controller: controller,
+            tree: .init(root: .pane(.init(
+                id: pane,
+                tabs: [TabID(uuid: zero)]
+            ))),
+            exactTabIDs: [TabID(uuid: zero)]
+        )
+        assertValidationError(
+            .emptySplitID,
+            controller: controller,
+            tree: .init(root: .split(.init(
+                id: zero,
+                orientation: .horizontal,
+                ratio: 0.5,
+                first: .pane(.init(id: pane, tabs: [first])),
+                second: .pane(.init(id: PaneID(), tabs: [second]))
+            ))),
+            exactTabIDs: currentTabs
+        )
+
+        let collidingPane = PaneID()
+        assertValidationError(
+            .duplicateNodeIdentity(collidingPane.id),
+            controller: controller,
+            tree: .init(root: .split(.init(
+                id: collidingPane.id,
+                orientation: .horizontal,
+                ratio: 0.5,
+                first: .pane(.init(id: collidingPane, tabs: [first])),
+                second: .pane(.init(id: PaneID(), tabs: [second]))
+            ))),
+            exactTabIDs: currentTabs
+        )
+    }
+
+    @MainActor
+    private func assertValidationError(
+        _ expected: BonsplitAuthoritativeTreeError,
+        controller: BonsplitController,
+        tree: BonsplitAuthoritativeTree,
+        exactTabIDs: Set<TabID>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try controller.validateAuthoritativeTree(tree, exactTabIDs: exactTabIDs),
+            file: file,
+            line: line
+        ) { error in
+            XCTAssertEqual(
+                error as? BonsplitAuthoritativeTreeError,
+                expected,
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    @MainActor
+    private func sameRootIdentity(_ first: SplitNode, _ second: SplitNode) -> Bool {
+        switch (first, second) {
+        case (.pane(let lhs), .pane(let rhs)):
+            return lhs === rhs
+        case (.split(let lhs), .split(let rhs)):
+            return lhs === rhs
+        default:
+            return false
+        }
+    }
+
+    private func requiresSendable<T: Sendable>(_ value: T) {}
+}

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1540,6 +1540,19 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testCreateTabCanRestoreExactIdentityAndRejectsDuplicate() {
+        let controller = BonsplitController()
+        let restoredID = TabID()
+
+        XCTAssertEqual(
+            controller.createTab(title: "Restored", tabID: restoredID),
+            restoredID
+        )
+        XCTAssertNil(controller.createTab(title: "Duplicate", tabID: restoredID))
+        XCTAssertEqual(controller.allTabIds.filter { $0 == restoredID }.count, 1)
+    }
+
+    @MainActor
     func testCreateAndUpdateTabCustomTitleFlag() {
         let controller = BonsplitController()
         let tabId = controller.createTab(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -13,6 +13,45 @@ private final class DropZoneModel {
 
 final class BonsplitTests: XCTestCase {
     @MainActor
+    func testDividerInteractionConfigurationReachesManagedSplitView() throws {
+        for allowDividerResizing in [true, false] {
+            let controller = BonsplitController(configuration: BonsplitConfiguration(
+                allowDividerResizing: allowDividerResizing,
+                appearance: .init(enableAnimations: false)
+            ))
+            _ = controller.createTab(title: "Base")
+            let sourcePane = try XCTUnwrap(controller.focusedPaneId)
+            XCTAssertNotNil(controller.splitPane(sourcePane, orientation: .horizontal))
+
+            let hostingView = NSHostingView(
+                rootView: BonsplitView(controller: controller) { _, _ in
+                    Color.clear
+                } emptyPane: { _ in
+                    Color.clear
+                }
+            )
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            defer { window.orderOut(nil) }
+            let contentView = try XCTUnwrap(window.contentView)
+            hostingView.frame = contentView.bounds
+            hostingView.autoresizingMask = [.width, .height]
+            contentView.addSubview(hostingView)
+            window.makeKeyAndOrderFront(nil)
+            contentView.layoutSubtreeIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            contentView.layoutSubtreeIfNeeded()
+
+            let splitView = try XCTUnwrap(firstDescendant(ofType: ThemedSplitView.self, in: hostingView))
+            XCTAssertEqual(splitView.isDividerInteractionEnabled, allowDividerResizing)
+        }
+    }
+
+    @MainActor
     private final class FakeTabBarHitRegionView: NSView {
         deinit {
             BonsplitTabBarHitRegionRegistry.unregister(self)

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -8,6 +8,8 @@ final class EmbeddedConfigurationTests: XCTestCase {
 
         XCTAssertTrue(configuration.allowsTabContextMenu)
         XCTAssertEqual(configuration.dividerPositionRange, 0.1...0.9)
+        XCTAssertTrue(configuration.allowDividerResizing)
+        XCTAssertFalse(BonsplitConfiguration.readOnly.allowDividerResizing)
     }
 
     func testConfiguredDividerRangeAllowsNarrowProgrammaticLayouts() throws {
@@ -98,5 +100,22 @@ final class EmbeddedConfigurationTests: XCTestCase {
         ))
         XCTAssertEqual(controller.allPaneIds.count, paneCountBefore)
         XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
+    }
+
+    func testCallerCanInstallStablePaneIdentities() throws {
+        let rootPane = PaneID(id: UUID())
+        let secondPane = PaneID(id: UUID())
+        let controller = BonsplitController(initialPaneID: rootPane)
+
+        XCTAssertEqual(controller.allPaneIds, [rootPane])
+        XCTAssertEqual(
+            controller.splitPane(
+                rootPane,
+                orientation: .horizontal,
+                newPaneID: secondPane
+            ),
+            secondPane
+        )
+        XCTAssertEqual(Set(controller.allPaneIds), [rootPane, secondPane])
     }
 }


### PR DESCRIPTION
Adds caller-supplied stable IDs for root and split panes. Adds `allowDividerResizing` so read-only topology projections can reject pointer-driven divider changes while preserving programmatic projection updates.

Tests: `swift test --filter 'EmbeddedConfigurationTests|testDividerInteractionConfigurationReachesManagedSplitView'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786942094&installation_id=133855650&pr_number=191&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F191&signature=545ac84eb956fa5c18a2cd7bdac12b77e9f50a5e3780edb3053d9932160995ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stable, caller-supplied pane and tab IDs, a divider interaction flag, and an atomic authoritative tree API. This makes identity predictable, supports read-only projections, and enables safe, single-notification topology updates.

- **New Features**
  - Stable pane IDs
    - Set the initial root pane via `BonsplitController(initialPaneID:)`.
    - Provide IDs for new panes in split APIs via `newPaneID`.
  - Caller-supplied tab IDs
    - New `createTab(title:tabID:)` preserves exact tab identity during restore and rejects duplicates.
  - Divider interaction policy
    - New `BonsplitConfiguration.allowDividerResizing` (default true; false in `.readOnly`).
    - Disables divider cursor/drag in the managed split view; programmatic divider changes still work.
  - Authoritative split-tree transaction
    - New `BonsplitAuthoritativeTree` plus `validateAuthoritativeTree` and `applyAuthoritativeTree`.
    - Applies a complete topology atomically, preserves tab metadata and default presentation state, strictly validates the exact tab set and IDs, and emits exactly one geometry notification with no create/close/move/split delegate callbacks.

<sup>Written for commit c0f067fa54720b773a26bc968c36066283e68eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

