### PR TITLE
Bind tab hit testing to the main actor

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -47,6 +47,7 @@ public enum BonsplitTabBarHitRegionRegistry {
     }
 }
 
+@MainActor
 public protocol BonsplitTabItemHitRegionProviding: AnyObject {
     func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool
 }
@@ -83,6 +84,7 @@ public enum BonsplitTabItemHitRegionRegistry {
         return true
     }
 
+    @MainActor
     public static func containsWindowPoint(_ windowPoint: CGPoint, in window: NSWindow) -> Bool {
         for view in snapshot() {
             guard view.window === window,
@@ -2308,7 +2310,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
 
     final class TabBarBackgroundNSView: NSView, BonsplitTabItemHitRegionProviding {
         var isMinimalMode = false
-        nonisolated(unsafe) var tabIds: [UUID] = []
+        var tabIds: [UUID] = []
         weak var geometryRegistry: TabBarItemGeometryRegistry?
         var onDoubleClick: (() -> Bool)?
         var onHoverChanged: ((Bool) -> Void)?
@@ -2353,15 +2355,13 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             }
         }
 
-        nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
-            MainActor.assumeIsolated {
-                let frames = geometryRegistry?.frames(for: tabIds, in: self).values.map { $0 } ?? []
-                return BonsplitTabItemHitTesting.containsTabLaneHit(
-                    localPoint: localPoint,
-                    tabFrames: frames,
-                    bounds: bounds
-                )
-            }
+        func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
+            let frames = geometryRegistry?.frames(for: tabIds, in: self).values.map { $0 } ?? []
+            return BonsplitTabItemHitTesting.containsTabLaneHit(
+                localPoint: localPoint,
+                tabFrames: frames,
+                bounds: bounds
+            )
         }
 
         override func updateTrackingAreas() {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1000,6 +1000,29 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
+    func testTabItemHitProviderUsesStaticMainActorIsolation() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURL = repositoryRoot
+            .appendingPathComponent("Sources/Bonsplit/Internal/Views/TabBarView.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("@MainActor\npublic protocol BonsplitTabItemHitRegionProviding"),
+            "AppKit hit providers must use static UI isolation instead of a runtime executor assumption"
+        )
+        XCTAssertFalse(
+            source.contains("nonisolated func containsBonsplitTabItemHit"),
+            "Hit testing must not cross out of the main actor"
+        )
+        XCTAssertFalse(
+            source.contains("MainActor.assumeIsolated"),
+            "AppKit hit testing must not enter Swift's dynamic main-executor check"
+        )
+    }
+
     @MainActor
     func testTabItemHitRegionRegistryIgnoresHiddenProviders() {
         let window = NSWindow(

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -37,7 +37,7 @@ final class BonsplitTests: XCTestCase {
 
     @MainActor
     private final class FakeTabItemHitRegionView: NSView, BonsplitTabItemHitRegionProviding {
-        nonisolated(unsafe) var tabFrames: [CGRect] = []
+        var tabFrames: [CGRect] = []
 
         deinit {
             BonsplitTabItemHitRegionRegistry.unregister(self)
@@ -58,7 +58,7 @@ final class BonsplitTests: XCTestCase {
             }
         }
 
-        nonisolated func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
+        func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
             tabFrames.contains { $0.contains(localPoint) }
         }
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -13,6 +13,10 @@ private final class DropZoneModel {
 }
 
 final class BonsplitTests: XCTestCase {
+    private struct CallbackSendableBox<Value>: @unchecked Sendable {
+        let value: Value
+    }
+
     @MainActor
     private final class FakeTabBarHitRegionView: NSView {
         deinit {
@@ -60,6 +64,13 @@ final class BonsplitTests: XCTestCase {
 
         func containsBonsplitTabItemHit(localPoint: NSPoint) -> Bool {
             tabFrames.contains { $0.contains(localPoint) }
+        }
+    }
+
+    @MainActor
+    private final class MainActorHitRegionProbe: NSObject, BonsplitTabItemHitRegionProviding {
+        func containsBonsplitTabItemHit(localPoint _: NSPoint) -> Bool {
+            Thread.isMainThread
         }
     }
 
@@ -1000,26 +1011,19 @@ final class BonsplitTests: XCTestCase {
         )
     }
 
-    func testTabItemHitProviderUsesStaticMainActorIsolation() throws {
-        let repositoryRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let sourceURL = repositoryRoot
-            .appendingPathComponent("Sources/Bonsplit/Internal/Views/TabBarView.swift")
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+    func testTabItemHitProviderHopsToMainActor() async {
+        let callbackBox = await MainActor.run {
+            let provider: any BonsplitTabItemHitRegionProviding = MainActorHitRegionProbe()
+            return CallbackSendableBox(value: provider.containsBonsplitTabItemHit)
+        }
+
+        let ranOnMainThread = await Task.detached {
+            await callbackBox.value(.zero)
+        }.value
 
         XCTAssertTrue(
-            source.contains("@MainActor\npublic protocol BonsplitTabItemHitRegionProviding"),
-            "AppKit hit providers must use static UI isolation instead of a runtime executor assumption"
-        )
-        XCTAssertFalse(
-            source.contains("nonisolated func containsBonsplitTabItemHit"),
-            "Hit testing must not cross out of the main actor"
-        )
-        XCTAssertFalse(
-            source.contains("MainActor.assumeIsolated"),
-            "AppKit hit testing must not enter Swift's dynamic main-executor check"
+            ranOnMainThread,
+            "The protocol callback must preserve main-actor isolation when it escapes"
         )
     }
 


### PR DESCRIPTION
Fixes the executor-boundary crash recorded by https://manaflow.sentry.io/issues/7612222120/.

The AppKit hit-test provider is now statically main-actor isolated, so pointer dispatch no longer enters `MainActor.assumeIsolated` and its runtime executor check.

Regression proof:
- test-only commit `ea0374e` fails all three actor-boundary assertions
- fix commit `c629f28` passes the focused test
- `swift test`: 205 XCTest tests and 3 Swift Testing tests pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788378608&installation_model_id=21920&pr_number=201&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F201&signature=ff672fc061961439d07723d4bfe9c671410f189f0b1259218037548e5a3183a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind tab bar hit testing to the main actor to stop the AppKit hit-test executor crash. Pointer dispatch now stays on the UI thread and avoids runtime executor checks. Fixes https://manaflow.sentry.io/issues/7612222120/.

- **Bug Fixes**
  - Marked `BonsplitTabItemHitRegionProviding` and `containsWindowPoint` as `@MainActor`; removed `nonisolated` and `MainActor.assumeIsolated`.
  - Updated `TabBarBackgroundNSView` and test providers to keep state and hit testing on the main actor.
  - Added a test that invokes the hit-test callback from a detached task to verify it hops back to the main actor.

<sup>Written for commit 691c67c9147a0308837e9861d8c4c58331d636bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

