### PR TITLE
Refresh fork availability in open tab context menus

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1252,6 +1252,12 @@ struct TabBarView: View {
             forkConversationAvailabilityProvider: {
                 controller.tabContextForkConversationAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? .hidden
             },
+            forkConversationAvailabilityRefreshHandler: {
+                await controller.tabContextForkConversationAvailabilityRefreshHandler?(
+                    TabID(id: tab.id),
+                    pane.id
+                )
+            },
             onSelect: {
                 // Tab selection must be instant. Animating this transaction causes the pane
                 // content (often swapped via opacity) to crossfade, which is undesirable for

--- a/Sources/Bonsplit/Internal/Views/TabContextMenuPresenter.swift
+++ b/Sources/Bonsplit/Internal/Views/TabContextMenuPresenter.swift
@@ -1,0 +1,163 @@
+import AppKit
+import SwiftUI
+
+struct TabContextMenuSnapshot {
+    let tabId: UUID
+    let state: TabContextMenuState
+    let moveDestinationsProvider: () -> [TabContextMoveDestination]
+    let forkConversationAvailabilityProvider: () -> TabContextForkConversationAvailability
+    let forkConversationAvailabilityRefreshHandler: @MainActor () async -> Void
+
+    init(
+        tabId: UUID,
+        state: TabContextMenuState,
+        moveDestinationsProvider: @escaping () -> [TabContextMoveDestination],
+        forkConversationAvailabilityProvider: @escaping () -> TabContextForkConversationAvailability,
+        forkConversationAvailabilityRefreshHandler: @escaping @MainActor () async -> Void = {}
+    ) {
+        self.tabId = tabId
+        self.state = state
+        self.moveDestinationsProvider = moveDestinationsProvider
+        self.forkConversationAvailabilityProvider = forkConversationAvailabilityProvider
+        self.forkConversationAvailabilityRefreshHandler = forkConversationAvailabilityRefreshHandler
+    }
+}
+
+final class TabContextMenuActionTarget: NSObject {
+    var onContextAction: ((TabContextAction) -> Void)?
+    var onMoveDestination: ((String) -> Void)?
+
+    @objc func performContextAction(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let action = TabContextAction(rawValue: rawValue) else {
+            return
+        }
+        onContextAction?(action)
+    }
+
+    @objc func performMoveDestination(_ sender: NSMenuItem) {
+        guard let destinationId = sender.representedObject as? String else { return }
+        onMoveDestination?(destinationId)
+    }
+}
+
+@MainActor
+final class TabContextMenu: NSMenu, NSMenuDelegate {
+    let snapshot: TabContextMenuSnapshot
+    private(set) var forkConversationAvailability: TabContextForkConversationAvailability
+    private var refreshTask: Task<Void, Never>?
+
+    init(
+        snapshot: TabContextMenuSnapshot,
+        forkConversationAvailability: TabContextForkConversationAvailability
+    ) {
+        self.snapshot = snapshot
+        self.forkConversationAvailability = forkConversationAvailability
+        super.init(title: "")
+        autoenablesItems = false
+        delegate = self
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        reevaluateForkConversationAvailability()
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+        reevaluateForkConversationAvailability()
+        guard forkConversationAvailability == .refreshing,
+              refreshTask == nil else { return }
+        refreshTask = Task { @MainActor [weak self] in
+            await self?.resolveRefreshingForkConversationAvailability()
+            self?.refreshTask = nil
+        }
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    func resolveRefreshingForkConversationAvailability() async {
+        guard forkConversationAvailability == .refreshing else { return }
+        await snapshot.forkConversationAvailabilityRefreshHandler()
+        guard !Task.isCancelled else { return }
+        reevaluateForkConversationAvailability()
+    }
+
+    private func reevaluateForkConversationAvailability() {
+        let availability = snapshot.forkConversationAvailabilityProvider()
+        forkConversationAvailability = availability
+        TabContextMenuBuilder.updateForkConversationAvailability(availability, in: self)
+    }
+}
+
+struct TabContextMenuPresenter: NSViewRepresentable {
+    let snapshot: TabContextMenuSnapshot
+    let onContextAction: (TabContextAction) -> Void
+    let onMoveDestination: (String) -> Void
+
+    @MainActor
+    final class Coordinator {
+        var snapshot: TabContextMenuSnapshot
+        let actionTarget = TabContextMenuActionTarget()
+        weak var view: NSView?
+        var monitor: Any?
+
+        init(snapshot: TabContextMenuSnapshot) {
+            self.snapshot = snapshot
+        }
+
+        deinit {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+        }
+
+        func presentMenu(at point: NSPoint, in view: NSView) {
+            let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: actionTarget)
+            menu.popUp(positioning: nil, at: point, in: view)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        let coordinator = Coordinator(snapshot: snapshot)
+        coordinator.actionTarget.onContextAction = onContextAction
+        coordinator.actionTarget.onMoveDestination = onMoveDestination
+        return coordinator
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.clear.cgColor
+
+        context.coordinator.view = view
+
+        let coordinator = context.coordinator
+        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.rightMouseDown, .leftMouseDown]) { [weak coordinator] event in
+            guard event.type == .rightMouseDown || event.modifierFlags.contains(.control) else { return event }
+            guard let coordinator, let view = coordinator.view, let window = view.window else { return event }
+            guard event.window === window else { return event }
+
+            let point = view.convert(event.locationInWindow, from: nil)
+            guard view.bounds.contains(point) else { return event }
+
+            coordinator.presentMenu(at: point, in: view)
+            return nil
+        }
+
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.view = nsView
+        context.coordinator.snapshot = snapshot
+        context.coordinator.actionTarget.onContextAction = onContextAction
+        context.coordinator.actionTarget.onMoveDestination = onMoveDestination
+    }
+}

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -286,6 +286,7 @@ struct TabItemView: View {
     let contextMenuState: TabContextMenuState
     let moveDestinationsProvider: () -> [TabContextMoveDestination]
     let forkConversationAvailabilityProvider: () -> TabContextForkConversationAvailability
+    let forkConversationAvailabilityRefreshHandler: @MainActor () async -> Void
     let onSelect: () -> Void
     let onClose: (TabCloseRequestSource) -> Void
     let onZoomToggle: () -> Void
@@ -351,7 +352,8 @@ struct TabItemView: View {
                         tabId: tab.id,
                         state: contextMenuState,
                         moveDestinationsProvider: moveDestinationsProvider,
-                        forkConversationAvailabilityProvider: forkConversationAvailabilityProvider
+                        forkConversationAvailabilityProvider: forkConversationAvailabilityProvider,
+                        forkConversationAvailabilityRefreshHandler: forkConversationAvailabilityRefreshHandler
                     ),
                     onContextAction: onContextAction,
                     onMoveDestination: onMoveDestination
@@ -1343,41 +1345,29 @@ private struct MiddleClickMonitorView: NSViewRepresentable {
     }
 }
 
-struct TabContextMenuSnapshot {
-    let tabId: UUID
-    let state: TabContextMenuState
-    let moveDestinationsProvider: () -> [TabContextMoveDestination]
-    let forkConversationAvailabilityProvider: () -> TabContextForkConversationAvailability
-}
-
-final class TabContextMenuActionTarget: NSObject {
-    var onContextAction: ((TabContextAction) -> Void)?
-    var onMoveDestination: ((String) -> Void)?
-
-    @objc func performContextAction(_ sender: NSMenuItem) {
-        guard let rawValue = sender.representedObject as? String,
-              let action = TabContextAction(rawValue: rawValue) else {
-            return
-        }
-        onContextAction?(action)
-    }
-
-    @objc func performMoveDestination(_ sender: NSMenuItem) {
-        guard let destinationId = sender.representedObject as? String else { return }
-        onMoveDestination?(destinationId)
-    }
-}
-
+@MainActor
 enum TabContextMenuBuilder {
+    private static let forkConversationSeparatorIdentifier = NSUserInterfaceItemIdentifier(
+        "Bonsplit.TabContextMenu.ForkConversationSeparator"
+    )
+    private static let forkConversationItemIdentifier = NSUserInterfaceItemIdentifier(
+        "Bonsplit.TabContextMenu.ForkConversation"
+    )
+    private static let forkConversationSubmenuIdentifier = NSUserInterfaceItemIdentifier(
+        "Bonsplit.TabContextMenu.ForkConversationSubmenu"
+    )
+
     static func makeMenu(
         snapshot: TabContextMenuSnapshot,
         target: TabContextMenuActionTarget
-    ) -> NSMenu {
+    ) -> TabContextMenu {
         let state = snapshot.state
         let forkConversationAvailability = snapshot.forkConversationAvailabilityProvider()
         let forkConversationEnabled = forkConversationAvailability == .available
-        let menu = NSMenu()
-        menu.autoenablesItems = false
+        let menu = TabContextMenu(
+            snapshot: snapshot,
+            forkConversationAvailability: forkConversationAvailability
+        )
 
         addAction(
             title: localized("tabContext.renameTab", defaultValue: "Rename Tab…"),
@@ -1446,8 +1436,10 @@ enum TabContextMenuBuilder {
         }
 
         if forkConversationAvailability != .hidden {
-            menu.addItem(.separator())
-            addAction(
+            let separator = NSMenuItem.separator()
+            separator.identifier = forkConversationSeparatorIdentifier
+            menu.addItem(separator)
+            let forkConversationItem = addAction(
                 title: forkConversationDefaultTitle(for: state.forkConversationDefaultAction),
                 action: .forkConversation,
                 enabled: forkConversationEnabled,
@@ -1455,11 +1447,14 @@ enum TabContextMenuBuilder {
                 target: target,
                 to: menu
             )
-            menu.addItem(forkConversationSubmenuItem(
+            forkConversationItem.identifier = forkConversationItemIdentifier
+            let forkConversationSubmenu = forkConversationSubmenuItem(
                 state: state,
                 target: target,
                 enabled: forkConversationEnabled
-            ))
+            )
+            forkConversationSubmenu.identifier = forkConversationSubmenuIdentifier
+            menu.addItem(forkConversationSubmenu)
         }
 
         menu.addItem(.separator())
@@ -1582,6 +1577,29 @@ enum TabContextMenuBuilder {
         )
 
         return menu
+    }
+
+    static func updateForkConversationAvailability(
+        _ availability: TabContextForkConversationAvailability,
+        in menu: NSMenu
+    ) {
+        let isVisible = availability != .hidden
+        let isEnabled = availability == .available
+
+        menu.items.first { $0.identifier == forkConversationSeparatorIdentifier }?.isHidden = !isVisible
+
+        if let item = menu.items.first(where: { $0.identifier == forkConversationItemIdentifier }) {
+            item.isHidden = !isVisible
+            item.isEnabled = isEnabled
+        }
+
+        if let item = menu.items.first(where: { $0.identifier == forkConversationSubmenuIdentifier }) {
+            item.isHidden = !isVisible
+            item.isEnabled = isEnabled
+            for destinationItem in item.submenu?.items ?? [] where !destinationItem.isSeparatorItem {
+                destinationItem.isEnabled = isEnabled
+            }
+        }
     }
 
     private static func moveSubmenuItem(
@@ -1804,70 +1822,5 @@ private extension EventModifiers {
         if contains(.option) { flags.insert(.option) }
         if contains(.control) { flags.insert(.control) }
         return flags
-    }
-}
-
-struct TabContextMenuPresenter: NSViewRepresentable {
-    let snapshot: TabContextMenuSnapshot
-    let onContextAction: (TabContextAction) -> Void
-    let onMoveDestination: (String) -> Void
-
-    final class Coordinator {
-        var snapshot: TabContextMenuSnapshot
-        let actionTarget = TabContextMenuActionTarget()
-        weak var view: NSView?
-        var monitor: Any?
-
-        init(snapshot: TabContextMenuSnapshot) {
-            self.snapshot = snapshot
-        }
-
-        deinit {
-            if let monitor {
-                NSEvent.removeMonitor(monitor)
-            }
-        }
-
-        func presentMenu(at point: NSPoint, in view: NSView) {
-            let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: actionTarget)
-            menu.popUp(positioning: nil, at: point, in: view)
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        let coordinator = Coordinator(snapshot: snapshot)
-        coordinator.actionTarget.onContextAction = onContextAction
-        coordinator.actionTarget.onMoveDestination = onMoveDestination
-        return coordinator
-    }
-
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView(frame: .zero)
-        view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.clear.cgColor
-
-        context.coordinator.view = view
-
-        let coordinator = context.coordinator
-        coordinator.monitor = NSEvent.addLocalMonitorForEvents(matching: [.rightMouseDown, .leftMouseDown]) { [weak coordinator] event in
-            guard event.type == .rightMouseDown || event.modifierFlags.contains(.control) else { return event }
-            guard let coordinator, let view = coordinator.view, let window = view.window else { return event }
-            guard event.window === window else { return event }
-
-            let point = view.convert(event.locationInWindow, from: nil)
-            guard view.bounds.contains(point) else { return event }
-
-            coordinator.presentMenu(at: point, in: view)
-            return nil
-        }
-
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.view = nsView
-        context.coordinator.snapshot = snapshot
-        context.coordinator.actionTarget.onContextAction = onContextAction
-        context.coordinator.actionTarget.onMoveDestination = onMoveDestination
     }
 }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -81,6 +81,11 @@ public final class BonsplitController {
     /// remain visible but disabled; hidden actions are omitted.
     @ObservationIgnored public var tabContextForkConversationAvailabilityProvider: ((TabID, PaneID) -> TabContextForkConversationAvailability)?
 
+    /// Host-provided refresh invoked when Fork Conversation availability is still loading
+    /// as the tab context menu opens. When it returns, the open menu re-evaluates the
+    /// synchronous availability provider and updates its items in place.
+    @ObservationIgnored public var tabContextForkConversationAvailabilityRefreshHandler: (@MainActor (TabID, PaneID) async -> Void)?
+
     /// Host-provided default destination for the tab context menu's primary "Fork
     /// Conversation" action. Return a destination-specific fork action; invalid values
     /// fall back to `.forkConversationRight`.

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2169,6 +2169,8 @@ final class BonsplitTests: XCTestCase {
         var availability = TabContextForkConversationAvailability.refreshing
         var refreshCount = 0
         let refreshStarted = expectation(description: "Fork availability refresh started")
+        let availabilityReevaluated = expectation(description: "Fork availability reevaluated")
+        var didObserveAvailable = false
         let state = TabContextMenuState(
             isPinned: false,
             isUnread: false,
@@ -2191,7 +2193,13 @@ final class BonsplitTests: XCTestCase {
             tabId: UUID(),
             state: state,
             moveDestinationsProvider: { [] },
-            forkConversationAvailabilityProvider: { availability },
+            forkConversationAvailabilityProvider: {
+                if availability == .available, !didObserveAvailable {
+                    didObserveAvailable = true
+                    availabilityReevaluated.fulfill()
+                }
+                return availability
+            },
             forkConversationAvailabilityRefreshHandler: {
                 refreshCount += 1
                 availability = .available
@@ -2204,7 +2212,7 @@ final class BonsplitTests: XCTestCase {
 
         menu.menuWillOpen(menu)
         menu.menuWillOpen(menu)
-        await fulfillment(of: [refreshStarted], timeout: 1)
+        await fulfillment(of: [refreshStarted, availabilityReevaluated], timeout: 1)
 
         XCTAssertEqual(refreshCount, 1)
         XCTAssertEqual(menu.forkConversationAvailability, .available)

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2164,6 +2164,56 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabContextMenuRefreshReevaluatesForkConversationAvailability() async throws {
+        let target = TabContextMenuActionTarget()
+        var availability = TabContextForkConversationAvailability.refreshing
+        var refreshCount = 0
+        let refreshStarted = expectation(description: "Fork availability refresh started")
+        let state = TabContextMenuState(
+            isPinned: false,
+            isUnread: false,
+            isBrowser: false,
+            isAudioMuted: false,
+            isTerminal: true,
+            hasCustomTitle: false,
+            canCloseToLeft: true,
+            canCloseToRight: true,
+            canCloseOthers: true,
+            canMoveToNewWorkspace: false,
+            canMoveToLeftPane: false,
+            canMoveToRightPane: false,
+            forkConversationDefaultAction: .forkConversationRight,
+            isZoomed: false,
+            hasSplits: false,
+            shortcuts: [:]
+        )
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: state,
+            moveDestinationsProvider: { [] },
+            forkConversationAvailabilityProvider: { availability },
+            forkConversationAvailabilityRefreshHandler: {
+                refreshCount += 1
+                availability = .available
+                refreshStarted.fulfill()
+            }
+        )
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation to the Right" })
+        let forkSubmenuItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation To" })
+
+        menu.menuWillOpen(menu)
+        menu.menuWillOpen(menu)
+        await fulfillment(of: [refreshStarted], timeout: 1)
+
+        XCTAssertEqual(refreshCount, 1)
+        XCTAssertEqual(menu.forkConversationAvailability, .available)
+        XCTAssertTrue(forkItem.isEnabled)
+        XCTAssertTrue(forkSubmenuItem.isEnabled)
+        menu.menuDidClose(menu)
+    }
+
+    @MainActor
     func testTabContextMenuShowsDisconnectRemoteOnlyWhenAvailable() throws {
         let target = TabContextMenuActionTarget()
         var selectedAction: TabContextAction?

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2118,6 +2118,52 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabContextMenuUpdateReevaluatesForkConversationAvailability() throws {
+        let target = TabContextMenuActionTarget()
+        var availability = TabContextForkConversationAvailability.refreshing
+        let state = TabContextMenuState(
+            isPinned: false,
+            isUnread: false,
+            isBrowser: false,
+            isAudioMuted: false,
+            isTerminal: true,
+            hasCustomTitle: false,
+            canCloseToLeft: true,
+            canCloseToRight: true,
+            canCloseOthers: true,
+            canMoveToNewWorkspace: false,
+            canMoveToLeftPane: false,
+            canMoveToRightPane: false,
+            forkConversationDefaultAction: .forkConversationRight,
+            isZoomed: false,
+            hasSplits: false,
+            shortcuts: [:]
+        )
+        let snapshot = TabContextMenuSnapshot(
+            tabId: UUID(),
+            state: state,
+            moveDestinationsProvider: { [] },
+            forkConversationAvailabilityProvider: { availability }
+        )
+        let menu = TabContextMenuBuilder.makeMenu(snapshot: snapshot, target: target)
+        let forkItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation to the Right" })
+        let forkSubmenuItem = try XCTUnwrap(menu.items.first { $0.title == "Fork Conversation To" })
+
+        XCTAssertFalse(forkItem.isEnabled)
+        XCTAssertFalse(forkSubmenuItem.isEnabled)
+
+        availability = .available
+        menu.delegate?.menuNeedsUpdate?(menu)
+
+        XCTAssertTrue(forkItem.isEnabled)
+        XCTAssertTrue(forkSubmenuItem.isEnabled)
+        XCTAssertEqual(
+            forkSubmenuItem.submenu?.items.filter { !$0.isSeparatorItem }.map(\.isEnabled),
+            Array(repeating: true, count: 6)
+        )
+    }
+
+    @MainActor
     func testTabContextMenuShowsDisconnectRemoteOnlyWhenAvailable() throws {
         let target = TabContextMenuActionTarget()
         var selectedAction: TabContextAction?


### PR DESCRIPTION
## Summary
- add an async host refresh contract for tab fork availability
- let the open AppKit menu re-evaluate and update fork items in place
- cancel menu-owned refresh work when the menu closes

## Testing
- `swift test` (204 tests)

Supports manaflow-ai/cmux#9029.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787811802&installation_model_id=21920&pr_number=195&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F195&signature=f93d807ec54d7610feadaa30b3ae0c1659e6b0d6f0d5c3ee9288db00bcd1c7cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes “Fork Conversation” availability while a tab’s context menu is open, so items enable/disable without reopening. Fixes the first-click disabled state and supports manaflow-ai/cmux#9029.

- **Bug Fixes**
  - Added optional `BonsplitController.tabContextForkConversationAvailabilityRefreshHandler` to resolve `.refreshing` on menu open and re-query availability.
  - `TabContextMenu` now re-evaluates on `menuWillOpen`/`menuNeedsUpdate` and updates fork items in place; items stay hidden/disabled until ready.
  - Cancels in-flight refresh on close and dedupes refresh tasks; tests cover live updates and single-invocation behavior.

- **Refactors**
  - Extracted `TabContextMenuPresenter` and `TabContextMenu` from `TabItemView` and added `TabContextMenuBuilder.updateForkConversationAvailability`; wired the refresh handler through `TabBarView` → `TabItemView`.

<sup>Written for commit e3837a787968d8235106d12418b653e8d1e2619c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic availability updates for the “Fork Conversation” option in tab context menus.
  * Hosts can now provide an asynchronous refresh handler to update fork-conversation availability when menus open or refresh.
  * Context menus now accurately enable or disable fork-conversation actions and destinations.

* **Bug Fixes**
  * Improved menu state handling when fork-conversation availability changes while a menu is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->