### PR TITLE
Add per-selection-state TabStyle overrides for the surface tab bar

### DIFF
--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -331,7 +331,9 @@ enum TabBarColors {
     ) -> NSColor {
         if let hex = appearance.tabStyle.activeIndicatorHex,
            let override = NSColor(bonsplitHex: hex) {
-            return override
+            // Apply the same saturation the derived indicator uses so a themed
+            // indicator dims consistently when the window loses focus.
+            return override.bonsplitSaturating(by: saturation)
         }
         return nsColorActiveIndicator(saturation: saturation)
     }

--- a/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
+++ b/Sources/Bonsplit/Internal/Styling/TabBarColors.swift
@@ -41,6 +41,17 @@ enum TabBarColors {
         return resolved.alphaComponent <= 0.001 ? nil : resolved
     }
 
+    /// Resolves a host-supplied ``TabStyle`` hex override into an `NSColor`.
+    ///
+    /// Returns `.clear` for the sentinel `"none"` so callers can hide an element
+    /// (e.g. the divider), the parsed color for a valid hex, and `nil` when the
+    /// override is unset — letting the caller fall back to derived styling.
+    private static func tabStyleColor(_ hex: String?) -> NSColor? {
+        guard let hex else { return nil }
+        if hex.caseInsensitiveCompare("none") == .orderedSame { return .clear }
+        return NSColor(bonsplitHex: hex)
+    }
+
     private static func semanticTabBarBackgroundColor(
         for appearance: BonsplitConfiguration.Appearance
     ) -> NSColor? {
@@ -93,6 +104,14 @@ enum TabBarColors {
         for appearance: BonsplitConfiguration.Appearance,
         secondary: Bool
     ) -> NSColor {
+        // Explicit per-state label overrides win over any derived text color.
+        let overrideHex = secondary
+            ? appearance.tabStyle.inactiveForegroundHex
+            : appearance.tabStyle.activeForegroundHex
+        if let overrideHex, let overrideColor = NSColor(bonsplitHex: overrideHex) {
+            return overrideColor
+        }
+
         guard let custom = semanticTabBarBackgroundColor(for: appearance) else {
             return secondary ? .secondaryLabelColor : .labelColor
         }
@@ -164,6 +183,9 @@ enum TabBarColors {
     }
 
     static func activeTabBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        if let override = tabStyleColor(appearance.tabStyle.activeBackgroundHex) {
+            return Color(nsColor: override)
+        }
         guard let custom = tabBarBackgroundColor(for: appearance) else {
             return activeTabBackground
         }
@@ -181,6 +203,9 @@ enum TabBarColors {
     }
 
     static func hoveredTabBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        if let override = tabStyleColor(appearance.tabStyle.hoverBackgroundHex) {
+            return Color(nsColor: override)
+        }
         guard let custom = tabBarBackgroundColor(for: appearance) else {
             return hoveredTabBackground
         }
@@ -199,6 +224,13 @@ enum TabBarColors {
 
     static var inactiveTabBackground: Color {
         .clear
+    }
+
+    static func inactiveTabBackground(for appearance: BonsplitConfiguration.Appearance) -> Color {
+        if let override = tabStyleColor(appearance.tabStyle.inactiveBackgroundHex) {
+            return Color(nsColor: override)
+        }
+        return inactiveTabBackground
     }
 
     // MARK: - Text Colors
@@ -249,6 +281,10 @@ enum TabBarColors {
     }
 
     static func nsColorSeparator(for appearance: BonsplitConfiguration.Appearance) -> NSColor {
+        // An explicit tab divider override (including `"none"` → transparent) wins.
+        if let override = tabStyleColor(appearance.tabStyle.dividerHex) {
+            return override
+        }
         if let explicit = chromeBorderColor(for: appearance) {
             return explicit
         }
@@ -278,6 +314,26 @@ enum TabBarColors {
 
     static func nsColorActiveIndicator(saturation: Double) -> NSColor {
         NSColor.controlAccentColor.bonsplitSaturating(by: saturation)
+    }
+
+    static func activeIndicator(
+        for appearance: BonsplitConfiguration.Appearance,
+        saturation: Double
+    ) -> Color {
+        Color(nsColor: nsColorActiveIndicator(for: appearance, saturation: saturation))
+    }
+
+    /// The selected-tab accent color, preferring an explicit ``TabStyle`` override
+    /// over the system-accent–derived indicator so the highlight can match a theme.
+    static func nsColorActiveIndicator(
+        for appearance: BonsplitConfiguration.Appearance,
+        saturation: Double
+    ) -> NSColor {
+        if let hex = appearance.tabStyle.activeIndicatorHex,
+           let override = NSColor(bonsplitHex: hex) {
+            return override
+        }
+        return nsColorActiveIndicator(saturation: saturation)
     }
 
     static var focusRing: Color {

--- a/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
@@ -14,6 +14,7 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
     let selectedTabId: UUID?
     let geometryRegistry: TabBarItemGeometryRegistry
     let indicatorColor: NSColor
+    let indicatorEdge: BonsplitConfiguration.Appearance.TabStyle.IndicatorEdge
     let separatorColor: NSColor
     let mask: TabBarSelectionChromeMask
 
@@ -37,6 +38,7 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
     private func update(_ view: ChromeNSView) {
         view.selectedTabId = selectedTabId
         view.indicatorColor = indicatorColor
+        view.indicatorEdge = indicatorEdge
         view.separatorColor = separatorColor
         view.mask = mask
         view.needsDisplay = true
@@ -46,6 +48,7 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
         weak var geometryRegistry: TabBarItemGeometryRegistry?
         var selectedTabId: UUID?
         var indicatorColor: NSColor = .controlAccentColor
+        var indicatorEdge: BonsplitConfiguration.Appearance.TabStyle.IndicatorEdge = .top
         var separatorColor: NSColor = .separatorColor
         var mask = TabBarSelectionChromeMask(
             leftFadeWidth: 0,
@@ -151,11 +154,32 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
             }
         }
 
-        private func drawSelectedIndicator(in selectedFrame: CGRect?) {
-            guard var frame = selectedFrame else { return }
-            frame.origin.y = bounds.minY
-            frame.size.width = max(0, frame.width - TabBarMetrics.activeIndicatorTrailingInset)
+        /// Positions the active-tab indicator line on the configured edge.
+        ///
+        /// The chrome view is flipped, so `minY` is the top edge and `maxY` the
+        /// bottom. `.top` (and `.hidden`, which is drawn transparent) keep the
+        /// historical top placement; `.bottom` pins the line to the bottom edge.
+        nonisolated static func positionedIndicatorFrame(
+            base: CGRect,
+            in bounds: CGRect,
+            edge: BonsplitConfiguration.Appearance.TabStyle.IndicatorEdge
+        ) -> CGRect {
+            var frame = base
+            frame.size.width = max(0, base.width - TabBarMetrics.activeIndicatorTrailingInset)
             frame.size.height = TabBarMetrics.activeIndicatorHeight
+            frame.origin.y = edge == .bottom
+                ? max(bounds.minY, bounds.maxY - frame.size.height)
+                : bounds.minY
+            return frame
+        }
+
+        private func drawSelectedIndicator(in selectedFrame: CGRect?) {
+            guard let selectedFrame else { return }
+            let frame = Self.positionedIndicatorFrame(
+                base: selectedFrame,
+                in: bounds,
+                edge: indicatorEdge
+            )
 
             let leftFadeFrame = NSRect(
                 x: bounds.minX,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -974,12 +974,21 @@ struct TabBarView: View {
         pane.tabs.map(\.id)
     }
 
+    private var selectionIndicatorColor: NSColor {
+        // A `.hidden` indicator edge suppresses the accent line entirely; any other
+        // edge keeps it, preferring an explicit theme override over the accent.
+        if appearance.tabStyle.activeIndicatorEdge == .hidden {
+            return .clear
+        }
+        return TabBarColors.nsColorActiveIndicator(for: appearance, saturation: tabBarSaturation)
+    }
+
     @ViewBuilder
     private var selectionChrome: some View {
         TabBarSelectionChromeView(
             selectedTabId: pane.selectedTabId,
             geometryRegistry: tabItemGeometryRegistry,
-            indicatorColor: TabBarColors.nsColorActiveIndicator(saturation: tabBarSaturation),
+            indicatorColor: selectionIndicatorColor,
             separatorColor: TabBarColors.nsColorSeparator(for: appearance),
             mask: selectionChromeMask
         )

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -989,6 +989,7 @@ struct TabBarView: View {
             selectedTabId: pane.selectedTabId,
             geometryRegistry: tabItemGeometryRegistry,
             indicatorColor: selectionIndicatorColor,
+            indicatorEdge: appearance.tabStyle.activeIndicatorEdge ?? .top,
             separatorColor: TabBarColors.nsColorSeparator(for: appearance),
             mask: selectionChromeMask
         )

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -529,17 +529,30 @@ struct TabItemView: View {
     private var tabTitleFont: Font {
         let size = appearance.tabTitleFontSize
         let style = appearance.tabStyle
-        let hasFamily = (style.fontFamily?.isEmpty == false)
-        switch (hasFamily, style.fontWeight) {
-        case (true, let weight?):
-            return .custom(style.fontFamily!, fixedSize: size).weight(weight.swiftUIFontWeight)
-        case (true, nil):
-            return .custom(style.fontFamily!, fixedSize: size)
-        case (false, let weight?):
-            return .system(size: size, weight: weight.swiftUIFontWeight)
-        case (false, nil):
-            return .system(size: size)
+        let weight = style.fontWeight?.swiftUIFontWeight
+
+        guard let family = style.fontFamily, !family.isEmpty else {
+            return weight.map { .system(size: size, weight: $0) } ?? .system(size: size)
         }
+
+        // "SF Mono" and friends aren't resolvable by name via Font.custom (they
+        // silently fall back to the default UI font), so map the common
+        // monospaced aliases to the system monospaced design instead.
+        let monospacedAliases: Set<String> = [
+            "sf mono", "sfmono", "sfmono-regular",
+            "ui-monospace", "monospace", "system-monospace",
+        ]
+        if monospacedAliases.contains(family.lowercased()) {
+            return .system(size: size, weight: weight ?? .regular, design: .monospaced)
+        }
+
+        // Only use Font.custom for a family AppKit can actually resolve; otherwise
+        // fall back to the system font rather than silently mis-rendering.
+        if NSFont(name: family, size: size) != nil {
+            let base = Font.custom(family, fixedSize: size)
+            return weight.map { base.weight($0) } ?? base
+        }
+        return weight.map { .system(size: size, weight: $0) } ?? .system(size: size)
     }
 
     /// Standard titled tab layout: leading icon, title, optional audio/zoom

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -524,6 +524,24 @@ struct TabItemView: View {
         }
     }
 
+    /// The font for the tab title, honoring the host's ``TabStyle`` family and
+    /// weight overrides and falling back to the system font at the configured size.
+    private var tabTitleFont: Font {
+        let size = appearance.tabTitleFontSize
+        let style = appearance.tabStyle
+        let hasFamily = (style.fontFamily?.isEmpty == false)
+        switch (hasFamily, style.fontWeight) {
+        case (true, let weight?):
+            return .custom(style.fontFamily!, fixedSize: size).weight(weight.swiftUIFontWeight)
+        case (true, nil):
+            return .custom(style.fontFamily!, fixedSize: size)
+        case (false, let weight?):
+            return .system(size: size, weight: weight.swiftUIFontWeight)
+        case (false, nil):
+            return .system(size: size)
+        }
+    }
+
     /// Standard titled tab layout: leading icon, title, optional audio/zoom
     /// affordances, and the trailing close/pin/dirty accessory.
     @ViewBuilder
@@ -534,7 +552,7 @@ struct TabItemView: View {
                 leadingIcon
 
                 Text(tab.title)
-                    .font(.system(size: appearance.tabTitleFontSize))
+                    .font(tabTitleFont)
                     .lineLimit(1)
                     .foregroundStyle(
                         isSelected
@@ -1003,7 +1021,8 @@ struct TabItemView: View {
                 Rectangle()
                     .fill(TabBarColors.hoveredTabBackground(for: appearance))
             } else {
-                Color.clear
+                Rectangle()
+                    .fill(TabBarColors.inactiveTabBackground(for: appearance))
             }
 
             // Right border separator

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import AppKit
 
 /// Controls how tab content views are managed when switching between tabs
 public enum ContentViewLifecycle: Sendable {
@@ -504,6 +505,135 @@ extension BonsplitConfiguration {
             }
         }
 
+        /// Per-selection-state color, border, and typography overrides for the
+        /// surface tab bar.
+        ///
+        /// Every field is optional; a `nil` value preserves Bonsplit's existing
+        /// derived styling for that attribute, so an empty ``TabStyle`` is a no-op
+        /// and the feature stays fully backward compatible. Hosts set only the
+        /// attributes they want to theme — e.g. a flat, color-driven strip that
+        /// matches a terminal theme:
+        ///
+        /// ```swift
+        /// var style = BonsplitConfiguration.Appearance.TabStyle()
+        /// style.activeBackgroundHex = "#1a1b26"
+        /// style.activeForegroundHex = "#c0caf5"
+        /// style.inactiveForegroundHex = "#565f89"
+        /// style.activeIndicatorHex = "#7aa2f7"   // replaces the system accent
+        /// style.dividerHex = "none"
+        /// ```
+        public struct TabStyle: Sendable, Equatable {
+            /// Which edge of the selected tab carries the accent indicator line.
+            ///
+            /// The case is named `hidden` rather than `none` to avoid colliding
+            /// with `Optional.none` when the property is compared as an optional.
+            public enum IndicatorEdge: String, Sendable, Codable, Equatable {
+                /// Draw the accent line along the top edge of the selected tab.
+                case top
+                /// Draw the accent line along the bottom edge of the selected tab.
+                case bottom
+                /// Draw no accent line; selection reads from color alone.
+                case hidden
+            }
+
+            /// Weight applied to tab title labels.
+            public enum FontWeight: String, Sendable, Codable, CaseIterable {
+                case ultraLight, thin, light, regular, medium, semibold, bold, heavy, black
+
+                /// The AppKit font weight this case maps to.
+                public var nsFontWeight: NSFont.Weight {
+                    switch self {
+                    case .ultraLight: return .ultraLight
+                    case .thin: return .thin
+                    case .light: return .light
+                    case .regular: return .regular
+                    case .medium: return .medium
+                    case .semibold: return .semibold
+                    case .bold: return .bold
+                    case .heavy: return .heavy
+                    case .black: return .black
+                    }
+                }
+
+                /// The SwiftUI font weight this case maps to.
+                public var swiftUIFontWeight: Font.Weight {
+                    switch self {
+                    case .ultraLight: return .ultraLight
+                    case .thin: return .thin
+                    case .light: return .light
+                    case .regular: return .regular
+                    case .medium: return .medium
+                    case .semibold: return .semibold
+                    case .bold: return .bold
+                    case .heavy: return .heavy
+                    case .black: return .black
+                    }
+                }
+            }
+
+            /// Background hex for the selected tab. `nil` keeps the derived active background.
+            public var activeBackgroundHex: String?
+            /// Label hex for the selected tab. `nil` keeps the derived active text color.
+            public var activeForegroundHex: String?
+            /// Background hex for unselected tabs. `nil` keeps the transparent/derived background.
+            public var inactiveBackgroundHex: String?
+            /// Label hex for unselected tabs. `nil` keeps the derived secondary text color.
+            public var inactiveForegroundHex: String?
+            /// Background hex for a hovered, unselected tab. `nil` keeps the derived hover tint.
+            public var hoverBackgroundHex: String?
+            /// Hex for the thin dividers between tabs. `"none"` (or a fully transparent
+            /// hex) hides them; `nil` keeps the derived separator color.
+            public var dividerHex: String?
+            /// Hex for the accent indicator line on the selected tab. `nil` keeps the
+            /// system-accent–derived indicator.
+            public var activeIndicatorHex: String?
+            /// Which edge carries the accent indicator, or `.hidden` to hide it. `nil`
+            /// keeps the historical top-edge indicator.
+            public var activeIndicatorEdge: IndicatorEdge?
+            /// Font family for tab title labels. `nil` keeps the system font.
+            public var fontFamily: String?
+            /// Weight for tab title labels. `nil` keeps the default weight.
+            public var fontWeight: FontWeight?
+
+            public init(
+                activeBackgroundHex: String? = nil,
+                activeForegroundHex: String? = nil,
+                inactiveBackgroundHex: String? = nil,
+                inactiveForegroundHex: String? = nil,
+                hoverBackgroundHex: String? = nil,
+                dividerHex: String? = nil,
+                activeIndicatorHex: String? = nil,
+                activeIndicatorEdge: IndicatorEdge? = nil,
+                fontFamily: String? = nil,
+                fontWeight: FontWeight? = nil
+            ) {
+                self.activeBackgroundHex = activeBackgroundHex
+                self.activeForegroundHex = activeForegroundHex
+                self.inactiveBackgroundHex = inactiveBackgroundHex
+                self.inactiveForegroundHex = inactiveForegroundHex
+                self.hoverBackgroundHex = hoverBackgroundHex
+                self.dividerHex = dividerHex
+                self.activeIndicatorHex = activeIndicatorHex
+                self.activeIndicatorEdge = activeIndicatorEdge
+                self.fontFamily = fontFamily
+                self.fontWeight = fontWeight
+            }
+
+            /// Whether any override is set. When `false`, tab styling is unchanged
+            /// from Bonsplit's defaults and every resolver falls through to its
+            /// historical derivation.
+            public var hasOverrides: Bool {
+                activeBackgroundHex != nil || activeForegroundHex != nil
+                    || inactiveBackgroundHex != nil || inactiveForegroundHex != nil
+                    || hoverBackgroundHex != nil || dividerHex != nil
+                    || activeIndicatorHex != nil || activeIndicatorEdge != nil
+                    || fontFamily != nil || fontWeight != nil
+            }
+
+            /// An empty style with no overrides.
+            public static let none = TabStyle()
+        }
+
         /// Controls how surface tabs are sized within a pane's tab bar.
         public enum TabWidthMode: Sendable, Equatable, Codable {
             /// Tabs use a fixed width clamped to `tabMinWidth...tabMaxWidth` and the
@@ -609,6 +739,10 @@ extension BonsplitConfiguration {
         /// Optional color overrides for tab/pane chrome.
         public var chromeColors: ChromeColors
 
+        /// Optional per-selection-state color, border, and typography overrides
+        /// for the surface tab bar. Empty by default, leaving tab styling unchanged.
+        public var tabStyle: TabStyle
+
         /// When true, the host app is trying to make all surfaces share the
         /// same backdrop. Bonsplit should avoid local chrome color adjustments
         /// that would create visibly different translucent layers.
@@ -656,6 +790,7 @@ extension BonsplitConfiguration {
             animationDuration: Double = 0.15,
             enableAnimations: Bool = true,
             chromeColors: ChromeColors = .init(),
+            tabStyle: TabStyle = .none,
             usesSharedBackdrop: Bool = false
         ) {
             self.tabBarHeight = tabBarHeight
@@ -678,6 +813,7 @@ extension BonsplitConfiguration {
             self.animationDuration = animationDuration
             self.enableAnimations = enableAnimations
             self.chromeColors = chromeColors
+            self.tabStyle = tabStyle
             self.usesSharedBackdrop = usesSharedBackdrop
         }
 

--- a/Sources/Bonsplit/Public/BonsplitConfiguration.swift
+++ b/Sources/Bonsplit/Public/BonsplitConfiguration.swift
@@ -522,7 +522,7 @@ extension BonsplitConfiguration {
         /// style.activeIndicatorHex = "#7aa2f7"   // replaces the system accent
         /// style.dividerHex = "none"
         /// ```
-        public struct TabStyle: Sendable, Equatable {
+        public struct TabStyle: Sendable, Equatable, Codable {
             /// Which edge of the selected tab carries the accent indicator line.
             ///
             /// The case is named `hidden` rather than `none` to avoid colliding

--- a/Tests/BonsplitTests/TabStyleTests.swift
+++ b/Tests/BonsplitTests/TabStyleTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+import AppKit
+@testable import Bonsplit
+
+/// Verifies that ``BonsplitConfiguration/Appearance/TabStyle`` overrides flow
+/// through ``TabBarColors`` and that an empty style is a no-op that preserves the
+/// historical derived styling.
+final class TabStyleTests: XCTestCase {
+    private func components(_ color: NSColor) -> (CGFloat, CGFloat, CGFloat, CGFloat) {
+        let srgb = color.usingColorSpace(.sRGB) ?? color
+        return (srgb.redComponent, srgb.greenComponent, srgb.blueComponent, srgb.alphaComponent)
+    }
+
+    private func assertColor(
+        _ color: NSColor,
+        _ expected: (CGFloat, CGFloat, CGFloat, CGFloat),
+        accuracy: CGFloat = 0.01,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let actual = components(color)
+        XCTAssertEqual(actual.0, expected.0, accuracy: accuracy, "red", file: file, line: line)
+        XCTAssertEqual(actual.1, expected.1, accuracy: accuracy, "green", file: file, line: line)
+        XCTAssertEqual(actual.2, expected.2, accuracy: accuracy, "blue", file: file, line: line)
+        XCTAssertEqual(actual.3, expected.3, accuracy: accuracy, "alpha", file: file, line: line)
+    }
+
+    private func appearance(
+        tabStyle: BonsplitConfiguration.Appearance.TabStyle
+    ) -> BonsplitConfiguration.Appearance {
+        BonsplitConfiguration.Appearance(tabStyle: tabStyle)
+    }
+
+    func testForegroundOverridesResolveToConfiguredColors() {
+        let style = BonsplitConfiguration.Appearance.TabStyle(
+            activeForegroundHex: "#ff0000",
+            inactiveForegroundHex: "#00ff00"
+        )
+        let appearance = appearance(tabStyle: style)
+
+        assertColor(TabBarColors.nsColorActiveText(for: appearance), (1, 0, 0, 1))
+        assertColor(TabBarColors.nsColorInactiveText(for: appearance), (0, 1, 0, 1))
+    }
+
+    func testActiveIndicatorOverrideReplacesSystemAccent() {
+        let style = BonsplitConfiguration.Appearance.TabStyle(activeIndicatorHex: "#0000ff")
+        let appearance = appearance(tabStyle: style)
+
+        assertColor(
+            TabBarColors.nsColorActiveIndicator(for: appearance, saturation: 1),
+            (0, 0, 1, 1)
+        )
+    }
+
+    func testDividerOverrideAndNoneSentinel() {
+        let hexAppearance = appearance(
+            tabStyle: BonsplitConfiguration.Appearance.TabStyle(dividerHex: "#112233")
+        )
+        assertColor(
+            TabBarColors.nsColorSeparator(for: hexAppearance),
+            (0x11 / 255.0, 0x22 / 255.0, 0x33 / 255.0, 1)
+        )
+
+        let noneAppearance = appearance(
+            tabStyle: BonsplitConfiguration.Appearance.TabStyle(dividerHex: "none")
+        )
+        let separator = TabBarColors.nsColorSeparator(for: noneAppearance)
+        XCTAssertEqual(components(separator).3, 0, accuracy: 0.001, "divider 'none' should be transparent")
+    }
+
+    func testEmptyTabStyleFallsBackToDerivedIndicator() {
+        let appearance = appearance(tabStyle: .none)
+        XCTAssertFalse(appearance.tabStyle.hasOverrides)
+
+        let overridden = TabBarColors.nsColorActiveIndicator(for: appearance, saturation: 1)
+        let derived = TabBarColors.nsColorActiveIndicator(saturation: 1)
+        assertColor(overridden, components(derived))
+    }
+
+    func testFontWeightMapsToAppKitWeight() {
+        XCTAssertEqual(BonsplitConfiguration.Appearance.TabStyle.FontWeight.semibold.nsFontWeight, .semibold)
+        XCTAssertEqual(BonsplitConfiguration.Appearance.TabStyle.FontWeight.black.nsFontWeight, .black)
+    }
+}

--- a/Tests/BonsplitTests/TabStyleTests.swift
+++ b/Tests/BonsplitTests/TabStyleTests.swift
@@ -81,4 +81,22 @@ final class TabStyleTests: XCTestCase {
         XCTAssertEqual(BonsplitConfiguration.Appearance.TabStyle.FontWeight.semibold.nsFontWeight, .semibold)
         XCTAssertEqual(BonsplitConfiguration.Appearance.TabStyle.FontWeight.black.nsFontWeight, .black)
     }
+
+    func testActiveIndicatorEdgePlacement() {
+        let bounds = CGRect(x: 0, y: 0, width: 200, height: 30)
+        let base = CGRect(x: 10, y: 0, width: 100, height: 30)
+
+        let top = TabBarSelectionChromeView.ChromeNSView.positionedIndicatorFrame(
+            base: base, in: bounds, edge: .top
+        )
+        let bottom = TabBarSelectionChromeView.ChromeNSView.positionedIndicatorFrame(
+            base: base, in: bounds, edge: .bottom
+        )
+
+        // The view is flipped: .top pins to minY, .bottom to the far edge.
+        XCTAssertEqual(top.origin.y, bounds.minY, accuracy: 0.001)
+        XCTAssertEqual(bottom.origin.y, bounds.maxY - TabBarMetrics.activeIndicatorHeight, accuracy: 0.001)
+        XCTAssertNotEqual(top.origin.y, bottom.origin.y, "top and bottom must differ")
+        XCTAssertEqual(bottom.size.height, TabBarMetrics.activeIndicatorHeight, accuracy: 0.001)
+    }
 }


### PR DESCRIPTION
## What & why

Adds `BonsplitConfiguration.Appearance.TabStyle`: an optional, per-selection-state set of style overrides for the surface tab bar — background, label, divider, active-indicator color/edge, and title font family/weight. This is the Bonsplit substrate for making the pane tab bar directly themeable (requested downstream in cmux [#7458](https://github.com/manaflow-ai/cmux/issues/7458): "Tab styling controls for a sleeker, quieter, color-driven layout option").

Every field is optional and defaults to `nil`. An empty `TabStyle` is a no-op — each resolver falls through to the exact historical derivation — so the change is **fully backward compatible**.

## Changes

- **`BonsplitConfiguration.swift`** — new public `TabStyle` (Sendable, Equatable) on `Appearance`, plus `IndicatorEdge` (`top`/`bottom`/`hidden`) and `FontWeight` enums. The case is `hidden`, not `none`, to avoid colliding with `Optional.none`.
- **`TabBarColors.swift`** — active/inactive/hover backgrounds, active/inactive label colors, divider (with a `"none"` sentinel → transparent), and the active indicator now honor overrides first, else derive as before. New `nsColorActiveIndicator(for:saturation:)` prefers a theme hex over `NSColor.controlAccentColor`, so the selected-tab highlight can match a theme instead of the macOS system accent.
- **`TabItemView.swift`** — paints the inactive-tab background from the override and renders the title with the resolved font (family/weight/size).
- **`TabBarView.swift`** — wires the appearance-aware indicator color and `.hidden` edge.

## Notes

- Tabs already render as flat `Rectangle` cells, so a `flatCells` toggle would have been a no-op; omitted intentionally. The `top`/`bottom` indicator edge is modeled in the API but currently renders at the existing (top) position — happy to add the geometry flip if wanted.

## Tests

`TabStyleTests` (5 cases, all passing): foreground override resolution, active-indicator override replacing the system accent, divider override + `"none"` sentinel, empty-style fallback to the derived indicator, and font-weight → AppKit mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787540831&installation_model_id=21920&pr_number=194&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F194&signature=9815b5e0ffa838a0d16f720b23ffdfaf776b95fa70a5a0d26e4d046cc37dbf5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional per-selection-state tab bar styling via `BonsplitConfiguration.Appearance.TabStyle` to theme the surface tab bar. `TabStyle` is now `Codable` for serialization; defaults remain unchanged for full backward compatibility.

- **New Features**
  - New `TabStyle` overrides: backgrounds (active/inactive/hover), label colors, divider (`"none"` hides), active indicator hex and edge (`top`/`bottom`/`hidden`), and title font family/weight.
  - Active indicator prefers a theme hex and applies saturation; its line is placed per edge and hidden on `.hidden`.
  - `TabItemView` uses the inactive background override and a robust title font resolver: monospaced aliases (e.g. "SF Mono") map to the system monospaced design, custom families are validated via `NSFont(name:)`, else fall back to the system font.
  - Added `TabStyleTests` covering override resolution, `"none"` divider behavior, fallback to historical styling, font-weight mapping, and `.bottom` indicator placement.

<sup>Written for commit 9ff93135e20e59b128d692d4418ea60dc6fceac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable tab bar styling, including active, inactive, and hover colors.
  * Added configurable divider and active indicator colors, with support for hiding the indicator.
  * Added tab title font family and weight customization.
  * Preserved existing appearance defaults when no custom styling is configured.

* **Bug Fixes**
  * Improved tab selection indicator behavior for hidden indicator settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->