### PR TITLE
Keep synthetic divider drags live

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -4,17 +4,31 @@ import AppKit
 private var splitContainerProgrammaticSyncDepth = 0
 
 enum SplitDividerMouseState {
+    private static let maximumFallbackEventAge: TimeInterval = 0.1
+
+    static func matchesWindow(eventWindow: NSWindow?, splitWindow: NSWindow?) -> Bool {
+        guard let eventWindow, let splitWindow else { return false }
+        return eventWindow === splitWindow
+    }
+
+    static func isRecent(eventTimestamp: TimeInterval?, now: TimeInterval) -> Bool {
+        guard let eventTimestamp else { return false }
+        let age = now - eventTimestamp
+        return age >= 0 && age < maximumFallbackEventAge
+    }
+
     static func isActive(
         pressedMouseButtons: Int,
         eventType: NSEvent.EventType?,
         eventMatchesWindow: Bool,
+        eventIsRecent: Bool,
         sessionIsActive: Bool
     ) -> Bool {
         if pressedMouseButtons & 1 != 0 {
             return true
         }
 
-        guard sessionIsActive, eventMatchesWindow else { return false }
+        guard sessionIsActive, eventMatchesWindow, eventIsRecent else { return false }
         return eventType == .leftMouseDown || eventType == .leftMouseDragged
     }
 }
@@ -1212,10 +1226,19 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         func splitViewWillResizeSubviews(_ notification: Notification) {
             guard let splitView = notification.object as? NSSplitView else { return }
             let currentEvent = NSApp.currentEvent
+            let now = ProcessInfo.processInfo.systemUptime
+            let eventIsRecent = SplitDividerMouseState.isRecent(
+                eventTimestamp: currentEvent?.timestamp,
+                now: now
+            )
             let leftDown = SplitDividerMouseState.isActive(
                 pressedMouseButtons: NSEvent.pressedMouseButtons,
                 eventType: currentEvent?.type,
-                eventMatchesWindow: currentEvent?.window == splitView.window,
+                eventMatchesWindow: SplitDividerMouseState.matchesWindow(
+                    eventWindow: currentEvent?.window,
+                    splitWindow: splitView.window
+                ),
+                eventIsRecent: eventIsRecent,
                 sessionIsActive: isDragging
             )
             // If the left mouse button isn't down, this can't be an interactive divider drag.
@@ -1249,10 +1272,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             // Only treat this as a divider drag if the pointer is actually on the divider.
             // This delegate callback can also fire during window resizes or structural updates,
             // and persisting divider ratios in those cases can permanently collapse a pane.
-            let now = ProcessInfo.processInfo.systemUptime
             // `NSApp.currentEvent` can be stale when called from async UI work (e.g. socket commands).
             // Only trust very recent events.
-            guard (now - event.timestamp) < 0.1 else {
+            guard eventIsRecent else {
 #if DEBUG
                 debugLogDividerDragSkip("staleCurrentEvent", splitView: splitView, event: event)
 #endif
@@ -1345,10 +1367,18 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             }
             // Prevent stale drag state from persisting through programmatic/async resizes.
             let currentEvent = NSApp.currentEvent
+            let eventIsRecent = SplitDividerMouseState.isRecent(
+                eventTimestamp: currentEvent?.timestamp,
+                now: ProcessInfo.processInfo.systemUptime
+            )
             let leftDown = SplitDividerMouseState.isActive(
                 pressedMouseButtons: NSEvent.pressedMouseButtons,
                 eventType: currentEvent?.type,
-                eventMatchesWindow: currentEvent?.window == splitView.window,
+                eventMatchesWindow: SplitDividerMouseState.matchesWindow(
+                    eventWindow: currentEvent?.window,
+                    splitWindow: splitView.window
+                ),
+                eventIsRecent: eventIsRecent,
                 sessionIsActive: isDragging
             )
             if !leftDown {

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -3,6 +3,22 @@ import AppKit
 
 private var splitContainerProgrammaticSyncDepth = 0
 
+enum SplitDividerMouseState {
+    static func isActive(
+        pressedMouseButtons: Int,
+        eventType: NSEvent.EventType?,
+        eventMatchesWindow: Bool,
+        sessionIsActive: Bool
+    ) -> Bool {
+        if pressedMouseButtons & 1 != 0 {
+            return true
+        }
+
+        guard sessionIsActive, eventMatchesWindow else { return false }
+        return eventType == .leftMouseDown || eventType == .leftMouseDragged
+    }
+}
+
 private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
     var customDividerColor: NSColor?
 
@@ -1195,11 +1211,21 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
         func splitViewWillResizeSubviews(_ notification: Notification) {
             guard let splitView = notification.object as? NSSplitView else { return }
+            let currentEvent = NSApp.currentEvent
+            let leftDown = SplitDividerMouseState.isActive(
+                pressedMouseButtons: NSEvent.pressedMouseButtons,
+                eventType: currentEvent?.type,
+                eventMatchesWindow: currentEvent?.window == splitView.window,
+                sessionIsActive: isDragging
+            )
             // If the left mouse button isn't down, this can't be an interactive divider drag.
+            // The explicit split-view mouse session also counts while a synthetic
+            // drag event is current. Accessibility drivers can deliver a valid
+            // AppKit tracking loop without updating the process-wide button mask.
             // (`splitViewWillResizeSubviews` can fire for programmatic/layout-driven resizes too.)
-            guard (NSEvent.pressedMouseButtons & 1) != 0 else {
+            guard leftDown else {
 #if DEBUG
-                if let event = NSApp.currentEvent,
+                if let event = currentEvent,
                    event.type == .leftMouseDown || event.type == .leftMouseDragged {
                     debugLogDividerDragSkip("leftMouseNotPressed", splitView: splitView, event: event)
                 }
@@ -1213,7 +1239,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 return
             }
 
-            guard let event = NSApp.currentEvent else {
+            guard let event = currentEvent else {
 #if DEBUG
                 debugLogDividerDragSkip("noCurrentEvent", splitView: splitView, event: nil)
 #endif
@@ -1318,7 +1344,13 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 return
             }
             // Prevent stale drag state from persisting through programmatic/async resizes.
-            let leftDown = (NSEvent.pressedMouseButtons & 1) != 0
+            let currentEvent = NSApp.currentEvent
+            let leftDown = SplitDividerMouseState.isActive(
+                pressedMouseButtons: NSEvent.pressedMouseButtons,
+                eventType: currentEvent?.type,
+                eventMatchesWindow: currentEvent?.window == splitView.window,
+                sessionIsActive: isDragging
+            )
             if !leftDown {
 #if DEBUG
                 if isDragging {
@@ -1362,7 +1394,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 
                 // Check if drag ended (mouse up)
                 let wasDragging = isDragging && leftDown
-                if let event = NSApp.currentEvent, event.type == .leftMouseUp {
+                if let event = currentEvent, event.type == .leftMouseUp {
 #if DEBUG
                     dlog("divider.dragEnd split=\(splitState.id.uuidString.prefix(5))")
 #endif

--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -33,6 +33,24 @@ enum SplitDividerMouseState {
     }
 }
 
+struct SplitDividerDragState {
+    private(set) var sessionIsActive = false
+    private(set) var resizeIsActive = false
+
+    mutating func sessionChanged(_ active: Bool) {
+        sessionIsActive = active
+        resizeIsActive = active
+    }
+
+    mutating func acceptCurrentResize() {
+        resizeIsActive = true
+    }
+
+    mutating func rejectCurrentResize() {
+        resizeIsActive = false
+    }
+}
+
 private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
     var customDividerColor: NSColor?
 
@@ -316,7 +334,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             (internalController?.activeDividerDragSessions ?? 0) > 0
         }
         splitView.onDividerDragSession = { [weak coordinator = context.coordinator, weak internalController] active in
-            // The coordinator arms isDragging at begin, before any delegate
+            // The coordinator arms its drag state at begin, before any delegate
             // reacts to the session. At end the counter's zero crossing
             // delivers the final geometry notification — forced past the
             // external-update suppression window — before the delegate hears
@@ -757,8 +775,9 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
         weak var imposedRetrySplitView: NSSplitView?
         // Guard programmatic `setPosition` re-entrancy from resize callbacks.
         var isSyncingProgrammatically = false
-        /// Track if user is actively dragging the divider
-        var isDragging = false
+        /// Keep the mouse-down-bracketed session separate from whether the
+        /// current resize callback is accepted as part of that session.
+        var dividerDragState = SplitDividerDragState()
         /// Track child node types to detect structural changes
         var firstNodeType: SplitNode.NodeType
         var secondNodeType: SplitNode.NodeType
@@ -809,7 +828,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 didApplyInitialDividerPosition = false
                 initialDividerApplyAttempts = 0
                 isAnimating = false
-                isDragging = false
+                dividerDragState = SplitDividerDragState()
                 firstNodeType = newState.first.nodeType
                 secondNodeType = newState.second.nodeType
                 return
@@ -832,7 +851,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 #if DEBUG
             dlog("divider.session split=\(String(splitState.id.uuidString.prefix(5))) \(active ? "begin" : "end")")
 #endif
-            isDragging = active
+            dividerDragState.sessionChanged(active)
         }
 
         private func splitTotalSize(in splitView: NSSplitView) -> CGFloat {
@@ -1239,7 +1258,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     splitWindow: splitView.window
                 ),
                 eventIsRecent: eventIsRecent,
-                sessionIsActive: isDragging
+                sessionIsActive: dividerDragState.sessionIsActive
             )
             // If the left mouse button isn't down, this can't be an interactive divider drag.
             // The explicit split-view mouse session also counts while a synthetic
@@ -1253,12 +1272,19 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     debugLogDividerDragSkip("leftMouseNotPressed", splitView: splitView, event: event)
                 }
 #endif
-                isDragging = false
+                dividerDragState.rejectCurrentResize()
                 return
             }
 
-            // If we're already tracking an active drag, keep the flag until mouse-up.
-            if isDragging {
+            // A fresh same-window event can resume a synthetic drag after one
+            // stale callback was rejected without discarding the outer mouse session.
+            if dividerDragState.sessionIsActive {
+                dividerDragState.acceptCurrentResize()
+                return
+            }
+
+            // If we're already tracking an inferred drag, keep it until mouse-up.
+            if dividerDragState.resizeIsActive {
                 return
             }
 
@@ -1286,7 +1312,10 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 #endif
                 return
             }
-            guard event.window == splitView.window else {
+            guard SplitDividerMouseState.matchesWindow(
+                eventWindow: event.window,
+                splitWindow: splitView.window
+            ) else {
 #if DEBUG
                 debugLogDividerDragSkip("windowMismatch", splitView: splitView, event: event)
 #endif
@@ -1332,7 +1361,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
             let expansion = Self.dividerHitExpansion(for: splitView)
             let hitRect = dividerRect.insetBy(dx: -expansion, dy: -expansion)
             if dividerHitRectContains(location, rect: hitRect) {
-                isDragging = true
+                dividerDragState.acceptCurrentResize()
 #if DEBUG
                 dlog(
                     "divider.dragStart split=\(splitState.id.uuidString.prefix(5)) loc=\(debugPointString(location)) divider=\(debugRectString(dividerRect)) hit=\(debugRectString(hitRect))"
@@ -1379,15 +1408,15 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                     splitWindow: splitView.window
                 ),
                 eventIsRecent: eventIsRecent,
-                sessionIsActive: isDragging
+                sessionIsActive: dividerDragState.sessionIsActive
             )
             if !leftDown {
 #if DEBUG
-                if isDragging {
+                if dividerDragState.resizeIsActive {
                     dlog("divider.dragStateReset split=\(splitState.id.uuidString.prefix(5)) reason=leftMouseReleased")
                 }
 #endif
-                isDragging = false
+                dividerDragState.rejectCurrentResize()
             }
             // During structural updates (pane↔split), arranged subviews can be temporarily removed.
             // Avoid persisting a dividerPosition derived from a transient 1-subview layout.
@@ -1423,12 +1452,12 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
                 }
 
                 // Check if drag ended (mouse up)
-                let wasDragging = isDragging && leftDown
+                let wasDragging = dividerDragState.resizeIsActive && leftDown
                 if let event = currentEvent, event.type == .leftMouseUp {
 #if DEBUG
                     dlog("divider.dragEnd split=\(splitState.id.uuidString.prefix(5))")
 #endif
-                    isDragging = false
+                    dividerDragState.rejectCurrentResize()
                 }
 
                 // Only update the model when the user is actively dragging. For other resizes
@@ -1438,7 +1467,7 @@ struct SplitContainerView<Content: View, EmptyContent: View>: NSViewRepresentabl
 #if DEBUG
                     let eventType = NSApp.currentEvent.map { String(describing: $0.type) } ?? "none"
                     dlog(
-                        "divider.resizeIgnored split=\(splitState.id.uuidString.prefix(5)) eventType=\(eventType) leftDown=\(leftDown ? 1 : 0) isDragging=\(isDragging ? 1 : 0) normalized=\(String(format: "%.3f", normalizedPosition)) model=\(String(format: "%.3f", self.splitState.dividerPosition))"
+                        "divider.resizeIgnored split=\(splitState.id.uuidString.prefix(5)) eventType=\(eventType) leftDown=\(leftDown ? 1 : 0) isDragging=\(dividerDragState.resizeIsActive ? 1 : 0) normalized=\(String(format: "%.3f", normalizedPosition)) model=\(String(format: "%.3f", self.splitState.dividerPosition))"
                     )
 #endif
                     // A split the user positions by fraction puts its divider

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3826,35 +3826,63 @@ final class BonsplitTests: XCTestCase {
     /// imposed extent arriving mid-session must not move it. The imposition
     /// stays armed instead, and the session's end applies it with no fresh
     /// impose call from the host.
+    @MainActor
     func testActiveDividerSessionAcceptsSyntheticDragWithoutGlobalButtonState() {
+        let splitWindow = NSWindow()
+        let otherWindow = NSWindow()
+        XCTAssertTrue(SplitDividerMouseState.matchesWindow(
+            eventWindow: splitWindow,
+            splitWindow: splitWindow
+        ))
+        XCTAssertFalse(SplitDividerMouseState.matchesWindow(
+            eventWindow: nil,
+            splitWindow: nil
+        ))
+        XCTAssertFalse(SplitDividerMouseState.matchesWindow(
+            eventWindow: otherWindow,
+            splitWindow: splitWindow
+        ))
+
         XCTAssertTrue(SplitDividerMouseState.isActive(
             pressedMouseButtons: 0,
             eventType: .leftMouseDragged,
             eventMatchesWindow: true,
+            eventIsRecent: true,
             sessionIsActive: true
         ))
         XCTAssertTrue(SplitDividerMouseState.isActive(
             pressedMouseButtons: 1,
             eventType: nil,
             eventMatchesWindow: false,
+            eventIsRecent: false,
             sessionIsActive: false
         ))
         XCTAssertFalse(SplitDividerMouseState.isActive(
             pressedMouseButtons: 0,
             eventType: .leftMouseDragged,
             eventMatchesWindow: true,
+            eventIsRecent: true,
             sessionIsActive: false
         ))
         XCTAssertFalse(SplitDividerMouseState.isActive(
             pressedMouseButtons: 0,
             eventType: .leftMouseDragged,
             eventMatchesWindow: false,
+            eventIsRecent: true,
             sessionIsActive: true
         ))
         XCTAssertFalse(SplitDividerMouseState.isActive(
             pressedMouseButtons: 0,
             eventType: .leftMouseUp,
             eventMatchesWindow: true,
+            eventIsRecent: true,
+            sessionIsActive: true
+        ))
+        XCTAssertFalse(SplitDividerMouseState.isActive(
+            pressedMouseButtons: 0,
+            eventType: .leftMouseDragged,
+            eventMatchesWindow: true,
+            eventIsRecent: false,
             sessionIsActive: true
         ))
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3887,6 +3887,26 @@ final class BonsplitTests: XCTestCase {
         ))
     }
 
+    func testRejectedSyntheticResizeCanRecoverWithinSameDividerSession() {
+        var state = SplitDividerDragState()
+
+        state.sessionChanged(true)
+        XCTAssertTrue(state.sessionIsActive)
+        XCTAssertTrue(state.resizeIsActive)
+
+        state.rejectCurrentResize()
+        XCTAssertTrue(state.sessionIsActive)
+        XCTAssertFalse(state.resizeIsActive)
+
+        state.acceptCurrentResize()
+        XCTAssertTrue(state.sessionIsActive)
+        XCTAssertTrue(state.resizeIsActive)
+
+        state.sessionChanged(false)
+        XCTAssertFalse(state.sessionIsActive)
+        XCTAssertFalse(state.resizeIsActive)
+    }
+
     @MainActor
     func testImposeDuringDragSessionDefersUntilSessionEnds() throws {
         var configuration = BonsplitConfiguration()

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -3826,6 +3826,39 @@ final class BonsplitTests: XCTestCase {
     /// imposed extent arriving mid-session must not move it. The imposition
     /// stays armed instead, and the session's end applies it with no fresh
     /// impose call from the host.
+    func testActiveDividerSessionAcceptsSyntheticDragWithoutGlobalButtonState() {
+        XCTAssertTrue(SplitDividerMouseState.isActive(
+            pressedMouseButtons: 0,
+            eventType: .leftMouseDragged,
+            eventMatchesWindow: true,
+            sessionIsActive: true
+        ))
+        XCTAssertTrue(SplitDividerMouseState.isActive(
+            pressedMouseButtons: 1,
+            eventType: nil,
+            eventMatchesWindow: false,
+            sessionIsActive: false
+        ))
+        XCTAssertFalse(SplitDividerMouseState.isActive(
+            pressedMouseButtons: 0,
+            eventType: .leftMouseDragged,
+            eventMatchesWindow: true,
+            sessionIsActive: false
+        ))
+        XCTAssertFalse(SplitDividerMouseState.isActive(
+            pressedMouseButtons: 0,
+            eventType: .leftMouseDragged,
+            eventMatchesWindow: false,
+            sessionIsActive: true
+        ))
+        XCTAssertFalse(SplitDividerMouseState.isActive(
+            pressedMouseButtons: 0,
+            eventType: .leftMouseUp,
+            eventMatchesWindow: true,
+            sessionIsActive: true
+        ))
+    }
+
     @MainActor
     func testImposeDuringDragSessionDefersUntilSessionEnds() throws {
         var configuration = BonsplitConfiguration()


### PR DESCRIPTION
Computer Use can deliver a valid `leftMouseDragged` event inside `NSSplitView`'s tracking session without updating `NSEvent.pressedMouseButtons`. Bonsplit then treated the resize as programmatic and restored the old ratio, producing a visible snap-back.

Use the explicit divider session as the fallback authority only for same-window left-down/left-drag events. The global mouse-button path remains unchanged.

Validation:
- failing regression test committed before the fix
- `swift test` (206 passed)
- autoreview clean at 0.90 confidence
- tagged `apipc` final-head rebuild succeeded; final Computer Use retest pending screen unlock

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788356496&installation_model_id=21920&pr_number=200&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F200&signature=96d15eb7e83b074a200dd6504183da31b545680900e0d5d68d186eb4d2f3ac9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes split-divider snap-back during synthetic drags by honoring active `NSSplitView` drag sessions even when `NSEvent.pressedMouseButtons` is 0, and by rejecting stale events without ending the session. This keeps live resizing reliable for accessibility and automation drivers.

- **Bug Fixes**
  - Added `SplitDividerMouseState` to validate same-window, recent events (≤100ms) and derive active left-down state; accepts session-backed `.leftMouseDown`/`.leftMouseDragged` with global button mask 0.
  - Replaced `isDragging` with `SplitDividerDragState` to separate session and resize state; stale callbacks now reject the resize but preserve the session, allowing recovery within the same drag.
  - Updated resize handlers to use the cached current event and clear stale drag state; global mouse-button path unchanged. Added tests for stale-event rejection and session recovery.

<sup>Written for commit f8a37e7079f0ec86d62e1b56d96e040389ba1a22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split-divider resizing during mouse and accessibility drag interactions.
  * Prevented incorrect resize handling when events are mismatched or a drag session has ended.

* **Tests**
  * Added coverage for real and synthetic divider-drag scenarios, including active and completed sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
