### PR TITLE
Fix floating tab drag ownership and fallback

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2697,6 +2697,11 @@ struct TabBarDragZoneView: NSViewRepresentable {
         // SplitNodeView.swift for the same class of bug on pane tab clicks.
         override var mouseDownCanMoveWindow: Bool { false }
 
+        // AppKit asks the hit view, not its outer NSHostingView, whether an
+        // inactive window should receive the activating mouse-down. Accepting
+        // it here preserves that same event as the start of the drag gesture.
+        override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             clearWindowDrag()

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -287,6 +287,14 @@ enum TabBarManualReorderPolicy {
     ) -> Bool {
         activeDragTabId != sourceTabId && draggingTabId != sourceTabId
     }
+
+    static func shouldApplyDeferredFallback(
+        sourceTabId: UUID,
+        originalTabIds: [UUID],
+        currentTabIds: [UUID]
+    ) -> Bool {
+        originalTabIds == currentTabIds && currentTabIds.contains(sourceTabId)
+    }
 }
 
 struct TabBarLayout: Equatable {
@@ -2120,6 +2128,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             session = ManualDragSession(
                 sourceTab: source,
                 sourcePaneId: pane.id,
+                originalTabIds: pane.tabs.map(\.id),
                 startPoint: point,
                 currentTargetIndex: nil,
                 didStartDrag: false
@@ -2154,17 +2163,37 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 return
             }
 
-            defer {
-                clearManualDrag()
+            let shouldApplyImmediately = TabBarManualReorderPolicy.shouldApplyFallback(
+                sourceTabId: session.sourceTab.id,
+                activeDragTabId: splitViewController?.activeDragTab?.id,
+                draggingTabId: splitViewController?.draggingTab?.id
+            )
+            clearManualDrag()
+
+            if shouldApplyImmediately {
+                applyFallback(session)
+                return
             }
 
+            // SwiftUI drop delegates run synchronously while dispatching mouseUp.
+            // Check on the next run loop only when that path started, and fall
+            // back only if it left the source pane byte-for-byte unchanged.
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      let pane = self.pane,
+                      TabBarManualReorderPolicy.shouldApplyDeferredFallback(
+                        sourceTabId: session.sourceTab.id,
+                        originalTabIds: session.originalTabIds,
+                        currentTabIds: pane.tabs.map(\.id)
+                      ) else { return }
+                self.applyFallback(session)
+            }
+        }
+
+        private func applyFallback(_ session: ManualDragSession) {
             guard session.didStartDrag,
-                  TabBarManualReorderPolicy.shouldApplyFallback(
-                    sourceTabId: session.sourceTab.id,
-                    activeDragTabId: splitViewController?.activeDragTab?.id,
-                    draggingTabId: splitViewController?.draggingTab?.id
-                  ),
                   let pane,
+                  pane.id == session.sourcePaneId,
                   let bonsplitController,
                   let targetIndex = session.currentTargetIndex,
                   !shouldSuppressIndicator(sourceTabId: session.sourceTab.id, targetIndex: targetIndex),
@@ -2241,6 +2270,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
         private struct ManualDragSession {
             let sourceTab: TabItem
             let sourcePaneId: PaneID
+            let originalTabIds: [UUID]
             let startPoint: NSPoint
             var currentTargetIndex: Int?
             var didStartDrag: Bool

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -268,6 +268,18 @@ enum TabBarStyling {
 
 }
 
+/// The AppKit monitor is a compatibility path for minimal chrome, where the
+/// normal SwiftUI drag recognizer can lose the mouse sequence to window chrome.
+/// Standard tab bars use the item-provider drag as their single drag owner.
+enum TabBarManualReorderPolicy {
+    static func shouldInstall(
+        allowsTabReordering: Bool,
+        isMinimalMode: Bool
+    ) -> Bool {
+        allowsTabReordering && isMinimalMode
+    }
+}
+
 struct TabBarLayout: Equatable {
     let barHeight: CGFloat
     let availableWidth: CGFloat
@@ -1017,7 +1029,10 @@ struct TabBarView: View {
 
     @ViewBuilder
     private var manualReorderTracker: some View {
-        if controller.configuration.allowTabReordering {
+        if TabBarManualReorderPolicy.shouldInstall(
+            allowsTabReordering: controller.configuration.allowTabReordering,
+            isMinimalMode: isMinimalMode
+        ) {
             TabBarManualReorderTrackingView(
                 pane: pane,
                 bonsplitController: controller,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2318,6 +2318,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         private var windowDidResignKeyObserver: NSObjectProtocol?
         private var localMouseMonitor: Any?
         private var isHovering = false
+        private var windowDragSession = BonsplitWindowDragSession()
 
         override var mouseDownCanMoveWindow: Bool { false }
 
@@ -2330,6 +2331,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            windowDragSession.end()
             BonsplitTabBarHitRegionRegistry.unregister(self)
             BonsplitTabItemHitRegionRegistry.unregister(self)
             removeWindowObservers()
@@ -2423,10 +2425,20 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
                 super.mouseDown(with: event)
                 return
             }
-            let wasMovable = window.isMovable
-            window.isMovable = true
-            window.performDrag(with: event)
-            window.isMovable = wasMovable
+            windowDragSession.begin(with: event, in: window)
+        }
+
+        override func mouseDragged(with event: NSEvent) {
+            guard isMinimalMode, let window, windowDragSession.isActive else {
+                super.mouseDragged(with: event)
+                return
+            }
+            windowDragSession.update(with: event, in: window)
+        }
+
+        override func mouseUp(with event: NSEvent) {
+            windowDragSession.end()
+            super.mouseUp(with: event)
         }
 
         func syncHoverStateToCurrentMouseLocation() {
@@ -2556,7 +2568,12 @@ struct TabBarDragZoneView: NSViewRepresentable {
         }
         var hitTestEventTypeOverride: NSEvent.EventType?
         var isMinimalMode = false {
-            didSet { invalidateWindowDragCursorRects() }
+            didSet {
+                if !isMinimalMode {
+                    clearWindowDrag()
+                }
+                invalidateWindowDragCursorRects()
+            }
         }
         var isFocusedPane = false
         var onSingleClick: (() -> Bool)?
@@ -2564,6 +2581,8 @@ struct TabBarDragZoneView: NSViewRepresentable {
         var performWindowDrag: ((NSEvent) -> Bool)?
         private var pendingWindowDragEvent: NSEvent?
         private var pendingWindowDragStart: NSPoint?
+        private var isWindowDragActive = false
+        private var windowDragSession = BonsplitWindowDragSession()
 
         private static let windowDragStartDistanceSquared: CGFloat = 16
 
@@ -2575,13 +2594,14 @@ struct TabBarDragZoneView: NSViewRepresentable {
         // own window-drag tracking. When AppKit steals mouseUp from the first
         // click, the second click of a double-click is registered as a fresh
         // clickCount=1 instead of 2, making new-tab double-clicks flaky. We
-        // still support window dragging via the custom mouseDragged →
-        // window.performDrag flow below. See `NonDraggableHostingView` in
+        // still support window dragging via the custom screen-space drag
+        // session below. See `NonDraggableHostingView` in
         // SplitNodeView.swift for the same class of bug on pane tab clicks.
         override var mouseDownCanMoveWindow: Bool { false }
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            clearWindowDrag()
             invalidateWindowDragCursorRects()
         }
 
@@ -2617,12 +2637,13 @@ struct TabBarDragZoneView: NSViewRepresentable {
             )
 #endif
             guard let window = self.window else {
+                clearWindowDrag()
                 super.mouseDown(with: event)
                 return
             }
+            clearWindowDrag()
 
             if !isMinimalMode {
-                clearPendingWindowDrag()
                 if event.clickCount == 1 {
                     if !isFocusedPane, onSingleClick?() == true {
 #if DEBUG
@@ -2650,7 +2671,6 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if event.clickCount >= 2 {
-                clearPendingWindowDrag()
 #if DEBUG
                 dlog("tab.bar.dragZone.doubleClick action=titlebar")
 #endif
@@ -2659,7 +2679,6 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
 
             if !isFocusedPane, onSingleClick?() == true {
-                clearPendingWindowDrag()
 #if DEBUG
                 dlog("tab.bar.dragZone.focusPane")
 #endif
@@ -2668,6 +2687,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
             pendingWindowDragEvent = event
             pendingWindowDragStart = event.locationInWindow
+            windowDragSession.begin(with: event, in: window)
         }
 
         private func shouldCaptureHit(at point: NSPoint) -> Bool {
@@ -2784,9 +2804,18 @@ struct TabBarDragZoneView: NSViewRepresentable {
         }
 
         override func mouseDragged(with event: NSEvent) {
-            guard isMinimalMode,
-                  let window,
-                  let pendingEvent = pendingWindowDragEvent,
+            guard isMinimalMode, let window else {
+                clearWindowDrag()
+                super.mouseDragged(with: event)
+                return
+            }
+
+            if isWindowDragActive {
+                windowDragSession.update(with: event, in: window)
+                return
+            }
+
+            guard let pendingEvent = pendingWindowDragEvent,
                   let start = pendingWindowDragStart else {
                 super.mouseDragged(with: event)
                 return
@@ -2804,12 +2833,25 @@ struct TabBarDragZoneView: NSViewRepresentable {
                 "dx=\(dx.rounded()) dy=\(dy.rounded())"
             )
 #endif
-            clearPendingWindowDrag()
-            startWindowDrag(with: pendingEvent, in: window)
+            if let performWindowDrag, performWindowDrag(pendingEvent) {
+                clearWindowDrag()
+#if DEBUG
+                dlog("tab.bar.dragZone.dragStart action=testHook")
+#endif
+                return
+            }
+
+            pendingWindowDragEvent = nil
+            pendingWindowDragStart = nil
+            isWindowDragActive = true
+            windowDragSession.update(with: event, in: window)
+#if DEBUG
+            dlog("tab.bar.dragZone.dragStart action=screenSpaceSession")
+#endif
         }
 
         override func mouseUp(with event: NSEvent) {
-            clearPendingWindowDrag()
+            clearWindowDrag()
             super.mouseUp(with: event)
         }
 
@@ -2818,20 +2860,10 @@ struct TabBarDragZoneView: NSViewRepresentable {
             pendingWindowDragStart = nil
         }
 
-        private func startWindowDrag(with event: NSEvent, in window: NSWindow) {
-            if let performWindowDrag, performWindowDrag(event) {
-#if DEBUG
-                dlog("tab.bar.dragZone.dragStart action=testHook")
-#endif
-                return
-            }
-            let wasMovable = window.isMovable
-            window.isMovable = true
-            defer { window.isMovable = wasMovable }
-            window.performDrag(with: event)
-#if DEBUG
-            dlog("tab.bar.dragZone.dragStart action=windowPerformDrag")
-#endif
+        private func clearWindowDrag() {
+            clearPendingWindowDrag()
+            isWindowDragActive = false
+            windowDragSession.end()
         }
 
         private func performTitlebarDoubleClickAction(in window: NSWindow) {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1003,6 +1003,19 @@ struct TabBarView: View {
         }
     }
 
+    /// Only the first leaf in Bonsplit's left/top-first tree owns window-leading
+    /// chrome. Other panes already have a split divider on their leading edge.
+    private var ownsWindowLeadingChrome: Bool {
+        appearance.tabBarLeadingInset > 0
+            && controller.internalController.rootNode.allPaneIds.first == pane.id
+    }
+
+    private var leadingChromeSeparatorBottomInset: CGFloat {
+        visibleTabEntries.first?.tab.id == pane.selectedTabId
+            ? TabBarMetrics.selectedTabLeftSeparatorBottomInset
+            : 0
+    }
+
     private var tabIds: [UUID] {
         pane.tabs.map(\.id)
     }
@@ -1113,13 +1126,20 @@ struct TabBarView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
+            if ownsWindowLeadingChrome {
                 TabBarDragZoneView(
                     doubleClickBehavior: emptyChromeDoubleClickBehavior,
                     isFocusedPane: isFocused,
                     onSingleClick: focusPaneFromTabBarChrome
                 ) { return false }
                     .frame(width: appearance.tabBarLeadingInset)
+                    .overlay(alignment: .trailing) {
+                        Rectangle()
+                            .fill(TabBarColors.separator(for: appearance))
+                            .frame(width: 1)
+                            .padding(.bottom, leadingChromeSeparatorBottomInset)
+                            .allowsHitTesting(false)
+                    }
             }
             // Scrollable tabs with fade overlays
             GeometryReader { containerGeo in

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -268,15 +268,24 @@ enum TabBarStyling {
 
 }
 
-/// The AppKit monitor is a compatibility path for minimal chrome, where the
-/// normal SwiftUI drag recognizer can lose the mouse sequence to window chrome.
-/// Standard tab bars use the item-provider drag as their single drag owner.
+/// The AppKit monitor is a compatibility path for hosts where the normal
+/// SwiftUI drag recognizer can lose the mouse sequence. It yields whenever a
+/// matching item-provider drag started, so one path completes each reorder.
 enum TabBarManualReorderPolicy {
     static func shouldInstall(
         allowsTabReordering: Bool,
-        isMinimalMode: Bool
+        isMinimalMode: Bool,
+        hostRequestsFallback: Bool
     ) -> Bool {
-        allowsTabReordering && isMinimalMode
+        allowsTabReordering && (isMinimalMode || hostRequestsFallback)
+    }
+
+    static func shouldApplyFallback(
+        sourceTabId: UUID,
+        activeDragTabId: UUID?,
+        draggingTabId: UUID?
+    ) -> Bool {
+        activeDragTabId != sourceTabId && draggingTabId != sourceTabId
     }
 }
 
@@ -1031,7 +1040,8 @@ struct TabBarView: View {
     private var manualReorderTracker: some View {
         if TabBarManualReorderPolicy.shouldInstall(
             allowsTabReordering: controller.configuration.allowTabReordering,
-            isMinimalMode: isMinimalMode
+            isMinimalMode: isMinimalMode,
+            hostRequestsFallback: controller.configuration.manualTabReorderFallbackEnabled
         ) {
             TabBarManualReorderTrackingView(
                 pane: pane,
@@ -2123,7 +2133,6 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             let dy = point.y - session.startPoint.y
             if !session.didStartDrag {
                 guard dx * dx + dy * dy >= Self.dragStartDistanceSquared else { return }
-                beginManualDrag(for: session)
                 session.didStartDrag = true
             }
 
@@ -2146,11 +2155,15 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             }
 
             defer {
-                clearControllerDragStateIfNeeded(sourceTabId: session.sourceTab.id)
                 clearManualDrag()
             }
 
             guard session.didStartDrag,
+                  TabBarManualReorderPolicy.shouldApplyFallback(
+                    sourceTabId: session.sourceTab.id,
+                    activeDragTabId: splitViewController?.activeDragTab?.id,
+                    draggingTabId: splitViewController?.draggingTab?.id
+                  ),
                   let pane,
                   let bonsplitController,
                   let targetIndex = session.currentTargetIndex,
@@ -2159,6 +2172,12 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
                 return
             }
 
+#if DEBUG
+            dlog(
+                "tab.manualReorderFallback pane=\(session.sourcePaneId.id.uuidString.prefix(5)) " +
+                    "tab=\(session.sourceTab.id.uuidString.prefix(5)) target=\(targetIndex)"
+            )
+#endif
             let orderBeforeReorder = pane.tabs.map { $0.id }
             withTransaction(Transaction(animation: nil)) {
                 pane.moveTab(from: currentSourceIndex, to: targetIndex)
@@ -2173,32 +2192,9 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
             }
         }
 
-        private func beginManualDrag(for session: ManualDragSession) {
-            guard let splitViewController else { return }
-#if DEBUG
-            dlog(
-                "tab.manualDragStart pane=\(session.sourcePaneId.id.uuidString.prefix(5)) " +
-                    "tab=\(session.sourceTab.id.uuidString.prefix(5)) title=\"\(session.sourceTab.title)\""
-            )
-#endif
-            _ = splitViewController.beginTabDrag(session.sourceTab, from: session.sourcePaneId)
-        }
-
         private func clearManualDrag() {
             session = nil
             onDropStateChanged?(nil, .idle)
-        }
-
-        private func clearControllerDragStateIfNeeded(sourceTabId: UUID) {
-            guard let splitViewController else { return }
-            if splitViewController.draggingTab?.id == sourceTabId {
-                splitViewController.draggingTab = nil
-                splitViewController.dragSourcePaneId = nil
-            }
-            if splitViewController.activeDragTab?.id == sourceTabId {
-                splitViewController.activeDragTab = nil
-                splitViewController.activeDragSourcePaneId = nil
-            }
         }
 
         private func tab(at point: NSPoint, in pane: PaneState) -> TabItem? {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -938,6 +938,10 @@ struct TabBarView: View {
         presentationMode == "minimal"
     }
 
+    private var emptyChromeDoubleClickBehavior: TabBarEmptyChromeDoubleClickBehavior {
+        isMinimalMode ? .titlebar : .newTabAction
+    }
+
     private var trailingTabContentInset: CGFloat {
         tabBarLayout.trailingTabContentInset
     }
@@ -1023,7 +1027,7 @@ struct TabBarView: View {
                 tabIds: tabIds,
                 reservedTrailingWidth: shouldRenderSplitButtons ? splitButtonsBackdropWidth : 0
             ),
-            isMinimalMode: isMinimalMode,
+            doubleClickBehavior: emptyChromeDoubleClickBehavior,
             isFocusedPane: isFocused,
             onSingleClick: focusPaneFromTabBarChrome
         ) {
@@ -1034,7 +1038,7 @@ struct TabBarView: View {
 
     private var dragAndHoverBackground: some View {
         TabBarDragAndHoverView(
-            isMinimalMode: isMinimalMode,
+            doubleClickBehavior: emptyChromeDoubleClickBehavior,
             geometryRegistry: tabItemGeometryRegistry,
             tabIds: tabIds,
             onDoubleClick: {
@@ -1111,7 +1115,7 @@ struct TabBarView: View {
         HStack(spacing: 0) {
             if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
                 TabBarDragZoneView(
-                    isMinimalMode: isMinimalMode,
+                    doubleClickBehavior: emptyChromeDoubleClickBehavior,
                     isFocusedPane: isFocused,
                     onSingleClick: focusPaneFromTabBarChrome
                 ) { return false }
@@ -1134,7 +1138,7 @@ struct TabBarView: View {
                         let trailing = max(0, containerGeo.size.width - contentWidth)
                         if trailing >= 1 {
                             TabBarDragZoneView(
-                                isMinimalMode: isMinimalMode,
+                                doubleClickBehavior: emptyChromeDoubleClickBehavior,
                                 isFocusedPane: isFocused,
                                 onSingleClick: focusPaneFromTabBarChrome
                             ) {
@@ -1380,7 +1384,7 @@ struct TabBarView: View {
     @ViewBuilder
     private var dropZoneAfterTabs: some View {
         TabBarDragZoneView(
-            isMinimalMode: isMinimalMode,
+            doubleClickBehavior: emptyChromeDoubleClickBehavior,
             isFocusedPane: isFocused,
             onSingleClick: focusPaneFromTabBarChrome
         ) {
@@ -2278,12 +2282,101 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
     }
 }
 
-/// Background view that provides window-drag-from-empty-space in minimal mode
+enum TabBarEmptyChromeDoubleClickBehavior {
+    case newTabAction
+    case titlebar
+}
+
+@MainActor
+private struct TabBarEmptyChromeDragGesture {
+    enum Update {
+        case inactive
+        case waiting
+        case started(dx: CGFloat, dy: CGFloat)
+        case moved
+        case handledByTestHook(dx: CGFloat, dy: CGFloat)
+    }
+
+    private enum Phase {
+        case idle
+        case armed(mouseDownEvent: NSEvent, startLocation: NSPoint)
+        case dragging
+    }
+
+    private static let startDistanceSquared: CGFloat = 16
+
+    private var phase = Phase.idle
+    private var windowDragSession = BonsplitWindowDragSession()
+
+    mutating func begin(with event: NSEvent, in window: NSWindow) {
+        end()
+        phase = .armed(
+            mouseDownEvent: event,
+            startLocation: event.locationInWindow
+        )
+        windowDragSession.begin(with: event, in: window)
+    }
+
+    mutating func update(
+        with event: NSEvent,
+        in window: NSWindow,
+        performWindowDrag: ((NSEvent) -> Bool)? = nil
+    ) -> Update {
+        switch phase {
+        case .idle:
+            return .inactive
+        case .armed(let mouseDownEvent, let startLocation):
+            let dx = event.locationInWindow.x - startLocation.x
+            let dy = event.locationInWindow.y - startLocation.y
+            guard dx * dx + dy * dy >= Self.startDistanceSquared else {
+                return .waiting
+            }
+            if let performWindowDrag, performWindowDrag(mouseDownEvent) {
+                end()
+                return .handledByTestHook(dx: dx, dy: dy)
+            }
+            phase = .dragging
+            windowDragSession.update(with: event, in: window)
+            return .started(dx: dx, dy: dy)
+        case .dragging:
+            windowDragSession.update(with: event, in: window)
+            return .moved
+        }
+    }
+
+    mutating func end() {
+        phase = .idle
+        windowDragSession.end()
+    }
+}
+
+@MainActor
+private func performTabBarEmptyChromeDoubleClick(
+    behavior: TabBarEmptyChromeDoubleClickBehavior,
+    in window: NSWindow,
+    newTabAction: () -> Bool
+) {
+    switch behavior {
+    case .newTabAction:
+        _ = newTabAction()
+    case .titlebar:
+        let action = UserDefaults.standard
+            .persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
+        switch action {
+        case "Minimize":
+            window.miniaturize(nil)
+        default:
+            window.zoom(nil)
+        }
+    }
+}
+
+/// Background view that provides window-drag-from-empty-space in every presentation mode
 /// and hover tracking via NSTrackingArea (replacing .contentShape + .onHover).
 /// As a .background(), AppKit routes clicks to tabs/buttons in front first;
 /// this view only receives hits in truly empty space.
 private struct TabBarDragAndHoverView: NSViewRepresentable {
-    let isMinimalMode: Bool
+    let doubleClickBehavior: TabBarEmptyChromeDoubleClickBehavior
     let geometryRegistry: TabBarItemGeometryRegistry
     let tabIds: [UUID]
     let onDoubleClick: () -> Bool
@@ -2291,7 +2384,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> TabBarBackgroundNSView {
         let view = TabBarBackgroundNSView()
-        view.isMinimalMode = isMinimalMode
+        view.doubleClickBehavior = doubleClickBehavior
         view.geometryRegistry = geometryRegistry
         view.tabIds = tabIds
         view.onDoubleClick = onDoubleClick
@@ -2300,7 +2393,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: TabBarBackgroundNSView, context: Context) {
-        nsView.isMinimalMode = isMinimalMode
+        nsView.doubleClickBehavior = doubleClickBehavior
         nsView.geometryRegistry = geometryRegistry
         nsView.tabIds = tabIds
         nsView.onDoubleClick = onDoubleClick
@@ -2308,7 +2401,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
     }
 
     final class TabBarBackgroundNSView: NSView, BonsplitTabItemHitRegionProviding {
-        var isMinimalMode = false
+        var doubleClickBehavior = TabBarEmptyChromeDoubleClickBehavior.newTabAction
         nonisolated(unsafe) var tabIds: [UUID] = []
         weak var geometryRegistry: TabBarItemGeometryRegistry?
         var onDoubleClick: (() -> Bool)?
@@ -2318,7 +2411,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
         private var windowDidResignKeyObserver: NSObjectProtocol?
         private var localMouseMonitor: Any?
         private var isHovering = false
-        private var windowDragSession = BonsplitWindowDragSession()
+        private var windowDragGesture = TabBarEmptyChromeDragGesture()
 
         override var mouseDownCanMoveWindow: Bool { false }
 
@@ -2331,7 +2424,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
-            windowDragSession.end()
+            windowDragGesture.end()
             BonsplitTabBarHitRegionRegistry.unregister(self)
             BonsplitTabItemHitRegionRegistry.unregister(self)
             removeWindowObservers()
@@ -2395,8 +2488,12 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
         override func mouseDown(with event: NSEvent) {
 #if DEBUG
-            dlog("tab.bar.bg.mouseDown isMinimal=\(isMinimalMode ? 1 : 0) clickCount=\(event.clickCount)")
+            dlog(
+                "tab.bar.bg.mouseDown doubleClickBehavior=\(String(describing: doubleClickBehavior)) " +
+                "clickCount=\(event.clickCount)"
+            )
 #endif
+            windowDragGesture.end()
             guard let window else {
                 super.mouseDown(with: event)
                 return
@@ -2409,35 +2506,28 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
                 return
             }
             if event.clickCount >= 2 {
-                if isMinimalMode {
-                    let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
-                    switch action {
-                    case "Minimize": window.miniaturize(nil)
-                    default: window.zoom(nil)
-                    }
-                    return
-                }
-                if onDoubleClick?() == true {
-                    return
-                }
-            }
-            guard isMinimalMode else {
-                super.mouseDown(with: event)
+                performTabBarEmptyChromeDoubleClick(
+                    behavior: doubleClickBehavior,
+                    in: window,
+                    newTabAction: { onDoubleClick?() == true }
+                )
                 return
             }
-            windowDragSession.begin(with: event, in: window)
+            windowDragGesture.begin(with: event, in: window)
         }
 
         override func mouseDragged(with event: NSEvent) {
-            guard isMinimalMode, let window, windowDragSession.isActive else {
+            guard let window else {
                 super.mouseDragged(with: event)
                 return
             }
-            windowDragSession.update(with: event, in: window)
+            if case .inactive = windowDragGesture.update(with: event, in: window) {
+                super.mouseDragged(with: event)
+            }
         }
 
         override func mouseUp(with event: NSEvent) {
-            windowDragSession.end()
+            windowDragGesture.end()
             super.mouseUp(with: event)
         }
 
@@ -2533,7 +2623,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
     }
 
     var hitRegion: HitRegion = .entireBounds
-    let isMinimalMode: Bool
+    let doubleClickBehavior: TabBarEmptyChromeDoubleClickBehavior
     let isFocusedPane: Bool
     let onSingleClick: () -> Bool
     let onDoubleClick: () -> Bool
@@ -2541,7 +2631,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
     func makeNSView(context: Context) -> DragNSView {
         let view = DragNSView()
         view.hitRegion = hitRegion
-        view.isMinimalMode = isMinimalMode
+        view.doubleClickBehavior = doubleClickBehavior
         view.isFocusedPane = isFocusedPane
         view.onSingleClick = onSingleClick
         view.onDoubleClick = onDoubleClick
@@ -2552,7 +2642,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
 
     func updateNSView(_ nsView: DragNSView, context: Context) {
         nsView.hitRegion = hitRegion
-        nsView.isMinimalMode = isMinimalMode
+        nsView.doubleClickBehavior = doubleClickBehavior
         nsView.isFocusedPane = isFocusedPane
         nsView.onSingleClick = onSingleClick
         nsView.onDoubleClick = onDoubleClick
@@ -2567,24 +2657,12 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
         }
         var hitTestEventTypeOverride: NSEvent.EventType?
-        var isMinimalMode = false {
-            didSet {
-                if !isMinimalMode {
-                    clearWindowDrag()
-                }
-                invalidateWindowDragCursorRects()
-            }
-        }
+        var doubleClickBehavior = TabBarEmptyChromeDoubleClickBehavior.newTabAction
         var isFocusedPane = false
         var onSingleClick: (() -> Bool)?
         var onDoubleClick: (() -> Bool)?
         var performWindowDrag: ((NSEvent) -> Bool)?
-        private var pendingWindowDragEvent: NSEvent?
-        private var pendingWindowDragStart: NSPoint?
-        private var isWindowDragActive = false
-        private var windowDragSession = BonsplitWindowDragSession()
-
-        private static let windowDragStartDistanceSquared: CGFloat = 16
+        private var windowDragGesture = TabBarEmptyChromeDragGesture()
 
         deinit {
             unregisterGeometryObserver(from: hitRegion)
@@ -2630,7 +2708,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
 #if DEBUG
             let point = convert(event.locationInWindow, from: nil)
             dlog(
-                "tab.bar.dragZone.mouseDown isMinimal=\(isMinimalMode ? 1 : 0) " +
+                "tab.bar.dragZone.mouseDown doubleClickBehavior=\(String(describing: doubleClickBehavior)) " +
                 "focused=\(isFocusedPane ? 1 : 0) clickCount=\(event.clickCount) " +
                 "point=\(point.x.rounded()),\(point.y.rounded()) " +
                 "bounds=\(bounds.width.rounded())x\(bounds.height.rounded())"
@@ -2643,38 +2721,18 @@ struct TabBarDragZoneView: NSViewRepresentable {
             }
             clearWindowDrag()
 
-            if !isMinimalMode {
-                if event.clickCount == 1 {
-                    if !isFocusedPane, onSingleClick?() == true {
-#if DEBUG
-                        dlog("tab.bar.dragZone.focusPane")
-#endif
-                    } else {
-#if DEBUG
-                        dlog("tab.bar.dragZone.click skipped reason=standardSingleClick clickCount=\(event.clickCount)")
-#endif
-                    }
-                    return
-                }
-                if event.clickCount >= 2 {
-                    if onDoubleClick?() == true {
-#if DEBUG
-                        dlog("tab.bar.dragZone.doubleClick action=newTab")
-#endif
-                        return
-                    }
-                }
-#if DEBUG
-                dlog("tab.bar.dragZone.click skipped reason=standardUnhandledClick clickCount=\(event.clickCount)")
-#endif
-                return
-            }
-
             if event.clickCount >= 2 {
 #if DEBUG
-                dlog("tab.bar.dragZone.doubleClick action=titlebar")
+                dlog(
+                    "tab.bar.dragZone.doubleClick action=" +
+                    "\(String(describing: doubleClickBehavior))"
+                )
 #endif
-                performTitlebarDoubleClickAction(in: window)
+                performTabBarEmptyChromeDoubleClick(
+                    behavior: doubleClickBehavior,
+                    in: window,
+                    newTabAction: { onDoubleClick?() == true }
+                )
                 return
             }
 
@@ -2682,12 +2740,9 @@ struct TabBarDragZoneView: NSViewRepresentable {
 #if DEBUG
                 dlog("tab.bar.dragZone.focusPane")
 #endif
-                return
             }
 
-            pendingWindowDragEvent = event
-            pendingWindowDragStart = event.locationInWindow
-            windowDragSession.begin(with: event, in: window)
+            windowDragGesture.begin(with: event, in: window)
         }
 
         private func shouldCaptureHit(at point: NSPoint) -> Bool {
@@ -2738,7 +2793,7 @@ struct TabBarDragZoneView: NSViewRepresentable {
         }
 
         func windowDragCursorRectsForCurrentState() -> [NSRect] {
-            guard isMinimalMode, !bounds.isEmpty else { return [] }
+            guard !bounds.isEmpty else { return [] }
 
             switch hitRegion {
             case .entireBounds:
@@ -2804,50 +2859,38 @@ struct TabBarDragZoneView: NSViewRepresentable {
         }
 
         override func mouseDragged(with event: NSEvent) {
-            guard isMinimalMode, let window else {
+            guard let window else {
                 clearWindowDrag()
                 super.mouseDragged(with: event)
                 return
             }
 
-            if isWindowDragActive {
-                windowDragSession.update(with: event, in: window)
-                return
-            }
-
-            guard let pendingEvent = pendingWindowDragEvent,
-                  let start = pendingWindowDragStart else {
+            switch windowDragGesture.update(
+                with: event,
+                in: window,
+                performWindowDrag: performWindowDrag
+            ) {
+            case .inactive:
                 super.mouseDragged(with: event)
-                return
-            }
-
-            let dx = event.locationInWindow.x - start.x
-            let dy = event.locationInWindow.y - start.y
-            guard dx * dx + dy * dy >= Self.windowDragStartDistanceSquared else {
-                return
-            }
-
+            case .waiting, .moved:
+                break
+            case .started(let dx, let dy):
 #if DEBUG
-            dlog(
-                "tab.bar.dragZone.dragStart " +
-                "dx=\(dx.rounded()) dy=\(dy.rounded())"
-            )
+                dlog(
+                    "tab.bar.dragZone.dragStart " +
+                    "dx=\(dx.rounded()) dy=\(dy.rounded()) " +
+                    "action=screenSpaceSession"
+                )
 #endif
-            if let performWindowDrag, performWindowDrag(pendingEvent) {
-                clearWindowDrag()
+            case .handledByTestHook(let dx, let dy):
 #if DEBUG
-                dlog("tab.bar.dragZone.dragStart action=testHook")
+                dlog(
+                    "tab.bar.dragZone.dragStart " +
+                    "dx=\(dx.rounded()) dy=\(dy.rounded()) " +
+                    "action=testHook"
+                )
 #endif
-                return
             }
-
-            pendingWindowDragEvent = nil
-            pendingWindowDragStart = nil
-            isWindowDragActive = true
-            windowDragSession.update(with: event, in: window)
-#if DEBUG
-            dlog("tab.bar.dragZone.dragStart action=screenSpaceSession")
-#endif
         }
 
         override func mouseUp(with event: NSEvent) {
@@ -2855,23 +2898,8 @@ struct TabBarDragZoneView: NSViewRepresentable {
             super.mouseUp(with: event)
         }
 
-        private func clearPendingWindowDrag() {
-            pendingWindowDragEvent = nil
-            pendingWindowDragStart = nil
-        }
-
         private func clearWindowDrag() {
-            clearPendingWindowDrag()
-            isWindowDragActive = false
-            windowDragSession.end()
-        }
-
-        private func performTitlebarDoubleClickAction(in window: NSWindow) {
-            let action = UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain)?["AppleActionOnDoubleClick"] as? String
-            switch action {
-            case "Minimize": window.miniaturize(nil)
-            default: window.zoom(nil)
-            }
+            windowDragGesture.end()
         }
     }
 }

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -59,6 +59,12 @@ public struct BonsplitConfiguration: Sendable {
     /// Whether to allow drag & drop reordering of tabs
     public var allowTabReordering: Bool
 
+    /// Installs an AppKit mouse-sequence fallback for hosts where SwiftUI's
+    /// item-provider drag recognizer does not reliably start. The fallback
+    /// only completes a same-pane reorder when no matching item-provider drag
+    /// owns the gesture.
+    public var manualTabReorderFallbackEnabled: Bool
+
     /// Whether to allow moving tabs between panes
     public var allowCrossPaneTabMove: Bool
 
@@ -112,6 +118,7 @@ public struct BonsplitConfiguration: Sendable {
         allowCloseTabs: Bool = true,
         allowCloseLastPane: Bool = false,
         allowTabReordering: Bool = true,
+        manualTabReorderFallbackEnabled: Bool = false,
         allowCrossPaneTabMove: Bool = true,
         allowsTabContextMenu: Bool = true,
         autoCloseEmptyPanes: Bool = true,
@@ -125,6 +132,7 @@ public struct BonsplitConfiguration: Sendable {
         self.allowCloseTabs = allowCloseTabs
         self.allowCloseLastPane = allowCloseLastPane
         self.allowTabReordering = allowTabReordering
+        self.manualTabReorderFallbackEnabled = manualTabReorderFallbackEnabled
         self.allowCrossPaneTabMove = allowCrossPaneTabMove
         self.allowsTabContextMenu = allowsTabContextMenu
         self.autoCloseEmptyPanes = autoCloseEmptyPanes

--- a/Sources/Bonsplit/Public/BonsplitWindowDragSession.swift
+++ b/Sources/Bonsplit/Public/BonsplitWindowDragSession.swift
@@ -1,0 +1,64 @@
+import AppKit
+
+/// Owns one explicit window-drag mouse sequence in screen coordinates.
+///
+/// AppKit's native `performDrag(with:)` does not reliably move child windows.
+/// Explicit chrome uses this session so the same mouse sequence works for both
+/// ordinary windows and windows attached to a workspace owner.
+@MainActor
+public struct BonsplitWindowDragSession {
+    private var windowIdentifier: ObjectIdentifier?
+    private var initialMouseLocation: NSPoint?
+    private var initialWindowOrigin: NSPoint?
+
+    public init() {}
+
+    public var isActive: Bool {
+        windowIdentifier != nil
+    }
+
+    public mutating func begin(with event: NSEvent, in window: NSWindow) {
+        window.makeKey()
+        windowIdentifier = ObjectIdentifier(window)
+        initialMouseLocation = window.convertPoint(toScreen: event.locationInWindow)
+        initialWindowOrigin = window.frame.origin
+    }
+
+    @discardableResult
+    public mutating func update(with event: NSEvent, in window: NSWindow) -> NSPoint? {
+        guard windowIdentifier == ObjectIdentifier(window),
+              let initialMouseLocation,
+              let initialWindowOrigin else {
+            return nil
+        }
+
+        let mouseLocation = window.convertPoint(toScreen: event.locationInWindow)
+        var proposedFrame = window.frame
+        proposedFrame.origin = Self.movedOrigin(
+            initialWindowOrigin: initialWindowOrigin,
+            initialMouseLocation: initialMouseLocation,
+            currentMouseLocation: mouseLocation
+        )
+        let targetScreen = NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? window.screen
+        let constrainedFrame = window.constrainFrameRect(proposedFrame, to: targetScreen)
+        window.setFrameOrigin(constrainedFrame.origin)
+        return constrainedFrame.origin
+    }
+
+    public mutating func end() {
+        windowIdentifier = nil
+        initialMouseLocation = nil
+        initialWindowOrigin = nil
+    }
+
+    public nonisolated static func movedOrigin(
+        initialWindowOrigin: NSPoint,
+        initialMouseLocation: NSPoint,
+        currentMouseLocation: NSPoint
+    ) -> NSPoint {
+        NSPoint(
+            x: initialWindowOrigin.x + currentMouseLocation.x - initialMouseLocation.x,
+            y: initialWindowOrigin.y + currentMouseLocation.y - initialMouseLocation.y
+        )
+    }
+}

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3960,7 +3960,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     func testTabBarDragZoneFocusesInactivePaneInMinimalMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = true
+        view.doubleClickBehavior = .titlebar
         view.isFocusedPane = false
 
         var focused = false
@@ -3999,7 +3999,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     func testTabBarDragZoneMinimalModeNeverRequestsNewTabAfterSingleThenDoubleClick() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = true
+        view.doubleClickBehavior = .titlebar
         view.isFocusedPane = true
 
         var requestedNewTab = false
@@ -4047,7 +4047,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     func testTabBarDragZoneDoubleClickDoesNotRequestNewTabInMinimalMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = true
+        view.doubleClickBehavior = .titlebar
         view.isFocusedPane = true
 
         var requestedNewTab = false
@@ -4085,7 +4085,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     func testTabBarDragZoneSingleClickDoesNotRequestNewTabInStandardMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = false
+        view.doubleClickBehavior = .newTabAction
         view.isFocusedPane = true
 
         var newTabCount = 0
@@ -4123,7 +4123,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     func testTabBarDragZoneSingleClickFocusesInactivePaneInStandardMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = false
+        view.doubleClickBehavior = .newTabAction
         view.isFocusedPane = false
 
         var focused = false
@@ -4167,7 +4167,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     func testTabBarDragZoneStandardModeDoubleClickCreatesOnlyOneTab() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = false
+        view.doubleClickBehavior = .newTabAction
         view.isFocusedPane = true
 
         var newTabCount = 0
@@ -4270,7 +4270,7 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testTabBarDragZoneCursorMarksOnlyMinimalModeWindowDragArea() {
+    func testTabBarDragZoneCursorMarksEmptyWindowDragAreaInEveryMode() {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 320, height: 30))
         view.hitRegion = .trailingEmptyChrome(
             tabFrames: [CGRect(x: 10, y: 0, width: 90, height: 30)],
@@ -4279,23 +4279,23 @@ final class BonsplitTests: XCTestCase {
 
         XCTAssertEqual(
             view.windowDragCursorRectsForCurrentState(),
-            [],
-            "Standard mode should not advertise tab-bar window dragging with an open-hand cursor"
+            [NSRect(x: 110, y: 0, width: 162, height: 30)],
+            "Standard mode should mark empty tab chrome as a window-drag area"
         )
 
-        view.isMinimalMode = true
+        view.doubleClickBehavior = .titlebar
 
         XCTAssertEqual(
             view.windowDragCursorRectsForCurrentState(),
             [NSRect(x: 110, y: 0, width: 162, height: 30)],
-            "Minimal mode should show the open-hand cursor only in empty chrome after the tab frames and before action buttons"
+            "Minimal mode should mark the same empty tab chrome as a window-drag area"
         )
     }
 
     @MainActor
     func testTabBarDragZoneCursorCoversEntireExplicitDragZoneInMinimalMode() {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = true
+        view.doubleClickBehavior = .titlebar
 
         XCTAssertEqual(
             view.windowDragCursorRectsForCurrentState(),
@@ -4307,7 +4307,7 @@ final class BonsplitTests: XCTestCase {
     @MainActor
     func testTabBarDragZoneKeepsFocusedPaneWindowDragInMinimalMode() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
-        view.isMinimalMode = true
+        view.doubleClickBehavior = .titlebar
         view.isFocusedPane = true
 
         var focused = false
@@ -4352,16 +4352,18 @@ final class BonsplitTests: XCTestCase {
 
     @MainActor
     func testTabBarDragZoneMovesChildWindowWhenNativeDragHandoffDoesNothing() throws {
-        try assertTabBarDragZoneMovesChildWindow(isMinimalMode: true)
+        try assertTabBarDragZoneMovesChildWindow(doubleClickBehavior: .titlebar)
     }
 
     @MainActor
     func testTabBarDragZoneMovesChildWindowInStandardMode() throws {
-        try assertTabBarDragZoneMovesChildWindow(isMinimalMode: false)
+        try assertTabBarDragZoneMovesChildWindow(doubleClickBehavior: .newTabAction)
     }
 
     @MainActor
-    private func assertTabBarDragZoneMovesChildWindow(isMinimalMode: Bool) throws {
+    private func assertTabBarDragZoneMovesChildWindow(
+        doubleClickBehavior: TabBarEmptyChromeDoubleClickBehavior
+    ) throws {
         let parent = NSWindow(
             contentRect: NSRect(x: 40, y: 80, width: 500, height: 320),
             styleMask: [.titled],
@@ -4383,7 +4385,7 @@ final class BonsplitTests: XCTestCase {
         let view = TabBarDragZoneView.DragNSView(
             frame: NSRect(x: 0, y: 0, width: 160, height: 30)
         )
-        view.isMinimalMode = isMinimalMode
+        view.doubleClickBehavior = doubleClickBehavior
         view.isFocusedPane = true
         child.contentView?.addSubview(view)
         parent.addChildWindow(child, ordered: .above)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -4008,6 +4008,16 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabBarDragZoneAcceptsFirstMouseInInactiveWindow() {
+        let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
+
+        XCTAssertTrue(
+            view.acceptsFirstMouse(for: nil),
+            "Empty titlebar chrome must receive the first drag gesture while its window is inactive"
+        )
+    }
+
+    @MainActor
     func testTabBarDragZoneMinimalModeNeverRequestsNewTabAfterSingleThenDoubleClick() throws {
         let view = TabBarDragZoneView.DragNSView(frame: NSRect(x: 0, y: 0, width: 160, height: 30))
         view.doubleClickBehavior = .titlebar

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -4350,6 +4350,60 @@ final class BonsplitTests: XCTestCase {
         XCTAssertFalse(view.mouseDownCanMoveWindow, "Focused-pane drag zone must not advertise window dragging to AppKit or AppKit steals mouseUp and breaks new-tab double-clicks")
     }
 
+    @MainActor
+    func testTabBarDragZoneMovesChildWindowWhenNativeDragHandoffDoesNothing() throws {
+        let parent = NSWindow(
+            contentRect: NSRect(x: 40, y: 80, width: 500, height: 320),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let child = NoOpNativeDragWindow(
+            contentRect: NSRect(x: 100, y: 140, width: 200, height: 60),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            parent.removeChildWindow(child)
+            child.orderOut(nil)
+            parent.orderOut(nil)
+        }
+
+        let view = TabBarDragZoneView.DragNSView(
+            frame: NSRect(x: 0, y: 0, width: 160, height: 30)
+        )
+        view.isMinimalMode = true
+        view.isFocusedPane = true
+        child.contentView?.addSubview(view)
+        parent.addChildWindow(child, ordered: .above)
+        parent.orderFront(nil)
+        child.orderFront(nil)
+
+        let initialOrigin = child.frame.origin
+        let mouseDown = try makeLeftMouseDownEvent(
+            in: view,
+            at: NSPoint(x: 20, y: 15),
+            clickCount: 1
+        )
+        let mouseDragged = try makeMouseEvent(
+            type: .leftMouseDragged,
+            in: view,
+            at: NSPoint(x: 50, y: 35),
+            clickCount: 1
+        )
+
+        view.mouseDown(with: mouseDown)
+        view.mouseDragged(with: mouseDragged)
+
+        XCTAssertEqual(
+            child.frame.origin,
+            NSPoint(x: initialOrigin.x + 30, y: initialOrigin.y + 20),
+            "Empty tab chrome must move a child window even when native performDrag cannot take ownership"
+        )
+        XCTAssertTrue(child.parent === parent)
+    }
+
     private func withShortcutHintDefaultsSuite(_ body: (UserDefaults) -> Void) {
         let suiteName = "BonsplitShortcutHintPolicyTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -5568,4 +5622,9 @@ final class BonsplitTests: XCTestCase {
         let configured = BonsplitConfiguration.Appearance(tabWidthMode: .fill)
         XCTAssertEqual(configured.tabWidthMode, .fill)
     }
+}
+
+@MainActor
+private final class NoOpNativeDragWindow: NSWindow {
+    override func performDrag(with event: NSEvent) {}
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3029,6 +3029,17 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testLeadingTabBarInsetEndsWithSeparator() {
+        guard let alphas = renderedLeadingTabBarInsetBoundaryAlphas() else {
+            XCTFail("Expected rendered leading tab-bar inset boundary alphas")
+            return
+        }
+
+        XCTAssertLessThan(alphas.inset, 0.1)
+        XCTAssertGreaterThan(alphas.boundary, 0.3)
+    }
+
+    @MainActor
     func testInactiveSelectedTabIndicatorUsesDesaturatedAccent() {
         guard let focusedSaturation = renderedTabBarIndicatorSaturation(isFocused: true),
               let unfocusedSaturation = renderedTabBarIndicatorSaturation(isFocused: false) else {
@@ -5210,6 +5221,36 @@ final class BonsplitTests: XCTestCase {
                 return nil
             }
             return (top: top, bottom: bottom)
+        }
+    }
+
+    @MainActor
+    private func renderedLeadingTabBarInsetBoundaryAlphas() -> (inset: CGFloat, boundary: CGFloat)? {
+        let leadingInset: CGFloat = 80
+        let appearance = BonsplitConfiguration.Appearance(
+            tabBarLeadingInset: leadingInset,
+            chromeColors: .init(
+                backgroundHex: "#00000000",
+                tabBarBackgroundHex: "#00000000",
+                borderHex: "#FFFFFF80"
+            )
+        )
+        return renderedTabBarValue(
+            isFocused: true,
+            appearance: appearance,
+            size: NSSize(width: 320, height: TabBarMetrics.barHeight)
+        ) { hostingView in
+            guard let inset = renderedColorInViewCoordinates(
+                in: hostingView,
+                at: NSPoint(x: leadingInset - 2, y: 4)
+            )?.usingColorSpace(.sRGB)?.alphaComponent,
+                  let boundary = renderedColorInViewCoordinates(
+                    in: hostingView,
+                    at: NSPoint(x: leadingInset - 0.5, y: 4)
+                  )?.usingColorSpace(.sRGB)?.alphaComponent else {
+                return nil
+            }
+            return (inset: inset, boundary: boundary)
         }
     }
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -4352,6 +4352,16 @@ final class BonsplitTests: XCTestCase {
 
     @MainActor
     func testTabBarDragZoneMovesChildWindowWhenNativeDragHandoffDoesNothing() throws {
+        try assertTabBarDragZoneMovesChildWindow(isMinimalMode: true)
+    }
+
+    @MainActor
+    func testTabBarDragZoneMovesChildWindowInStandardMode() throws {
+        try assertTabBarDragZoneMovesChildWindow(isMinimalMode: false)
+    }
+
+    @MainActor
+    private func assertTabBarDragZoneMovesChildWindow(isMinimalMode: Bool) throws {
         let parent = NSWindow(
             contentRect: NSRect(x: 40, y: 80, width: 500, height: 320),
             styleMask: [.titled],
@@ -4373,7 +4383,7 @@ final class BonsplitTests: XCTestCase {
         let view = TabBarDragZoneView.DragNSView(
             frame: NSRect(x: 0, y: 0, width: 160, height: 30)
         )
-        view.isMinimalMode = true
+        view.isMinimalMode = isMinimalMode
         view.isFocusedPane = true
         child.contentView?.addSubview(view)
         parent.addChildWindow(child, ordered: .above)
@@ -4399,7 +4409,7 @@ final class BonsplitTests: XCTestCase {
         XCTAssertEqual(
             child.frame.origin,
             NSPoint(x: initialOrigin.x + 30, y: initialOrigin.y + 20),
-            "Empty tab chrome must move a child window even when native performDrag cannot take ownership"
+            "Empty tab chrome must move a child window in every presentation mode"
         )
         XCTAssertTrue(child.parent === parent)
     }

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -100,18 +100,45 @@ final class EmbeddedConfigurationTests: XCTestCase {
         XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
     }
 
-    func testManualTabReorderFallbackOnlyOwnsMinimalModeDrags() {
+    func testManualTabReorderFallbackInstallsForMinimalModeOrExplicitHostRequest() {
         XCTAssertFalse(TabBarManualReorderPolicy.shouldInstall(
             allowsTabReordering: true,
-            isMinimalMode: false
+            isMinimalMode: false,
+            hostRequestsFallback: false
         ))
         XCTAssertTrue(TabBarManualReorderPolicy.shouldInstall(
             allowsTabReordering: true,
-            isMinimalMode: true
+            isMinimalMode: true,
+            hostRequestsFallback: false
+        ))
+        XCTAssertTrue(TabBarManualReorderPolicy.shouldInstall(
+            allowsTabReordering: true,
+            isMinimalMode: false,
+            hostRequestsFallback: true
         ))
         XCTAssertFalse(TabBarManualReorderPolicy.shouldInstall(
             allowsTabReordering: false,
-            isMinimalMode: true
+            isMinimalMode: true,
+            hostRequestsFallback: true
+        ))
+    }
+
+    func testManualTabReorderFallbackYieldsToMatchingItemProviderDrag() {
+        let sourceTabId = UUID()
+        XCTAssertTrue(TabBarManualReorderPolicy.shouldApplyFallback(
+            sourceTabId: sourceTabId,
+            activeDragTabId: nil,
+            draggingTabId: nil
+        ))
+        XCTAssertFalse(TabBarManualReorderPolicy.shouldApplyFallback(
+            sourceTabId: sourceTabId,
+            activeDragTabId: sourceTabId,
+            draggingTabId: nil
+        ))
+        XCTAssertFalse(TabBarManualReorderPolicy.shouldApplyFallback(
+            sourceTabId: sourceTabId,
+            activeDragTabId: nil,
+            draggingTabId: sourceTabId
         ))
     }
 }

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -141,4 +141,26 @@ final class EmbeddedConfigurationTests: XCTestCase {
             draggingTabId: sourceTabId
         ))
     }
+
+    func testDeferredManualFallbackOnlyAppliesToAnUnchangedSourcePane() {
+        let sourceTabId = UUID()
+        let siblingTabId = UUID()
+        let originalOrder = [siblingTabId, sourceTabId]
+
+        XCTAssertTrue(TabBarManualReorderPolicy.shouldApplyDeferredFallback(
+            sourceTabId: sourceTabId,
+            originalTabIds: originalOrder,
+            currentTabIds: originalOrder
+        ))
+        XCTAssertFalse(TabBarManualReorderPolicy.shouldApplyDeferredFallback(
+            sourceTabId: sourceTabId,
+            originalTabIds: originalOrder,
+            currentTabIds: [sourceTabId, siblingTabId]
+        ))
+        XCTAssertFalse(TabBarManualReorderPolicy.shouldApplyDeferredFallback(
+            sourceTabId: sourceTabId,
+            originalTabIds: originalOrder,
+            currentTabIds: [siblingTabId]
+        ))
+    }
 }

--- a/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
+++ b/Tests/BonsplitTests/EmbeddedConfigurationTests.swift
@@ -99,4 +99,19 @@ final class EmbeddedConfigurationTests: XCTestCase {
         XCTAssertEqual(controller.allPaneIds.count, paneCountBefore)
         XCTAssertEqual(controller.tabs(inPane: rootPane).map(\.id), orderBefore)
     }
+
+    func testManualTabReorderFallbackOnlyOwnsMinimalModeDrags() {
+        XCTAssertFalse(TabBarManualReorderPolicy.shouldInstall(
+            allowsTabReordering: true,
+            isMinimalMode: false
+        ))
+        XCTAssertTrue(TabBarManualReorderPolicy.shouldInstall(
+            allowsTabReordering: true,
+            isMinimalMode: true
+        ))
+        XCTAssertFalse(TabBarManualReorderPolicy.shouldInstall(
+            allowsTabReordering: false,
+            isMinimalMode: true
+        ))
+    }
 }


### PR DESCRIPTION
Standard tab bars use the SwiftUI item-provider drag as their primary owner. Hosts that need AppKit tracking in custom window chrome can opt into `manualTabReorderFallbackEnabled`.

The fallback observes the same mouse sequence, yields when the matching item-provider drag starts, and defers recovery after cancellation. Recovery mutates only when the source pane and its exact tab order are unchanged, preventing a successful SwiftUI drop from being applied twice. cmux Floating Docks enable this host-scoped fallback through https://github.com/manaflow-ai/cmux/pull/8351.

Empty tab chrome uses one screen-space window-drag session in standard and minimal modes. The actual AppKit drag-zone view accepts the first mouse event, so an inactive child window starts moving on its first gesture while tab hit regions retain tab-drag ownership.

Regression history is preserved as test-only commits followed by fixes for event ownership, host-scoped fallback behavior, cancelled item-provider recovery, and inactive-window first-mouse routing. The focused inactive-window regression passes; the prior full suite passed 204 tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787355773&installation_model_id=21920&pr_number=192&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F192&signature=3eb8324b845add33848c555f003527fef141552e904dc6312c96d843a9f6f724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab reordering behavior so manual drag handling is limited to minimal-mode tab bars when reordering is enabled.
  * Prevented unintended manual drag handling in non-minimal tab bar layouts.

* **Tests**
  * Added coverage for tab reordering behavior across minimal and non-minimal modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standard tab bars now use SwiftUI item‑provider drags as the single owner with a safe AppKit fallback. Empty tab chrome uses a screen‑space window‑drag session across modes and accepts the first click in inactive windows so the initial drag always works; the leading inset now draws a separator at the window‑chrome boundary.

- **New Features**
  - Added `manualTabReorderFallbackEnabled` to `BonsplitConfiguration` to opt into the fallback outside minimal mode.
  - Added `BonsplitWindowDragSession` and unified empty tab‑bar window dragging across standard and minimal modes.
  - Mode‑aware double‑clicks on empty chrome: new tab in standard mode, titlebar action in minimal mode.
  - Draw a separator at the end of the leading tab‑bar inset when the pane owns window‑leading chrome.

- **Bug Fixes**
  - Centralized reorder ownership with `TabBarManualReorderPolicy`, including yield‑to‑item‑provider and a deferred fallback that applies only when the source pane is unchanged.
  - Replaced native `performDrag(with:)` with `BonsplitWindowDragSession` for empty tab chrome in all modes, fixing child‑window dragging and standard‑mode empty‑chrome dragging, and preserving the first drag on inactive windows by accepting the first mouse.

<sup>Written for commit f334bf05062b3f51eded70c9e633badeb15a914b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

