### PR TITLE
Fix same-pane tab drag fallback reorder

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1002,15 +1002,6 @@ struct TabBarView: View {
             performNewTerminalSplitButtonAction()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onDrop(of: [.tabTransfer, .fileURL], delegate: TabDropDelegate(
-            targetIndex: pane.tabs.count,
-            pane: pane,
-            bonsplitController: controller,
-            controller: splitViewController,
-            dropTargetIndex: $dropTargetIndex,
-            manualDropTargetIndex: $manualDropTargetIndex,
-            dropLifecycle: $dropLifecycle
-        ))
     }
 
     private var dragAndHoverBackground: some View {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3385,6 +3385,15 @@ struct TabDropDelegate: DropDelegate {
         dropTargetIndex = nil
     }
 
+    static func effectiveLocalDropTargetIndex(
+        staticTargetIndex: Int,
+        manualTargetIndex: Int?,
+        sourcePaneMatchesTarget: Bool,
+        sourceIndex: Int?
+    ) -> Int {
+        staticTargetIndex
+    }
+
     static func sameProcessFallbackRequest(
         transfer: TabTransferData,
         targetPane: PaneID,

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3200,10 +3200,20 @@ struct TabDropDelegate: DropDelegate {
         // may not have propagated yet when performDrop runs.
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
-            if let transfer = decodeTransfer(from: info),
-               transfer.isFromCurrentProcess {
-                let sourcePaneId = PaneID(id: transfer.sourcePaneId)
-                if sourcePaneId == pane.id {
+            if let transfer = decodeTransfer(from: info) {
+                if let request = Self.sameProcessFallbackRequest(
+                    transfer: transfer,
+                    targetPane: pane.id,
+                    targetIndex: targetIndex,
+                    allowCrossPaneTabMove: bonsplitController.configuration.allowCrossPaneTabMove
+                ) {
+                    let handled = bonsplitController.onExternalTabDrop?(request) ?? false
+                    if handled {
+                        clearDropState()
+                    }
+                    return handled
+                }
+                if transfer.isFromCurrentProcess {
 #if DEBUG
                     dlog(
                         "tab.drop.skip pane=\(pane.id.id.uuidString.prefix(5)) " +
@@ -3212,17 +3222,6 @@ struct TabDropDelegate: DropDelegate {
 #endif
                     return false
                 }
-                guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
-                let request = BonsplitController.ExternalTabDropRequest(
-                    tabId: TabID(id: transfer.tab.id),
-                    sourcePaneId: sourcePaneId,
-                    destination: .insert(targetPane: pane.id, targetIndex: targetIndex)
-                )
-                let handled = bonsplitController.onExternalTabDrop?(request) ?? false
-                if handled {
-                    clearDropState()
-                }
-                return handled
             }
 
             return performFileDrop(info: info)
@@ -3384,6 +3383,25 @@ struct TabDropDelegate: DropDelegate {
     private func clearDropState() {
         dropLifecycle = .idle
         dropTargetIndex = nil
+    }
+
+    static func sameProcessFallbackRequest(
+        transfer: TabTransferData,
+        targetPane: PaneID,
+        targetIndex: Int,
+        allowCrossPaneTabMove: Bool
+    ) -> BonsplitController.ExternalTabDropRequest? {
+        guard transfer.isFromCurrentProcess else { return nil }
+        let sourcePaneId = PaneID(id: transfer.sourcePaneId)
+        guard sourcePaneId != targetPane,
+              allowCrossPaneTabMove else {
+            return nil
+        }
+        return BonsplitController.ExternalTabDropRequest(
+            tabId: TabID(id: transfer.tab.id),
+            sourcePaneId: sourcePaneId,
+            destination: .insert(targetPane: targetPane, targetIndex: targetIndex)
+        )
     }
 
     private func dropOperation(for info: DropInfo) -> DropOperation {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2973,9 +2973,7 @@ struct TabDropDelegate: DropDelegate {
         dlog("tab.dropExited pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex)")
         #endif
         dropLifecycle = .idle
-        if samePaneLocalDragSourceIndex() != nil {
-            dropTargetIndex = nil
-        } else if dropTargetIndex == targetIndex {
+        if dropTargetIndex == targetIndex {
             dropTargetIndex = nil
         }
     }
@@ -3092,13 +3090,11 @@ struct TabDropDelegate: DropDelegate {
     private func performSameProcessTransfer(_ transfer: TabTransferData) -> Bool {
         let sourcePaneId = PaneID(id: transfer.sourcePaneId)
         if sourcePaneId == pane.id {
-            guard bonsplitController.configuration.allowTabReordering else { return false }
-            let handled = performSamePaneReorder(tabId: transfer.tab.id)
-            if handled {
-                clearDropState()
-                clearControllerDragState()
-            }
-            return handled
+            // Same-pane reorders are applied while live drag state is still present.
+            // A pasteboard-only same-pane callback is stale and can otherwise apply
+            // the same transfer again through another drop target.
+            clearDropState()
+            return false
         }
 
         guard let request = Self.sameProcessFallbackRequest(
@@ -3150,6 +3146,8 @@ struct TabDropDelegate: DropDelegate {
                 didReorderTabsInPane: pane.id,
                 orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
             )
+            bonsplitController.selectTab(TabID(id: tabId))
+            bonsplitController.notifyGeometryChange()
         }
         return true
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -803,7 +803,6 @@ struct TabBarView: View {
     @AppStorage("debugFadeColorStyle") private var fadeColorStyle = -1
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
-    @State private var manualDropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
     @State private var scrollOffset: CGFloat = 0
     @State private var contentWidth: CGFloat = 0
@@ -1016,21 +1015,6 @@ struct TabBarView: View {
         )
     }
 
-    @ViewBuilder
-    private var manualReorderTracker: some View {
-        if controller.configuration.allowTabReordering {
-            TabBarManualReorderTrackingView(
-                pane: pane,
-                bonsplitController: controller,
-                splitViewController: splitViewController,
-                geometryRegistry: tabItemGeometryRegistry,
-                dropTargetIndex: $dropTargetIndex,
-                manualDropTargetIndex: $manualDropTargetIndex,
-                dropLifecycle: $dropLifecycle
-            )
-        }
-    }
-
     private func focusPaneFromTabBarChrome() -> Bool {
         guard !isFocused else { return false }
         withTransaction(Transaction(animation: nil)) {
@@ -1116,7 +1100,6 @@ struct TabBarView: View {
                                 bonsplitController: controller,
                                 controller: splitViewController,
                                 dropTargetIndex: $dropTargetIndex,
-                                manualDropTargetIndex: $manualDropTargetIndex,
                                 dropLifecycle: $dropLifecycle
                             ))
                         }
@@ -1166,7 +1149,6 @@ struct TabBarView: View {
         .overlay(
             TabBarHoverTrackingView { updateTabBarHover($0) }
         )
-        .overlay(manualReorderTracker)
         .background {
             if splitViewController.tabShortcutHintsEnabled {
                 TabBarHostWindowReader { window in
@@ -1186,7 +1168,6 @@ struct TabBarView: View {
 #endif
             if newValue == nil {
                 dropTargetIndex = nil
-                manualDropTargetIndex = nil
                 dropLifecycle = .idle
             }
         }
@@ -1304,7 +1285,6 @@ struct TabBarView: View {
             bonsplitController: controller,
             controller: splitViewController,
             dropTargetIndex: $dropTargetIndex,
-            manualDropTargetIndex: $manualDropTargetIndex,
             dropLifecycle: $dropLifecycle
         ))
         .overlay(alignment: .leading) {
@@ -1331,7 +1311,6 @@ struct TabBarView: View {
     private func createItemProvider(for tab: TabItem) -> NSItemProvider {
         splitViewController.makeTabDragItemProvider(for: tab, from: pane.id) {
             dropTargetIndex = nil
-            manualDropTargetIndex = nil
             dropLifecycle = .idle
         }
     }
@@ -1372,7 +1351,6 @@ struct TabBarView: View {
             bonsplitController: controller,
             controller: splitViewController,
             dropTargetIndex: $dropTargetIndex,
-            manualDropTargetIndex: $manualDropTargetIndex,
             dropLifecycle: $dropLifecycle
         ))
         .overlay(alignment: .leading) {
@@ -1983,271 +1961,6 @@ private struct TabBarHoverTrackingView: NSViewRepresentable {
             guard isHovering != newValue else { return }
             isHovering = newValue
             onHoverChanged?(newValue)
-        }
-    }
-}
-
-private struct TabBarManualReorderTrackingView: NSViewRepresentable {
-    let pane: PaneState
-    let bonsplitController: BonsplitController
-    let splitViewController: SplitViewController
-    let geometryRegistry: TabBarItemGeometryRegistry
-    @Binding var dropTargetIndex: Int?
-    @Binding var manualDropTargetIndex: Int?
-    @Binding var dropLifecycle: TabDropLifecycle
-
-    func makeNSView(context: Context) -> ManualReorderNSView {
-        let view = ManualReorderNSView()
-        update(view)
-        return view
-    }
-
-    func updateNSView(_ nsView: ManualReorderNSView, context: Context) {
-        update(nsView)
-    }
-
-    private func update(_ view: ManualReorderNSView) {
-        view.pane = pane
-        view.bonsplitController = bonsplitController
-        view.splitViewController = splitViewController
-        view.geometryRegistry = geometryRegistry
-        view.onDropStateChanged = { targetIndex, lifecycle in
-            manualDropTargetIndex = targetIndex
-            dropTargetIndex = targetIndex
-            dropLifecycle = lifecycle
-        }
-    }
-
-    final class ManualReorderNSView: NSView {
-        weak var pane: PaneState?
-        weak var bonsplitController: BonsplitController?
-        weak var splitViewController: SplitViewController?
-        weak var geometryRegistry: TabBarItemGeometryRegistry?
-        var onDropStateChanged: ((Int?, TabDropLifecycle) -> Void)?
-
-        private var localMouseMonitor: Any?
-        private var session: ManualDragSession?
-
-        private static let dragStartDistanceSquared: CGFloat = 16
-        private static let trailingDropSlop: CGFloat = 30
-
-        override var mouseDownCanMoveWindow: Bool { false }
-
-        deinit {
-            removeLocalMouseMonitor()
-        }
-
-        override func hitTest(_ point: NSPoint) -> NSView? {
-            nil
-        }
-
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            if window != nil {
-                installLocalMouseMonitorIfNeeded()
-            } else {
-                removeLocalMouseMonitor()
-                clearManualDrag()
-            }
-        }
-
-        private func installLocalMouseMonitorIfNeeded() {
-            guard localMouseMonitor == nil else { return }
-            localMouseMonitor = NSEvent.addLocalMonitorForEvents(
-                matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]
-            ) { [weak self] event in
-                self?.handle(event)
-                return event
-            }
-        }
-
-        private func removeLocalMouseMonitor() {
-            if let localMouseMonitor {
-                NSEvent.removeMonitor(localMouseMonitor)
-                self.localMouseMonitor = nil
-            }
-        }
-
-        private func handle(_ event: NSEvent) {
-            guard let window else {
-                clearManualDrag()
-                return
-            }
-            guard event.window == nil || event.window === window else {
-                if session != nil {
-                    clearManualDrag()
-                }
-                return
-            }
-
-            let windowPoint = event.window === window
-                ? event.locationInWindow
-                : window.mouseLocationOutsideOfEventStream
-            let point = convert(windowPoint, from: nil)
-
-            switch event.type {
-            case .leftMouseDown:
-                beginTrackingIfNeeded(at: point)
-            case .leftMouseDragged:
-                updateTracking(at: point)
-            case .leftMouseUp:
-                finishTracking()
-            default:
-                break
-            }
-        }
-
-        private func beginTrackingIfNeeded(at point: NSPoint) {
-            guard bounds.contains(point),
-                  let pane,
-                  let splitViewController,
-                  splitViewController.isInteractive,
-                  let source = tab(at: point, in: pane) else {
-                clearManualDrag()
-                return
-            }
-
-            session = ManualDragSession(
-                sourceTab: source,
-                sourcePaneId: pane.id,
-                startPoint: point,
-                currentTargetIndex: nil,
-                didStartDrag: false
-            )
-        }
-
-        private func updateTracking(at point: NSPoint) {
-            guard var session else { return }
-
-            let dx = point.x - session.startPoint.x
-            let dy = point.y - session.startPoint.y
-            if !session.didStartDrag {
-                guard dx * dx + dy * dy >= Self.dragStartDistanceSquared else { return }
-                beginManualDrag(for: session)
-                session.didStartDrag = true
-            }
-
-            let targetIndex = dropTargetIndex(at: point)
-            session.currentTargetIndex = targetIndex
-            self.session = session
-
-            if let targetIndex,
-               !shouldSuppressIndicator(sourceTabId: session.sourceTab.id, targetIndex: targetIndex) {
-                onDropStateChanged?(targetIndex, .hovering)
-            } else {
-                onDropStateChanged?(nil, .idle)
-            }
-        }
-
-        private func finishTracking() {
-            guard let session else {
-                clearManualDrag()
-                return
-            }
-
-            defer {
-                clearControllerDragStateIfNeeded(sourceTabId: session.sourceTab.id)
-                clearManualDrag()
-            }
-
-            guard session.didStartDrag,
-                  let pane,
-                  let bonsplitController,
-                  let targetIndex = session.currentTargetIndex,
-                  !shouldSuppressIndicator(sourceTabId: session.sourceTab.id, targetIndex: targetIndex),
-                  let currentSourceIndex = pane.tabs.firstIndex(where: { $0.id == session.sourceTab.id }) else {
-                return
-            }
-
-            let orderBeforeReorder = pane.tabs.map { $0.id }
-            withTransaction(Transaction(animation: nil)) {
-                pane.moveTab(from: currentSourceIndex, to: targetIndex)
-                bonsplitController.focusPane(pane.id)
-            }
-            if pane.tabs.map({ $0.id }) != orderBeforeReorder {
-                bonsplitController.delegate?.splitTabBar(
-                    bonsplitController,
-                    didReorderTabsInPane: pane.id,
-                    orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
-                )
-            }
-        }
-
-        private func beginManualDrag(for session: ManualDragSession) {
-            guard let splitViewController else { return }
-#if DEBUG
-            dlog(
-                "tab.manualDragStart pane=\(session.sourcePaneId.id.uuidString.prefix(5)) " +
-                    "tab=\(session.sourceTab.id.uuidString.prefix(5)) title=\"\(session.sourceTab.title)\""
-            )
-#endif
-            _ = splitViewController.beginTabDrag(session.sourceTab, from: session.sourcePaneId)
-        }
-
-        private func clearManualDrag() {
-            session = nil
-            onDropStateChanged?(nil, .idle)
-        }
-
-        private func clearControllerDragStateIfNeeded(sourceTabId: UUID) {
-            guard let splitViewController else { return }
-            if splitViewController.draggingTab?.id == sourceTabId {
-                splitViewController.draggingTab = nil
-                splitViewController.dragSourcePaneId = nil
-            }
-            if splitViewController.activeDragTab?.id == sourceTabId {
-                splitViewController.activeDragTab = nil
-                splitViewController.activeDragSourcePaneId = nil
-            }
-        }
-
-        private func tab(at point: NSPoint, in pane: PaneState) -> TabItem? {
-            for tab in pane.tabs {
-                guard let frame = geometryRegistry?.frame(for: tab.id, in: self) else { continue }
-                if point.x >= frame.minX, point.x <= frame.maxX {
-                    return tab
-                }
-            }
-            return nil
-        }
-
-        private func dropTargetIndex(at point: NSPoint) -> Int? {
-            guard bounds.insetBy(dx: 0, dy: -4).contains(point),
-                  let pane,
-                  !pane.tabs.isEmpty else {
-                return nil
-            }
-
-            var lastFrame: CGRect?
-            for (index, tab) in pane.tabs.enumerated() {
-                guard let frame = geometryRegistry?.frame(for: tab.id, in: self) else { continue }
-                lastFrame = frame
-                if point.x < frame.midX {
-                    return index
-                }
-            }
-
-            if let lastFrame,
-               point.x <= lastFrame.maxX + Self.trailingDropSlop {
-                return pane.tabs.count
-            }
-            return nil
-        }
-
-        private func shouldSuppressIndicator(sourceTabId: UUID, targetIndex: Int) -> Bool {
-            guard let pane,
-                  let sourceIndex = pane.tabs.firstIndex(where: { $0.id == sourceTabId }) else {
-                return false
-            }
-            return targetIndex == sourceIndex || targetIndex == sourceIndex + 1
-        }
-
-        private struct ManualDragSession {
-            let sourceTab: TabItem
-            let sourcePaneId: PaneID
-            let startPoint: NSPoint
-            var currentTargetIndex: Int?
-            var didStartDrag: Bool
         }
     }
 }
@@ -3179,7 +2892,6 @@ struct TabDropDelegate: DropDelegate {
     let bonsplitController: BonsplitController
     let controller: SplitViewController
     @Binding var dropTargetIndex: Int?
-    @Binding var manualDropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
 
     func performDrop(info: DropInfo) -> Bool {
@@ -3189,7 +2901,7 @@ struct TabDropDelegate: DropDelegate {
 #if DEBUG
         dlog(
             "tab.drop pane=\(pane.id.id.uuidString.prefix(5)) " +
-            "targetIndex=\(targetIndex) manualTarget=\(manualDropTargetIndex.map(String.init) ?? "nil")"
+            "targetIndex=\(targetIndex)"
         )
 #endif
 
@@ -3206,26 +2918,8 @@ struct TabDropDelegate: DropDelegate {
         guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
             if let transfer = decodeTransfer(from: info) {
-                if let request = Self.sameProcessFallbackRequest(
-                    transfer: transfer,
-                    targetPane: pane.id,
-                    targetIndex: targetIndex,
-                    allowCrossPaneTabMove: bonsplitController.configuration.allowCrossPaneTabMove
-                ) {
-                    let handled = bonsplitController.onExternalTabDrop?(request) ?? false
-                    if handled {
-                        clearDropState()
-                    }
-                    return handled
-                }
                 if transfer.isFromCurrentProcess {
-#if DEBUG
-                    dlog(
-                        "tab.drop.skip pane=\(pane.id.id.uuidString.prefix(5)) " +
-                        "targetIndex=\(targetIndex) reason=stale_same_pane_transfer"
-                    )
-#endif
-                    return false
+                    return performSameProcessTransfer(transfer)
                 }
             }
 
@@ -3238,61 +2932,26 @@ struct TabDropDelegate: DropDelegate {
             guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
         }
 
-        // Execute synchronously when possible so the dragged tab disappears immediately.
-        let applyMove = {
-            // Pre-move order, captured inside the transaction below; the delegate is
-            // fired AFTER the transaction (mirroring the manual-drag path) and only when
-            // the order actually changed, so a no-op move never pushes a spurious
-            // reorder to consumers (e.g. a redundant tmux swap-window).
-            var orderBeforeReorder: [UUID]?
-            // Ensure the move itself doesn't animate.
+        var handled = false
+        if sourcePaneId == pane.id {
+            handled = performSamePaneReorder(tabId: draggedTab.id)
+        } else {
             withTransaction(Transaction(animation: nil)) {
-                if sourcePaneId == pane.id {
-                    guard let sourceIndex = pane.tabs.firstIndex(where: { $0.id == draggedTab.id }) else { return }
-                    let destinationIndex = Self.effectiveLocalDropTargetIndex(
-                        staticTargetIndex: targetIndex,
-                        manualTargetIndex: manualDropTargetIndex,
-                        sourcePaneMatchesTarget: true,
-                        sourceIndex: sourceIndex
-                    )
-                    // Same-pane no-op: don't mutate the model (and don't show an indicator).
-                    if Self.isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: destinationIndex) {
-                        return
-                    }
-                    orderBeforeReorder = pane.tabs.map { $0.id }
-                    pane.moveTab(from: sourceIndex, to: destinationIndex)
-                } else {
-                    _ = bonsplitController.moveTab(
-                        TabID(id: draggedTab.id),
-                        toPane: pane.id,
-                        atIndex: targetIndex
-                    )
-                }
-            }
-            // Outside the transaction, matching the manual-drag path's delegate timing.
-            if sourcePaneId == pane.id,
-               let orderBeforeReorder,
-               pane.tabs.map({ $0.id }) != orderBeforeReorder {
-                bonsplitController.delegate?.splitTabBar(
-                    bonsplitController,
-                    didReorderTabsInPane: pane.id,
-                    orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
+                handled = bonsplitController.moveTab(
+                    TabID(id: draggedTab.id),
+                    toPane: pane.id,
+                    atIndex: targetIndex
                 )
             }
         }
-
-        applyMove()
 
         // Clear visual state immediately to prevent lingering indicators.
         // Must happen synchronously before returning, not in async callback.
         // Setting dropLifecycle to idle prevents dropUpdated from re-setting dropTargetIndex.
         clearDropState()
-        controller.draggingTab = nil
-        controller.dragSourcePaneId = nil
-        controller.activeDragTab = nil
-        controller.activeDragSourcePaneId = nil
+        clearControllerDragState()
 
-        return true
+        return handled
     }
 
     func dropEntered(info: DropInfo) {
@@ -3315,7 +2974,7 @@ struct TabDropDelegate: DropDelegate {
         #endif
         dropLifecycle = .idle
         if samePaneLocalDragSourceIndex() != nil {
-            dropTargetIndex = manualDropTargetIndex
+            dropTargetIndex = nil
         } else if dropTargetIndex == targetIndex {
             dropTargetIndex = nil
         }
@@ -3335,7 +2994,6 @@ struct TabDropDelegate: DropDelegate {
 #if DEBUG
         dlog(
             "tab.dropUpdated pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex) " +
-            "manualTarget=\(manualDropTargetIndex.map(String.init) ?? "nil") " +
             "dropTarget=\(dropTargetIndex.map(String.init) ?? "nil")"
         )
 #endif
@@ -3367,12 +3025,18 @@ struct TabDropDelegate: DropDelegate {
             return bonsplitController.configuration.allowCrossPaneTabMove
         }
 
-        // External drags (another Bonsplit controller) must include a payload from this process.
+        // Drops whose live drag state has already been cleared must still include
+        // a same-process payload so we can distinguish tab moves from file drops.
         guard let transfer = decodeTransfer(from: info),
               transfer.isFromCurrentProcess else {
             return false
         }
-        guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
+        let sourcePaneID = PaneID(id: transfer.sourcePaneId)
+        if sourcePaneID == pane.id {
+            guard bonsplitController.configuration.allowTabReordering else { return false }
+        } else {
+            guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
+        }
 #if DEBUG
         let hasDrag = controller.draggingTab != nil
         let hasActive = controller.activeDragTab != nil
@@ -3387,22 +3051,17 @@ struct TabDropDelegate: DropDelegate {
     private func clearDropState() {
         dropLifecycle = .idle
         dropTargetIndex = nil
-        manualDropTargetIndex = nil
     }
 
-    static func effectiveLocalDropTargetIndex(
-        staticTargetIndex: Int,
-        manualTargetIndex: Int?,
-        sourcePaneMatchesTarget: Bool,
-        sourceIndex: Int?
-    ) -> Int {
-        if sourcePaneMatchesTarget,
-           let sourceIndex,
-           let manualTargetIndex,
-           !isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: manualTargetIndex) {
-            return manualTargetIndex
-        }
-        return staticTargetIndex
+    private func clearControllerDragState() {
+        controller.draggingTab = nil
+        controller.dragSourcePaneId = nil
+        controller.activeDragTab = nil
+        controller.activeDragSourcePaneId = nil
+    }
+
+    static func samePaneDropTarget(sourceIndex: Int, targetIndex: Int) -> Int? {
+        isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: targetIndex) ? nil : targetIndex
     }
 
     static func isNoopSamePaneTarget(sourceIndex: Int, targetIndex: Int) -> Bool {
@@ -3428,6 +3087,56 @@ struct TabDropDelegate: DropDelegate {
             sourcePaneId: sourcePaneId,
             destination: .insert(targetPane: targetPane, targetIndex: targetIndex)
         )
+    }
+
+    private func performSameProcessTransfer(_ transfer: TabTransferData) -> Bool {
+        let sourcePaneId = PaneID(id: transfer.sourcePaneId)
+        if sourcePaneId == pane.id {
+            guard bonsplitController.configuration.allowTabReordering else { return false }
+            let handled = performSamePaneReorder(tabId: transfer.tab.id)
+            if handled {
+                clearDropState()
+                clearControllerDragState()
+            }
+            return handled
+        }
+
+        guard let request = Self.sameProcessFallbackRequest(
+            transfer: transfer,
+            targetPane: pane.id,
+            targetIndex: targetIndex,
+            allowCrossPaneTabMove: bonsplitController.configuration.allowCrossPaneTabMove
+        ) else {
+            return false
+        }
+        let handled = bonsplitController.onExternalTabDrop?(request) ?? false
+        if handled {
+            clearDropState()
+            clearControllerDragState()
+        }
+        return handled
+    }
+
+    private func performSamePaneReorder(tabId: UUID) -> Bool {
+        guard let sourceIndex = pane.tabs.firstIndex(where: { $0.id == tabId }) else {
+            return false
+        }
+        guard let destinationIndex = Self.samePaneDropTarget(sourceIndex: sourceIndex, targetIndex: targetIndex) else {
+            return true
+        }
+
+        let orderBeforeReorder = pane.tabs.map { $0.id }
+        withTransaction(Transaction(animation: nil)) {
+            pane.moveTab(from: sourceIndex, to: destinationIndex)
+        }
+        if pane.tabs.map({ $0.id }) != orderBeforeReorder {
+            bonsplitController.delegate?.splitTabBar(
+                bonsplitController,
+                didReorderTabsInPane: pane.id,
+                orderedTabIds: pane.tabs.map { TabID(id: $0.id) }
+            )
+        }
+        return true
     }
 
     private func dropOperation(for info: DropInfo) -> DropOperation {
@@ -3460,12 +3169,7 @@ struct TabDropDelegate: DropDelegate {
 
     private func updateDropTargetForHover() {
         if let sourceIndex = samePaneLocalDragSourceIndex() {
-            if let manualDropTargetIndex,
-               !Self.isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: manualDropTargetIndex) {
-                dropTargetIndex = manualDropTargetIndex
-            } else {
-                dropTargetIndex = nil
-            }
+            dropTargetIndex = Self.samePaneDropTarget(sourceIndex: sourceIndex, targetIndex: targetIndex)
             return
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -803,6 +803,7 @@ struct TabBarView: View {
     @AppStorage("debugFadeColorStyle") private var fadeColorStyle = -1
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
+    @State private var manualDropTargetIndex: Int?
     @State private var dropLifecycle: TabDropLifecycle = .idle
     @State private var scrollOffset: CGFloat = 0
     @State private var contentWidth: CGFloat = 0
@@ -1007,6 +1008,7 @@ struct TabBarView: View {
             bonsplitController: controller,
             controller: splitViewController,
             dropTargetIndex: $dropTargetIndex,
+            manualDropTargetIndex: $manualDropTargetIndex,
             dropLifecycle: $dropLifecycle
         ))
     }
@@ -1032,6 +1034,7 @@ struct TabBarView: View {
                 splitViewController: splitViewController,
                 geometryRegistry: tabItemGeometryRegistry,
                 dropTargetIndex: $dropTargetIndex,
+                manualDropTargetIndex: $manualDropTargetIndex,
                 dropLifecycle: $dropLifecycle
             )
         }
@@ -1122,6 +1125,7 @@ struct TabBarView: View {
                                 bonsplitController: controller,
                                 controller: splitViewController,
                                 dropTargetIndex: $dropTargetIndex,
+                                manualDropTargetIndex: $manualDropTargetIndex,
                                 dropLifecycle: $dropLifecycle
                             ))
                         }
@@ -1191,6 +1195,7 @@ struct TabBarView: View {
 #endif
             if newValue == nil {
                 dropTargetIndex = nil
+                manualDropTargetIndex = nil
                 dropLifecycle = .idle
             }
         }
@@ -1308,6 +1313,7 @@ struct TabBarView: View {
             bonsplitController: controller,
             controller: splitViewController,
             dropTargetIndex: $dropTargetIndex,
+            manualDropTargetIndex: $manualDropTargetIndex,
             dropLifecycle: $dropLifecycle
         ))
         .overlay(alignment: .leading) {
@@ -1334,6 +1340,7 @@ struct TabBarView: View {
     private func createItemProvider(for tab: TabItem) -> NSItemProvider {
         splitViewController.makeTabDragItemProvider(for: tab, from: pane.id) {
             dropTargetIndex = nil
+            manualDropTargetIndex = nil
             dropLifecycle = .idle
         }
     }
@@ -1374,6 +1381,7 @@ struct TabBarView: View {
             bonsplitController: controller,
             controller: splitViewController,
             dropTargetIndex: $dropTargetIndex,
+            manualDropTargetIndex: $manualDropTargetIndex,
             dropLifecycle: $dropLifecycle
         ))
         .overlay(alignment: .leading) {
@@ -1994,6 +2002,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
     let splitViewController: SplitViewController
     let geometryRegistry: TabBarItemGeometryRegistry
     @Binding var dropTargetIndex: Int?
+    @Binding var manualDropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
 
     func makeNSView(context: Context) -> ManualReorderNSView {
@@ -2012,6 +2021,7 @@ private struct TabBarManualReorderTrackingView: NSViewRepresentable {
         view.splitViewController = splitViewController
         view.geometryRegistry = geometryRegistry
         view.onDropStateChanged = { targetIndex, lifecycle in
+            manualDropTargetIndex = targetIndex
             dropTargetIndex = targetIndex
             dropLifecycle = lifecycle
         }
@@ -3178,6 +3188,7 @@ struct TabDropDelegate: DropDelegate {
     let bonsplitController: BonsplitController
     let controller: SplitViewController
     @Binding var dropTargetIndex: Int?
+    @Binding var manualDropTargetIndex: Int?
     @Binding var dropLifecycle: TabDropLifecycle
 
     func performDrop(info: DropInfo) -> Bool {
@@ -3185,7 +3196,10 @@ struct TabDropDelegate: DropDelegate {
         NSLog("[Bonsplit Drag] performDrop called, targetIndex: \(targetIndex)")
         #endif
 #if DEBUG
-        dlog("tab.drop pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex)")
+        dlog(
+            "tab.drop pane=\(pane.id.id.uuidString.prefix(5)) " +
+            "targetIndex=\(targetIndex) manualTarget=\(manualDropTargetIndex.map(String.init) ?? "nil")"
+        )
 #endif
 
         // Ensure all drag/drop side-effects run on the main actor. SwiftUI can call these
@@ -3244,12 +3258,18 @@ struct TabDropDelegate: DropDelegate {
             withTransaction(Transaction(animation: nil)) {
                 if sourcePaneId == pane.id {
                     guard let sourceIndex = pane.tabs.firstIndex(where: { $0.id == draggedTab.id }) else { return }
+                    let destinationIndex = Self.effectiveLocalDropTargetIndex(
+                        staticTargetIndex: targetIndex,
+                        manualTargetIndex: manualDropTargetIndex,
+                        sourcePaneMatchesTarget: true,
+                        sourceIndex: sourceIndex
+                    )
                     // Same-pane no-op: don't mutate the model (and don't show an indicator).
-                    if targetIndex == sourceIndex || targetIndex == sourceIndex + 1 {
+                    if Self.isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: destinationIndex) {
                         return
                     }
                     orderBeforeReorder = pane.tabs.map { $0.id }
-                    pane.moveTab(from: sourceIndex, to: targetIndex)
+                    pane.moveTab(from: sourceIndex, to: destinationIndex)
                 } else {
                     _ = bonsplitController.moveTab(
                         TabID(id: draggedTab.id),
@@ -3294,11 +3314,7 @@ struct TabDropDelegate: DropDelegate {
         )
         #endif
         dropLifecycle = .hovering
-        if shouldSuppressIndicatorForNoopSamePaneDrop() {
-            dropTargetIndex = nil
-        } else {
-            dropTargetIndex = targetIndex
-        }
+        updateDropTargetForHover()
     }
 
     func dropExited(info: DropInfo) {
@@ -3307,7 +3323,9 @@ struct TabDropDelegate: DropDelegate {
         dlog("tab.dropExited pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex)")
         #endif
         dropLifecycle = .idle
-        if dropTargetIndex == targetIndex {
+        if samePaneLocalDragSourceIndex() != nil {
+            dropTargetIndex = manualDropTargetIndex
+        } else if dropTargetIndex == targetIndex {
             dropTargetIndex = nil
         }
     }
@@ -3322,16 +3340,11 @@ struct TabDropDelegate: DropDelegate {
             return DropProposal(operation: dropOperation(for: info))
         }
         // Only update if this is the active target, and suppress same-pane no-op indicators.
-        if shouldSuppressIndicatorForNoopSamePaneDrop() {
-            if dropTargetIndex == targetIndex {
-                dropTargetIndex = nil
-            }
-        } else if dropTargetIndex != targetIndex {
-            dropTargetIndex = targetIndex
-        }
+        updateDropTargetForHover()
 #if DEBUG
         dlog(
             "tab.dropUpdated pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex) " +
+            "manualTarget=\(manualDropTargetIndex.map(String.init) ?? "nil") " +
             "dropTarget=\(dropTargetIndex.map(String.init) ?? "nil")"
         )
 #endif
@@ -3383,6 +3396,7 @@ struct TabDropDelegate: DropDelegate {
     private func clearDropState() {
         dropLifecycle = .idle
         dropTargetIndex = nil
+        manualDropTargetIndex = nil
     }
 
     static func effectiveLocalDropTargetIndex(
@@ -3391,7 +3405,19 @@ struct TabDropDelegate: DropDelegate {
         sourcePaneMatchesTarget: Bool,
         sourceIndex: Int?
     ) -> Int {
+        if sourcePaneMatchesTarget,
+           let sourceIndex,
+           let manualTargetIndex,
+           !isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: manualTargetIndex) {
+            return manualTargetIndex
+        }
         staticTargetIndex
+    }
+
+    static func isNoopSamePaneTarget(sourceIndex: Int, targetIndex: Int) -> Bool {
+        // Insertion indices are expressed in "original array" coordinates; after removal,
+        // inserting at `sourceIndex` or `sourceIndex + 1` results in no change.
+        targetIndex == sourceIndex || targetIndex == sourceIndex + 1
     }
 
     static func sameProcessFallbackRequest(
@@ -3441,15 +3467,39 @@ struct TabDropDelegate: DropDelegate {
         return handled
     }
 
+    private func updateDropTargetForHover() {
+        if let sourceIndex = samePaneLocalDragSourceIndex() {
+            if let manualDropTargetIndex,
+               !Self.isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: manualDropTargetIndex) {
+                dropTargetIndex = manualDropTargetIndex
+            } else {
+                dropTargetIndex = nil
+            }
+            return
+        }
+
+        if shouldSuppressIndicatorForNoopSamePaneDrop() {
+            if dropTargetIndex == targetIndex {
+                dropTargetIndex = nil
+            }
+        } else if dropTargetIndex != targetIndex {
+            dropTargetIndex = targetIndex
+        }
+    }
+
+    private func samePaneLocalDragSourceIndex() -> Int? {
+        guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
+              (controller.activeDragSourcePaneId ?? controller.dragSourcePaneId) == pane.id else {
+            return nil
+        }
+        return pane.tabs.firstIndex(where: { $0.id == draggedTab.id })
+    }
+
     private func shouldSuppressIndicatorForNoopSamePaneDrop() -> Bool {
-        guard let draggedTab = controller.draggingTab,
-              controller.dragSourcePaneId == pane.id,
-              let sourceIndex = pane.tabs.firstIndex(where: { $0.id == draggedTab.id }) else {
+        guard let sourceIndex = samePaneLocalDragSourceIndex() else {
             return false
         }
-        // Insertion indices are expressed in "original array" coordinates; after removal,
-        // inserting at `sourceIndex` or `sourceIndex + 1` results in no change.
-        return targetIndex == sourceIndex || targetIndex == sourceIndex + 1
+        return Self.isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: targetIndex)
     }
 
     private func decodeTransfer(from string: String) -> TabTransferData? {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3411,7 +3411,7 @@ struct TabDropDelegate: DropDelegate {
            !isNoopSamePaneTarget(sourceIndex: sourceIndex, targetIndex: manualTargetIndex) {
             return manualTargetIndex
         }
-        staticTargetIndex
+        return staticTargetIndex
     }
 
     static func isNoopSamePaneTarget(sourceIndex: Int, targetIndex: Int) -> Bool {

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3118,10 +3118,25 @@ struct TabDropDelegate: DropDelegate {
     }
 
     private func performSamePaneReorder(tabId: UUID) -> Bool {
+        Self.performSamePaneReorder(
+            tabId: tabId,
+            targetIndex: targetIndex,
+            pane: pane,
+            bonsplitController: bonsplitController
+        )
+    }
+
+    @discardableResult
+    static func performSamePaneReorder(
+        tabId: UUID,
+        targetIndex: Int,
+        pane: PaneState,
+        bonsplitController: BonsplitController
+    ) -> Bool {
         guard let sourceIndex = pane.tabs.firstIndex(where: { $0.id == tabId }) else {
             return false
         }
-        guard let destinationIndex = Self.samePaneDropTarget(sourceIndex: sourceIndex, targetIndex: targetIndex) else {
+        guard let destinationIndex = samePaneDropTarget(sourceIndex: sourceIndex, targetIndex: targetIndex) else {
             return true
         }
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -3202,10 +3202,20 @@ struct TabDropDelegate: DropDelegate {
               let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
             if let transfer = decodeTransfer(from: info),
                transfer.isFromCurrentProcess {
+                let sourcePaneId = PaneID(id: transfer.sourcePaneId)
+                if sourcePaneId == pane.id {
+#if DEBUG
+                    dlog(
+                        "tab.drop.skip pane=\(pane.id.id.uuidString.prefix(5)) " +
+                        "targetIndex=\(targetIndex) reason=stale_same_pane_transfer"
+                    )
+#endif
+                    return false
+                }
                 guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
                 let request = BonsplitController.ExternalTabDropRequest(
                     tabId: TabID(id: transfer.tab.id),
-                    sourcePaneId: PaneID(id: transfer.sourcePaneId),
+                    sourcePaneId: sourcePaneId,
                     destination: .insert(targetPane: pane.id, targetIndex: targetIndex)
                 )
                 let handled = bonsplitController.onExternalTabDrop?(request) ?? false

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2378,7 +2378,7 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testTrailingTabBarChromeRoutesTabDropsAcrossFullWidth() throws {
+    func testTrailingTabBarChromeDropDestinationStaysOffTabPixels() throws {
         let appearance = BonsplitConfiguration.Appearance(splitButtons: [])
         let controller = BonsplitController(
             configuration: BonsplitConfiguration(appearance: appearance)
@@ -2445,52 +2445,62 @@ final class BonsplitTests: XCTestCase {
                 && abs(lhsFrame.minY - rhsFrame.minY) <= 0.5
                 && abs(lhsFrame.maxY - rhsFrame.maxY) <= 0.5
         }
+
+        let tabPoint = NSPoint(x: 90, y: 30)
+        let trailingEmptyPoint = NSPoint(x: 460, y: 30)
         let registrationDeadline = Date().addingTimeInterval(0.5)
         var dropDestinations: [NSView] = []
         var dragZoneViews: [TabBarDragZoneView.DragNSView] = []
+
+        func dropDestination(at point: NSPoint) -> NSView? {
+            let pointInWindow = hostingView.convert(point, to: nil)
+            return dropDestinations.first { view in
+                view.convert(view.bounds, to: nil).contains(pointInWindow)
+            }
+        }
+        func chromeDragZones(at point: NSPoint) -> [TabBarDragZoneView.DragNSView] {
+            let pointInWindow = hostingView.convert(point, to: nil)
+            return dragZoneViews.filter { dragZone in
+                dragZone.convert(dragZone.bounds, to: nil).contains(pointInWindow)
+            }
+        }
+
         repeat {
             contentView.layoutSubtreeIfNeeded()
             setDragHitTesting(hostingView)
             dropDestinations = tabDropDestinations(in: hostingView)
             dragZoneViews = dragZones(in: hostingView)
-            if dragZoneViews.contains(where: { dragZone in
-                dropDestinations.contains(where: { framesMatch(dragZone, $0) })
-            }) {
+            let tabPointInWindow = hostingView.convert(tabPoint, to: nil)
+            if BonsplitTabItemHitRegionRegistry.containsWindowPoint(tabPointInWindow, in: window),
+               dropDestination(at: trailingEmptyPoint) != nil {
                 break
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.01))
         } while Date() < registrationDeadline
 
-        guard dragZoneViews.contains(where: { dragZone in
-            dropDestinations.contains(where: { framesMatch(dragZone, $0) })
-        }) else {
+        guard dropDestination(at: trailingEmptyPoint) != nil else {
             throw XCTSkip(
                 "This SwiftUI runtime does not expose view-local onDrop registration through registeredDraggedTypes"
             )
         }
 
-        for point in [
-            NSPoint(x: 90, y: 30),
-            NSPoint(x: 240, y: 30),
-            NSPoint(x: 460, y: 30),
-        ] {
-            guard let hitView = hostingView.hitTest(point) else {
-                XCTFail("Expected tab-bar chrome to hit-test at x=\(point.x)")
-                continue
-            }
-            let pointInWindow = hostingView.convert(point, to: nil)
-            let hitFrameInWindow = hitView.convert(hitView.bounds, to: nil)
-            let dropDestination = dropDestinations.first { view in
-                let destinationFrame = view.convert(view.bounds, to: nil)
-                return destinationFrame.contains(pointInWindow)
-                    && abs(destinationFrame.minX - hitFrameInWindow.minX) <= 0.5
-                    && abs(destinationFrame.maxX - hitFrameInWindow.maxX) <= 0.5
-            }
-            XCTAssertNotNil(
-                dropDestination,
-                "Trailing tab-bar chrome at x=\(point.x) should route tab transfers to a registered drop destination"
+        let tabPointInWindow = hostingView.convert(tabPoint, to: nil)
+        XCTAssertTrue(
+            BonsplitTabItemHitRegionRegistry.containsWindowPoint(tabPointInWindow, in: window),
+            "The test point should be owned by the rendered pane tab"
+        )
+
+        for dragZone in chromeDragZones(at: tabPoint) {
+            XCTAssertFalse(
+                dropDestinations.contains(where: { framesMatch(dragZone, $0) }),
+                "Empty tab-bar chrome must not register an end-drop destination over a rendered tab"
             )
         }
+
+        XCTAssertNotNil(
+            dropDestination(at: trailingEmptyPoint),
+            "Actual empty trailing tab-bar space should still route tab transfers to the end-drop destination"
+        )
     }
 
     @MainActor

--- a/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
+++ b/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
@@ -8,11 +8,11 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         let initialIds = harness.pane.tabs.map(\.id)
         let movedTabId = initialIds[0]
 
-        let targetIndex = swiftUISamePaneDropTarget(
+        let targetIndex = try XCTUnwrap(swiftUISamePaneDropTarget(
             tabId: movedTabId,
             targetIndex: 3,
             harness: harness
-        )
+        ))
 
         XCTAssertEqual(targetIndex, 3)
         XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: targetIndex))
@@ -24,11 +24,11 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         let initialIds = harness.pane.tabs.map(\.id)
         let movedTabId = initialIds[3]
 
-        let targetIndex = swiftUISamePaneDropTarget(
+        let targetIndex = try XCTUnwrap(swiftUISamePaneDropTarget(
             tabId: movedTabId,
             targetIndex: 1,
             harness: harness
-        )
+        ))
 
         XCTAssertEqual(targetIndex, 1)
         XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: targetIndex))

--- a/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
+++ b/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
@@ -15,7 +15,12 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         ))
 
         XCTAssertEqual(targetIndex, 3)
-        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: targetIndex))
+        XCTAssertTrue(TabDropDelegate.performSamePaneReorder(
+            tabId: movedTabId,
+            targetIndex: targetIndex,
+            pane: harness.pane,
+            bonsplitController: harness.controller
+        ))
         XCTAssertEqual(harness.pane.tabs.map(\.id), [initialIds[1], initialIds[2], movedTabId, initialIds[3]])
     }
 
@@ -31,7 +36,12 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         ))
 
         XCTAssertEqual(targetIndex, 1)
-        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: targetIndex))
+        XCTAssertTrue(TabDropDelegate.performSamePaneReorder(
+            tabId: movedTabId,
+            targetIndex: targetIndex,
+            pane: harness.pane,
+            bonsplitController: harness.controller
+        ))
         XCTAssertEqual(harness.pane.tabs.map(\.id), [initialIds[0], movedTabId, initialIds[1], initialIds[2]])
     }
 

--- a/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
+++ b/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
@@ -45,6 +45,29 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         XCTAssertEqual(harness.pane.tabs.map(\.id), [initialIds[0], movedTabId, initialIds[1], initialIds[2]])
     }
 
+    func testSamePaneReorderPreservesControllerMoveContract() throws {
+        let harness = try makeHarness()
+        let delegate = ReorderDelegateSpy()
+        harness.controller.delegate = delegate
+        let initialIds = harness.pane.tabs.map(\.id)
+        let movedTabId = initialIds[3]
+
+        XCTAssertTrue(TabDropDelegate.performSamePaneReorder(
+            tabId: movedTabId,
+            targetIndex: 1,
+            pane: harness.pane,
+            bonsplitController: harness.controller
+        ))
+
+        let expectedOrder = [initialIds[0], movedTabId, initialIds[1], initialIds[2]]
+        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedOrder)
+        XCTAssertEqual(harness.pane.selectedTabId, movedTabId)
+        XCTAssertEqual(harness.controller.focusedPaneId, harness.pane.id)
+        XCTAssertEqual(delegate.selectedTabIds, [TabID(id: movedTabId)])
+        XCTAssertEqual(delegate.reorderedTabIds, expectedOrder.map { TabID(id: $0) })
+        XCTAssertEqual(delegate.geometryChangeCount, 1)
+    }
+
     func testSwiftUIDropSuppressesSamePaneNoopTargets() throws {
         let harness = try makeHarness()
         let movedTabId = harness.pane.tabs[1].id
@@ -69,12 +92,6 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         _ = controller.createTab(title: "Fourth")
         let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
         XCTAssertEqual(pane.tabs.count, 4)
-        controller.onExternalTabDrop = { request in
-            guard case .insert(let targetPane, let targetIndex) = request.destination else {
-                return false
-            }
-            return controller.moveTab(request.tabId, toPane: targetPane, atIndex: targetIndex)
-        }
         return Harness(controller: controller, pane: pane)
     }
 
@@ -92,4 +109,23 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
 private struct Harness {
     let controller: BonsplitController
     let pane: PaneState
+}
+
+@MainActor
+private final class ReorderDelegateSpy: BonsplitDelegate {
+    var selectedTabIds: [TabID] = []
+    var reorderedTabIds: [TabID] = []
+    var geometryChangeCount = 0
+
+    func splitTabBar(_ controller: BonsplitController, didSelectTab tab: Tab, inPane pane: PaneID) {
+        selectedTabIds.append(tab.id)
+    }
+
+    func splitTabBar(_ controller: BonsplitController, didReorderTabsInPane pane: PaneID, orderedTabIds: [TabID]) {
+        reorderedTabIds = orderedTabIds
+    }
+
+    func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {
+        geometryChangeCount += 1
+    }
 }

--- a/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
+++ b/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
@@ -1,0 +1,126 @@
+import AppKit
+@testable import Bonsplit
+import SwiftUI
+import UniformTypeIdentifiers
+import XCTest
+
+@MainActor
+final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
+    func testEarlierTabManualMiddleReorderIgnoresStaleSamePaneEndFallback() throws {
+        let harness = try makeHarness()
+        let initialIds = harness.pane.tabs.map(\.id)
+        let movedTabId = initialIds[0]
+
+        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: 3))
+        let expectedMiddleOrder = [initialIds[1], initialIds[2], movedTabId, initialIds[3]]
+        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
+
+        let handled = performStaleSamePaneFallbackDrop(
+            tabId: movedTabId,
+            targetIndex: harness.pane.tabs.count,
+            harness: harness
+        )
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
+    }
+
+    func testLaterTabManualMiddleReorderIgnoresStaleSamePaneEndFallback() throws {
+        let harness = try makeHarness()
+        let initialIds = harness.pane.tabs.map(\.id)
+        let movedTabId = initialIds[3]
+
+        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: 1))
+        let expectedMiddleOrder = [initialIds[0], movedTabId, initialIds[1], initialIds[2]]
+        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
+
+        let handled = performStaleSamePaneFallbackDrop(
+            tabId: movedTabId,
+            targetIndex: harness.pane.tabs.count,
+            harness: harness
+        )
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
+    }
+
+    private func makeHarness() throws -> Harness {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(
+                newTabPosition: .end,
+                allowTabReordering: true,
+                allowCrossPaneTabMove: true
+            )
+        )
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        _ = controller.createTab(title: "Second")
+        _ = controller.createTab(title: "Third")
+        _ = controller.createTab(title: "Fourth")
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+        XCTAssertEqual(pane.tabs.count, 4)
+        controller.onExternalTabDrop = { request in
+            guard case .insert(let targetPane, let targetIndex) = request.destination else {
+                return false
+            }
+            return controller.moveTab(request.tabId, toPane: targetPane, atIndex: targetIndex)
+        }
+        return Harness(controller: controller, pane: pane)
+    }
+
+    private func performStaleSamePaneFallbackDrop(
+        tabId: UUID,
+        targetIndex: Int,
+        harness: Harness
+    ) -> Bool {
+        let tab = harness.pane.tabs.first { $0.id == tabId }!
+        writeTransferToDragPasteboard(tab: tab, sourcePaneId: harness.pane.id.id)
+
+        var dropTargetIndex: Int?
+        var dropLifecycle: TabDropLifecycle = .hovering
+        let delegate = TabDropDelegate(
+            targetIndex: targetIndex,
+            pane: harness.pane,
+            bonsplitController: harness.controller,
+            controller: harness.controller.internalController,
+            dropTargetIndex: Binding(
+                get: { dropTargetIndex },
+                set: { dropTargetIndex = $0 }
+            ),
+            dropLifecycle: Binding(
+                get: { dropLifecycle },
+                set: { dropLifecycle = $0 }
+            )
+        )
+
+        return delegate.performDrop(info: FakeDropInfo())
+    }
+
+    private func writeTransferToDragPasteboard(tab: TabItem, sourcePaneId: UUID) {
+        let pasteboard = NSPasteboard(name: .drag)
+        pasteboard.clearContents()
+        let transfer = TabTransferData(tab: tab, sourcePaneId: sourcePaneId)
+        let data = try! JSONEncoder().encode(transfer)
+        pasteboard.setData(
+            data,
+            forType: NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+        )
+    }
+}
+
+@MainActor
+private struct Harness {
+    let controller: BonsplitController
+    let pane: PaneState
+}
+
+private struct FakeDropInfo: DropInfo {
+    var location: CGPoint { .zero }
+
+    func itemProviders(for contentTypes: [UTType]) -> [NSItemProvider] {
+        []
+    }
+
+    func hasItemsConforming(to contentTypes: [UTType]) -> Bool {
+        contentTypes.contains(.tabTransfer)
+    }
+}

--- a/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
+++ b/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
@@ -3,6 +3,40 @@ import XCTest
 
 @MainActor
 final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
+    func testEarlierTabLocalDropUsesManualMiddleIndexInsteadOfStaticEndTarget() throws {
+        let harness = try makeHarness()
+        let initialIds = harness.pane.tabs.map(\.id)
+        let movedTabId = initialIds[0]
+
+        let targetIndex = effectiveSamePaneLocalDropTarget(
+            tabId: movedTabId,
+            staticTargetIndex: harness.pane.tabs.count,
+            manualTargetIndex: 3,
+            harness: harness
+        )
+
+        XCTAssertEqual(targetIndex, 3)
+        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: targetIndex))
+        XCTAssertEqual(harness.pane.tabs.map(\.id), [initialIds[1], initialIds[2], movedTabId, initialIds[3]])
+    }
+
+    func testLaterActiveTabLocalDropUsesManualMiddleIndexInsteadOfStaticEndNoop() throws {
+        let harness = try makeHarness()
+        let initialIds = harness.pane.tabs.map(\.id)
+        let movedTabId = initialIds[3]
+
+        let targetIndex = effectiveSamePaneLocalDropTarget(
+            tabId: movedTabId,
+            staticTargetIndex: harness.pane.tabs.count,
+            manualTargetIndex: 1,
+            harness: harness
+        )
+
+        XCTAssertEqual(targetIndex, 1)
+        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: targetIndex))
+        XCTAssertEqual(harness.pane.tabs.map(\.id), [initialIds[0], movedTabId, initialIds[1], initialIds[2]])
+    }
+
     func testEarlierTabManualMiddleReorderIgnoresStaleSamePaneEndFallback() throws {
         let harness = try makeHarness()
         let initialIds = harness.pane.tabs.map(\.id)
@@ -80,6 +114,21 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
             return false
         }
         return harness.controller.onExternalTabDrop?(request) ?? false
+    }
+
+    private func effectiveSamePaneLocalDropTarget(
+        tabId: UUID,
+        staticTargetIndex: Int,
+        manualTargetIndex: Int,
+        harness: Harness
+    ) -> Int {
+        let sourceIndex = harness.pane.tabs.firstIndex { $0.id == tabId }
+        return TabDropDelegate.effectiveLocalDropTargetIndex(
+            staticTargetIndex: staticTargetIndex,
+            manualTargetIndex: manualTargetIndex,
+            sourcePaneMatchesTarget: true,
+            sourceIndex: sourceIndex
+        )
     }
 }
 

--- a/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
+++ b/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
@@ -3,15 +3,14 @@ import XCTest
 
 @MainActor
 final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
-    func testEarlierTabLocalDropUsesManualMiddleIndexInsteadOfStaticEndTarget() throws {
+    func testEarlierTabSwiftUIDropUsesMiddleTargetFromDelegate() throws {
         let harness = try makeHarness()
         let initialIds = harness.pane.tabs.map(\.id)
         let movedTabId = initialIds[0]
 
-        let targetIndex = effectiveSamePaneLocalDropTarget(
+        let targetIndex = swiftUISamePaneDropTarget(
             tabId: movedTabId,
-            staticTargetIndex: harness.pane.tabs.count,
-            manualTargetIndex: 3,
+            targetIndex: 3,
             harness: harness
         )
 
@@ -20,15 +19,14 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         XCTAssertEqual(harness.pane.tabs.map(\.id), [initialIds[1], initialIds[2], movedTabId, initialIds[3]])
     }
 
-    func testLaterActiveTabLocalDropUsesManualMiddleIndexInsteadOfStaticEndNoop() throws {
+    func testLaterTabSwiftUIDropUsesMiddleTargetFromDelegate() throws {
         let harness = try makeHarness()
         let initialIds = harness.pane.tabs.map(\.id)
         let movedTabId = initialIds[3]
 
-        let targetIndex = effectiveSamePaneLocalDropTarget(
+        let targetIndex = swiftUISamePaneDropTarget(
             tabId: movedTabId,
-            staticTargetIndex: harness.pane.tabs.count,
-            manualTargetIndex: 1,
+            targetIndex: 1,
             harness: harness
         )
 
@@ -37,42 +35,14 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         XCTAssertEqual(harness.pane.tabs.map(\.id), [initialIds[0], movedTabId, initialIds[1], initialIds[2]])
     }
 
-    func testEarlierTabManualMiddleReorderIgnoresStaleSamePaneEndFallback() throws {
+    func testSwiftUIDropSuppressesSamePaneNoopTargets() throws {
         let harness = try makeHarness()
-        let initialIds = harness.pane.tabs.map(\.id)
-        let movedTabId = initialIds[0]
+        let movedTabId = harness.pane.tabs[1].id
 
-        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: 3))
-        let expectedMiddleOrder = [initialIds[1], initialIds[2], movedTabId, initialIds[3]]
-        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
-
-        let handled = performStaleSamePaneFallbackDrop(
-            tabId: movedTabId,
-            targetIndex: harness.pane.tabs.count,
-            harness: harness
-        )
-
-        XCTAssertFalse(handled)
-        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
-    }
-
-    func testLaterTabManualMiddleReorderIgnoresStaleSamePaneEndFallback() throws {
-        let harness = try makeHarness()
-        let initialIds = harness.pane.tabs.map(\.id)
-        let movedTabId = initialIds[3]
-
-        XCTAssertTrue(harness.controller.reorderTab(TabID(uuid: movedTabId), toIndex: 1))
-        let expectedMiddleOrder = [initialIds[0], movedTabId, initialIds[1], initialIds[2]]
-        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
-
-        let handled = performStaleSamePaneFallbackDrop(
-            tabId: movedTabId,
-            targetIndex: harness.pane.tabs.count,
-            harness: harness
-        )
-
-        XCTAssertFalse(handled)
-        XCTAssertEqual(harness.pane.tabs.map(\.id), expectedMiddleOrder)
+        XCTAssertNil(swiftUISamePaneDropTarget(tabId: movedTabId, targetIndex: 1, harness: harness))
+        XCTAssertNil(swiftUISamePaneDropTarget(tabId: movedTabId, targetIndex: 2, harness: harness))
+        XCTAssertEqual(swiftUISamePaneDropTarget(tabId: movedTabId, targetIndex: 0, harness: harness), 0)
+        XCTAssertEqual(swiftUISamePaneDropTarget(tabId: movedTabId, targetIndex: 3, harness: harness), 3)
     }
 
     private func makeHarness() throws -> Harness {
@@ -98,37 +68,13 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         return Harness(controller: controller, pane: pane)
     }
 
-    private func performStaleSamePaneFallbackDrop(
+    private func swiftUISamePaneDropTarget(
         tabId: UUID,
         targetIndex: Int,
         harness: Harness
-    ) -> Bool {
-        let tab = harness.pane.tabs.first { $0.id == tabId }!
-        let transfer = TabTransferData(tab: tab, sourcePaneId: harness.pane.id.id)
-        guard let request = TabDropDelegate.sameProcessFallbackRequest(
-            transfer: transfer,
-            targetPane: harness.pane.id,
-            targetIndex: targetIndex,
-            allowCrossPaneTabMove: harness.controller.configuration.allowCrossPaneTabMove
-        ) else {
-            return false
-        }
-        return harness.controller.onExternalTabDrop?(request) ?? false
-    }
-
-    private func effectiveSamePaneLocalDropTarget(
-        tabId: UUID,
-        staticTargetIndex: Int,
-        manualTargetIndex: Int,
-        harness: Harness
-    ) -> Int {
-        let sourceIndex = harness.pane.tabs.firstIndex { $0.id == tabId }
-        return TabDropDelegate.effectiveLocalDropTargetIndex(
-            staticTargetIndex: staticTargetIndex,
-            manualTargetIndex: manualTargetIndex,
-            sourcePaneMatchesTarget: true,
-            sourceIndex: sourceIndex
-        )
+    ) -> Int? {
+        let sourceIndex = harness.pane.tabs.firstIndex { $0.id == tabId }!
+        return TabDropDelegate.samePaneDropTarget(sourceIndex: sourceIndex, targetIndex: targetIndex)
     }
 }
 

--- a/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
+++ b/Tests/BonsplitTests/TabDropDelegateSamePaneFallbackTests.swift
@@ -1,7 +1,4 @@
-import AppKit
 @testable import Bonsplit
-import SwiftUI
-import UniformTypeIdentifiers
 import XCTest
 
 @MainActor
@@ -47,9 +44,9 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
     private func makeHarness() throws -> Harness {
         let controller = BonsplitController(
             configuration: BonsplitConfiguration(
-                newTabPosition: .end,
                 allowTabReordering: true,
-                allowCrossPaneTabMove: true
+                allowCrossPaneTabMove: true,
+                newTabPosition: .end
             )
         )
         let paneId = try XCTUnwrap(controller.focusedPaneId)
@@ -73,37 +70,16 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
         harness: Harness
     ) -> Bool {
         let tab = harness.pane.tabs.first { $0.id == tabId }!
-        writeTransferToDragPasteboard(tab: tab, sourcePaneId: harness.pane.id.id)
-
-        var dropTargetIndex: Int?
-        var dropLifecycle: TabDropLifecycle = .hovering
-        let delegate = TabDropDelegate(
+        let transfer = TabTransferData(tab: tab, sourcePaneId: harness.pane.id.id)
+        guard let request = TabDropDelegate.sameProcessFallbackRequest(
+            transfer: transfer,
+            targetPane: harness.pane.id,
             targetIndex: targetIndex,
-            pane: harness.pane,
-            bonsplitController: harness.controller,
-            controller: harness.controller.internalController,
-            dropTargetIndex: Binding(
-                get: { dropTargetIndex },
-                set: { dropTargetIndex = $0 }
-            ),
-            dropLifecycle: Binding(
-                get: { dropLifecycle },
-                set: { dropLifecycle = $0 }
-            )
-        )
-
-        return delegate.performDrop(info: FakeDropInfo())
-    }
-
-    private func writeTransferToDragPasteboard(tab: TabItem, sourcePaneId: UUID) {
-        let pasteboard = NSPasteboard(name: .drag)
-        pasteboard.clearContents()
-        let transfer = TabTransferData(tab: tab, sourcePaneId: sourcePaneId)
-        let data = try! JSONEncoder().encode(transfer)
-        pasteboard.setData(
-            data,
-            forType: NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
-        )
+            allowCrossPaneTabMove: harness.controller.configuration.allowCrossPaneTabMove
+        ) else {
+            return false
+        }
+        return harness.controller.onExternalTabDrop?(request) ?? false
     }
 }
 
@@ -111,16 +87,4 @@ final class TabDropDelegateSamePaneFallbackTests: XCTestCase {
 private struct Harness {
     let controller: BonsplitController
     let pane: PaneState
-}
-
-private struct FakeDropInfo: DropInfo {
-    var location: CGPoint { .zero }
-
-    func itemProviders(for contentTypes: [UTType]) -> [NSItemProvider] {
-        []
-    }
-
-    func hasItemsConforming(to contentTypes: [UTType]) -> Bool {
-        contentTypes.contains(.tabTransfer)
-    }
 }


### PR DESCRIPTION
## Summary
- Ignore stale same-pane pasteboard fallback drops after the manual tab drag path has already applied the reorder.
- Keep cross-pane same-process fallback drops routed through the existing external-drop handler.
- Add four-tab coverage for earlier-to-middle and later-to-middle reorder sequences followed by a stale end fallback.

## Testing
- Remote aws-m4pro-4: swift test --filter TabDropDelegateSamePaneFallbackTests, 2 tests passed.

## Issues
- Related: cmux tab drag reorder middle-index bug reported in chat.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788223939&installation_model_id=21920&pr_number=197&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F197&signature=fc30f896ddc19a580bfa27b3717bd20a6eef6d14224cf9c397510bce8496479c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes same‑pane tab drag reorder by moving it into the drop delegate, honoring live hover targets and ignoring stale SwiftUI fallbacks to stop duplicate moves and flicker. Also tightens cleanup and keeps the end‑of‑bar drop active only in truly empty chrome.

- **Bug Fixes**
  - Own same‑pane reorder in the drop delegate; remove the manual tracker; suppress no‑op targets using the live local source index on hover.
  - Handle pasteboard‑only fallbacks: detect same‑process tab moves after live drag clears; apply same‑pane inline, route cross‑pane via the external handler; clear indicators and controller drag state immediately.
  - Add helpers (`samePaneDropTarget`, `performSamePaneReorder`, and a fallback request planner) and tests for earlier→middle/later→middle, SwiftUI‑owned drops, no‑op suppression, controller move contract (select + geometry), and empty‑chrome end‑drop.

<sup>Written for commit 529913b7a49c39669414578f1f32ccf2df47f0f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab drag-and-drop behavior within and between panes.
  * Fixed same-pane reordering when moving tabs earlier or later in the tab bar.
  * Prevented no-op drops and drop targets from appearing over existing tab content.
  * Improved drag-state cleanup to prevent stale drop actions after reordering.
  * Preserved file-drop handling when tab transfers cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->