### PR TITLE
Cache tab rendering hot paths

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -5,11 +5,17 @@ import UniformTypeIdentifiers
 /// Custom UTTypes for tab drag and drop
 extension UTType {
     static var tabItem: UTType {
-        UTType(exportedAs: "com.splittabbar.tabitem")
+#if DEBUG
+        BonsplitDebugCounters.recordTabItemTypeConstruction()
+#endif
+        return UTType(exportedAs: "com.splittabbar.tabitem")
     }
 
     static var tabTransfer: UTType {
-        UTType(exportedAs: "com.splittabbar.tabtransfer", conformingTo: .data)
+#if DEBUG
+        BonsplitDebugCounters.recordTabTransferTypeConstruction()
+#endif
+        return UTType(exportedAs: "com.splittabbar.tabtransfer", conformingTo: .data)
     }
 }
 

--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -4,19 +4,19 @@ import UniformTypeIdentifiers
 
 /// Custom UTTypes for tab drag and drop
 extension UTType {
-    static var tabItem: UTType {
+    static let tabItem: UTType = {
 #if DEBUG
         BonsplitDebugCounters.recordTabItemTypeConstruction()
 #endif
         return UTType(exportedAs: "com.splittabbar.tabitem")
-    }
+    }()
 
-    static var tabTransfer: UTType {
+    static let tabTransfer: UTType = {
 #if DEBUG
         BonsplitDebugCounters.recordTabTransferTypeConstruction()
 #endif
         return UTType(exportedAs: "com.splittabbar.tabtransfer", conformingTo: .data)
-    }
+    }()
 }
 
 /// Represents a single tab in a pane's tab bar (internal representation)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -171,6 +171,9 @@ enum TabBarStyling {
     }
 
     static func splitActionSystemImage(for name: String) -> SplitActionSystemImage {
+#if DEBUG
+        BonsplitDebugCounters.recordSplitActionSystemImageLookup()
+#endif
         if NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil {
             return SplitActionSystemImage(name: name, rotationDegrees: 0, pointSize: 12)
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -171,16 +171,7 @@ enum TabBarStyling {
     }
 
     static func splitActionSystemImage(for name: String) -> SplitActionSystemImage {
-#if DEBUG
-        BonsplitDebugCounters.recordSplitActionSystemImageLookup()
-#endif
-        if NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil {
-            return SplitActionSystemImage(name: name, rotationDegrees: 0, pointSize: 12)
-        }
-        if name == "ellipsis.vertical" {
-            return SplitActionSystemImage(name: "ellipsis", rotationDegrees: 90, pointSize: 10.5)
-        }
-        return SplitActionSystemImage(name: "questionmark.circle", rotationDegrees: 0, pointSize: 12)
+        SplitActionSystemImageCache.shared.image(for: name)
     }
 
     static func splitButtonBackdropSolidSurfaceWidth(
@@ -1797,6 +1788,38 @@ private struct TabBarLayerBackedColor: NSViewRepresentable {
             layer?.isOpaque = color.alphaComponent >= 1
             CATransaction.commit()
         }
+    }
+}
+
+private final class SplitActionSystemImageCache {
+    static let shared = SplitActionSystemImageCache()
+
+    private let lock = NSLock()
+    private var imagesByName: [String: TabBarStyling.SplitActionSystemImage] = [:]
+
+    private init() {}
+
+    func image(for name: String) -> TabBarStyling.SplitActionSystemImage {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let cached = imagesByName[name] {
+            return cached
+        }
+
+#if DEBUG
+        BonsplitDebugCounters.recordSplitActionSystemImageLookup()
+#endif
+        let image: TabBarStyling.SplitActionSystemImage
+        if NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil {
+            image = .init(name: name, rotationDegrees: 0, pointSize: 12)
+        } else if name == "ellipsis.vertical" {
+            image = .init(name: "ellipsis", rotationDegrees: 90, pointSize: 10.5)
+        } else {
+            image = .init(name: "questionmark.circle", rotationDegrees: 0, pointSize: 12)
+        }
+        imagesByName[name] = image
+        return image
     }
 }
 

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -218,6 +218,9 @@ enum TabItemStyling {
 
     static func resolvedFaviconImage(existing: NSImage?, incomingData: Data?) -> NSImage? {
         guard let incomingData else { return nil }
+#if DEBUG
+        BonsplitDebugCounters.recordFaviconImageDecode()
+#endif
         if let decoded = NSImage(data: incomingData) {
             // Favicon bitmaps must never be treated as template/tintable symbols.
             decoded.isTemplate = false
@@ -696,7 +699,12 @@ struct TabItemView: View {
             ? TabBarColors.nsColorActiveText(for: appearance)
             : TabBarColors.nsColorInactiveText(for: appearance)
         let iconTint = Color(nsColor: iconTintColor)
-        let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { NSImage(data: $0) }
+        let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { data in
+#if DEBUG
+            BonsplitDebugCounters.recordFaviconImageDecode()
+#endif
+            return NSImage(data: data)
+        }
 
         Group {
             if tab.isLoading {

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -699,12 +699,7 @@ struct TabItemView: View {
             ? TabBarColors.nsColorActiveText(for: appearance)
             : TabBarColors.nsColorInactiveText(for: appearance)
         let iconTint = Color(nsColor: iconTintColor)
-        let faviconImage = renderedFaviconImage ?? tab.iconImageData.flatMap { data in
-#if DEBUG
-            BonsplitDebugCounters.recordFaviconImageDecode()
-#endif
-            return NSImage(data: data)
-        }
+        let faviconImage = renderedFaviconImage
 
         Group {
             if tab.isLoading {

--- a/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
+++ b/Sources/Bonsplit/Public/BonsplitDebugCounters.swift
@@ -8,12 +8,57 @@ import Foundation
 public enum BonsplitDebugCounters {
     public private(set) static var arrangedSubviewUnderflowCount: Int = 0
 
+    struct HotPathActivity: Equatable {
+        fileprivate(set) var splitActionSystemImageLookupCount = 0
+        fileprivate(set) var tabItemTypeConstructionCount = 0
+        fileprivate(set) var tabTransferTypeConstructionCount = 0
+        fileprivate(set) var faviconImageDecodeCount = 0
+    }
+
+    private final class HotPathRecorder: NSObject {
+        var activity = HotPathActivity()
+    }
+
+    private static let hotPathRecorderKey = "com.manaflow.bonsplit.hot-path-recorder"
+
     public static func reset() {
         arrangedSubviewUnderflowCount = 0
     }
 
     internal static func recordArrangedSubviewUnderflow() {
         arrangedSubviewUnderflowCount += 1
+    }
+
+    static func measureHotPathActivity(_ body: () -> Void) -> HotPathActivity {
+        let threadDictionary = Thread.current.threadDictionary
+        precondition(threadDictionary[hotPathRecorderKey] == nil)
+
+        let recorder = HotPathRecorder()
+        threadDictionary[hotPathRecorderKey] = recorder
+        defer { threadDictionary.removeObject(forKey: hotPathRecorderKey) }
+
+        body()
+        return recorder.activity
+    }
+
+    static func recordSplitActionSystemImageLookup() {
+        currentHotPathRecorder?.activity.splitActionSystemImageLookupCount += 1
+    }
+
+    static func recordTabItemTypeConstruction() {
+        currentHotPathRecorder?.activity.tabItemTypeConstructionCount += 1
+    }
+
+    static func recordTabTransferTypeConstruction() {
+        currentHotPathRecorder?.activity.tabTransferTypeConstructionCount += 1
+    }
+
+    static func recordFaviconImageDecode() {
+        currentHotPathRecorder?.activity.faviconImageDecodeCount += 1
+    }
+
+    private static var currentHotPathRecorder: HotPathRecorder? {
+        Thread.current.threadDictionary[hotPathRecorderKey] as? HotPathRecorder
     }
 }
 #endif

--- a/Tests/BonsplitTests/HotPathCachingTests.swift
+++ b/Tests/BonsplitTests/HotPathCachingTests.swift
@@ -1,0 +1,102 @@
+import AppKit
+import SwiftUI
+import Testing
+import UniformTypeIdentifiers
+@testable import Bonsplit
+
+@Suite("Hot-path caching")
+struct HotPathCachingTests {
+    @MainActor
+    @Test("split action symbol validation runs at most once per name")
+    func splitActionSystemImageLookupIsCached() {
+        let activity = BonsplitDebugCounters.measureHotPathActivity {
+            _ = TabBarStyling.splitActionSystemImage(for: "bonsplit.missing.test.symbol")
+            _ = TabBarStyling.splitActionSystemImage(for: "bonsplit.missing.test.symbol")
+        }
+
+        #expect(activity.splitActionSystemImageLookupCount <= 1)
+    }
+
+    @Test("custom drag types are constructed at most once")
+    func customDragTypesAreStableValues() {
+        let activity = BonsplitDebugCounters.measureHotPathActivity {
+            _ = UTType.tabItem
+            _ = UTType.tabItem
+            _ = UTType.tabTransfer
+            _ = UTType.tabTransfer
+        }
+
+        #expect(activity.tabItemTypeConstructionCount <= 1)
+        #expect(activity.tabTransferTypeConstructionCount <= 1)
+    }
+
+    @MainActor
+    @Test("tab body projection does not decode favicon data")
+    func tabBodyProjectionDoesNotDecodeFaviconData() throws {
+        let faviconData = try #require(makeFaviconData())
+        let view = makeTabItemView(faviconData: faviconData)
+
+        let activity = BonsplitDebugCounters.measureHotPathActivity {
+            _ = view.body
+            _ = view.body
+        }
+
+        #expect(activity.faviconImageDecodeCount == 0)
+    }
+
+    @MainActor
+    private func makeFaviconData() -> Data? {
+        let image = NSImage(size: NSSize(width: 16, height: 16))
+        image.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSBezierPath(rect: NSRect(x: 0, y: 0, width: 16, height: 16)).fill()
+        image.unlockFocus()
+        return image.tiffRepresentation
+    }
+
+    @MainActor
+    private func makeTabItemView(faviconData: Data) -> TabItemView {
+        TabItemView(
+            tab: TabItem(title: "Browser", icon: "globe", iconImageData: faviconData),
+            isSelected: true,
+            showsZoomIndicator: false,
+            appearance: .default,
+            fillsWidth: false,
+            saturation: 1,
+            trailingSeparatorBottomInset: 0,
+            controlShortcutDigit: nil,
+            tabShortcutHintsEnabled: false,
+            isFocused: true,
+            showsControlShortcutHint: false,
+            shortcutModifierSymbol: "⌃",
+            allowsClose: true,
+            allowsContextMenu: false,
+            contextMenuState: TabContextMenuState(
+                isPinned: false,
+                isUnread: false,
+                isBrowser: true,
+                isAudioMuted: false,
+                isTerminal: false,
+                hasCustomTitle: false,
+                canCloseToLeft: false,
+                canCloseToRight: false,
+                canCloseOthers: false,
+                canMoveToNewWorkspace: false,
+                canMoveToLeftPane: false,
+                canMoveToRightPane: false,
+                forkConversationDefaultAction: .forkConversationRight,
+                isZoomed: false,
+                hasSplits: false,
+                shortcuts: [:]
+            ),
+            moveDestinationsProvider: { [] },
+            forkConversationAvailabilityProvider: { .hidden },
+            forkConversationAvailabilityRefreshHandler: {},
+            onSelect: {},
+            onClose: { _ in },
+            onZoomToggle: {},
+            onContextAction: { _ in },
+            onMoveDestination: { _ in }
+        )
+    }
+}


### PR DESCRIPTION
Caches split-action SF Symbol validation by symbol name.

Makes Bonsplit drag UTTypes stable static values and removes synchronous favicon decoding from SwiftUI body projection. Favicon data still resolves on initial appearance and data changes.

The first commit adds deterministic counters and fails all three regressions. The second commit makes the same suite green.

Tests: swift test --filter HotPathCachingTests; swift test; swift build -c release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788318822&installation_model_id=21920&pr_number=198&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F198&signature=f8c28a3ec9ddabe7b5daaa5e5d8363f4c7bf16337156d7d50d4fc2e629cfe4ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches tab rendering hot paths to reduce repeated work in the tab bar and avoid decoding favicons in the SwiftUI body. Adds debug-only counters and tests to verify these hot paths stay cold.

- **Refactors**
  - Cache split-action SF Symbol validation per name via `SplitActionSystemImageCache`.
  - Make `UTType.tabItem` and `UTType.tabTransfer` static, stable values.
  - Remove synchronous favicon decoding from `TabItemView` body; decode only on appearance or data changes.

- **New Features**
  - Add DEBUG-only hot-path activity recorder in `BonsplitDebugCounters`.
  - Add `HotPathCachingTests` to verify symbol lookup caching, stable drag types, and no favicon decode during body projection.

<sup>Written for commit 96e631d2f122bab2828211a2a1e2587e666bf316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved caching for split-action icons and favicon images, reducing repeated lookups and decoding during tab rendering.
  - Optimized custom tab transfer type initialization.

- **Testing**
  - Added coverage verifying hot-path caching and activity tracking for icons, favicons, and tab transfer types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->