### PR TITLE
Make tab drag teardown authoritative

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -8,29 +8,30 @@ extension SplitViewController {
 #if DEBUG
         dlog("tab.dragStart pane=\(paneId.id.uuidString.prefix(5)) tab=\(tab.id.uuidString.prefix(5)) title=\"\(tab.title)\"")
 #endif
+        clearTabDragState()
         dragGeneration += 1
-        draggingTab = tab
-        dragSourcePaneId = paneId
-        activeDragTab = tab
-        activeDragSourcePaneId = paneId
+        let session = TabDragSession(tab: tab, sourcePaneId: paneId, generation: dragGeneration)
+        tabDragSession = session
+        let monitor = TabDragLifecycleMonitor(generation: session.generation) { [weak self] generation in
+            self?.cancelTabDragIfGenerationMatches(generation)
+        }
+        tabDragLifecycleMonitor = monitor
+        monitor.start()
         return dragGeneration
     }
 
     func clearTabDragState() {
-        draggingTab = nil
-        dragSourcePaneId = nil
-        activeDragTab = nil
-        activeDragSourcePaneId = nil
+        tabDragLifecycleMonitor?.stop()
+        tabDragLifecycleMonitor = nil
+        tabDragSession = nil
     }
 
     func cancelTabDragIfGenerationMatches(_ generation: Int) {
-        guard dragGeneration == generation else { return }
-        if draggingTab != nil || activeDragTab != nil {
+        guard tabDragSession?.generation == generation else { return }
 #if DEBUG
-            dlog("tab.dragCancel (stale draggingTab cleared)")
+        dlog("tab.dragCancel (stale tabDragSession cleared)")
 #endif
-            clearTabDragState()
-        }
+        clearTabDragState()
     }
 
     func makeTabDragItemProvider(
@@ -42,8 +43,7 @@ extension SplitViewController {
         NSLog("[Bonsplit Drag] createItemProvider for tab: \(tab.title)")
 #endif
         clearDropState()
-        let dragGeneration = beginTabDrag(tab, from: paneId)
-        installCancelledTabDragCleanup(forGeneration: dragGeneration)
+        _ = beginTabDrag(tab, from: paneId)
 
         let transfer = TabTransferData(tab: tab, sourcePaneId: paneId.id)
         if let data = try? JSONEncoder().encode(transfer) {
@@ -66,19 +66,4 @@ extension SplitViewController {
         return NSItemProvider()
     }
 
-    private func installCancelledTabDragCleanup(forGeneration generation: Int) {
-        var monitorRef: Any?
-        monitorRef = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
-            // One-shot: remove ourselves AND nil the capture box, or the cycle
-            // monitor -> closure -> box -> monitor leaks one monitor per drag.
-            if let m = monitorRef {
-                NSEvent.removeMonitor(m)
-                monitorRef = nil
-            }
-            DispatchQueue.main.async {
-                self?.cancelTabDragIfGenerationMatches(generation)
-            }
-            return event
-        }
-    }
 }

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -22,22 +22,16 @@ final class SplitViewController {
     /// Currently focused pane ID
     var focusedPaneId: PaneID?
 
-    /// Tab currently being dragged (for visual feedback and hit-testing).
-    /// This is @Observable so SwiftUI views react (e.g. allowsHitTesting).
-    var draggingTab: TabItem?
+    /// The only tab-drag state. SwiftUI observes this for visual feedback and
+    /// hit-testing while drop delegates read the same value synchronously.
+    var tabDragSession: TabDragSession?
 
-    /// Monotonic counter incremented on each drag start. Used to invalidate stale
-    /// timeout timers that would otherwise cancel a new drag of the same tab.
+    /// Monotonic counter incremented on each drag start. The current value is
+    /// copied into ``tabDragSession`` to invalidate stale lifecycle callbacks.
     var dragGeneration: Int = 0
 
-    /// Source pane of the dragging tab
-    var dragSourcePaneId: PaneID?
-
-    /// Non-observable drag session state. Drop delegates read these instead of the
-    /// @Observable properties above, because SwiftUI batches observable updates and
-    /// createItemProvider's writes may not be visible to validateDrop/performDrop yet.
-    @ObservationIgnored var activeDragTab: TabItem?
-    @ObservationIgnored var activeDragSourcePaneId: PaneID?
+    /// Controller-owned ground-truth cleanup for cancelled drags.
+    @ObservationIgnored var tabDragLifecycleMonitor: TabDragLifecycleMonitor?
 
     /// When false, drop delegates reject all drags and NSViews are hidden.
     /// Mirrors BonsplitController.isInteractive. Must be observable so

--- a/Sources/Bonsplit/Internal/Controllers/TabDragLifecycleMonitor.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragLifecycleMonitor.swift
@@ -1,0 +1,75 @@
+import AppKit
+
+/// Ground-truth exits for a tab drag that never reaches a SwiftUI drop callback.
+/// Event callbacks enqueue cancellation after returning so AppKit can finish
+/// delivering a real drop first; the session generation rejects stale callbacks.
+@MainActor
+final class TabDragLifecycleMonitor {
+    private static let escapeKeyCode: UInt16 = 53
+
+    private let generation: Int
+    private let onRequestEnd: @MainActor (Int) -> Void
+    private var appResignObserver: (any NSObjectProtocol)?
+    private var keyDownMonitor: Any?
+    private var localMouseUpMonitor: Any?
+    private var globalMouseUpMonitor: Any?
+    private var endRequested = false
+    private var isStopped = false
+
+    init(generation: Int, onRequestEnd: @escaping @MainActor (Int) -> Void) {
+        self.generation = generation
+        self.onRequestEnd = onRequestEnd
+    }
+
+    func start() {
+        appResignObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.requestEnd()
+        }
+        keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == Self.escapeKeyCode {
+                self?.requestEnd()
+            }
+            return event
+        }
+        localMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+            self?.requestEnd()
+            return event
+        }
+        globalMouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { [weak self] _ in
+            self?.requestEnd()
+        }
+    }
+
+    func stop() {
+        guard !isStopped else { return }
+        isStopped = true
+        if let appResignObserver {
+            NotificationCenter.default.removeObserver(appResignObserver)
+            self.appResignObserver = nil
+        }
+        if let keyDownMonitor {
+            NSEvent.removeMonitor(keyDownMonitor)
+            self.keyDownMonitor = nil
+        }
+        if let localMouseUpMonitor {
+            NSEvent.removeMonitor(localMouseUpMonitor)
+            self.localMouseUpMonitor = nil
+        }
+        if let globalMouseUpMonitor {
+            NSEvent.removeMonitor(globalMouseUpMonitor)
+            self.globalMouseUpMonitor = nil
+        }
+    }
+
+    private nonisolated func requestEnd() {
+        Task { @MainActor [weak self] in
+            guard let self, !self.isStopped, !self.endRequested else { return }
+            self.endRequested = true
+            self.onRequestEnd(self.generation)
+        }
+    }
+}

--- a/Sources/Bonsplit/Internal/Controllers/TabDragSession.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSession.swift
@@ -1,0 +1,8 @@
+/// The single in-memory identity of a tab drag owned by a split controller.
+/// Keeping the tab, source pane, and generation together prevents observable
+/// and drop-routing state from getting out of phase.
+struct TabDragSession {
+    let tab: TabItem
+    let sourcePaneId: PaneID
+    let generation: Int
+}

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -165,7 +165,7 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
     }
 
     private var isTabDragActive: Bool {
-        controller.draggingTab != nil || controller.activeDragTab != nil
+        controller.tabDragSession != nil
     }
 
     var body: some View {
@@ -183,12 +183,11 @@ struct PaneContainerView<Content: View, EmptyContent: View>: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
-        .onChange(of: controller.draggingTab) { _, newValue in
+        .onChange(of: controller.tabDragSession?.generation) { _, newValue in
 #if DEBUG
             dlog(
                 "pane.dragState pane=\(pane.id.id.uuidString.prefix(5)) " +
-                "draggingTab=\(newValue != nil ? 1 : 0) " +
-                "activeDragTab=\(controller.activeDragTab != nil ? 1 : 0) " +
+                "tabDragSession=\(newValue != nil ? 1 : 0) " +
                 "dropHit=\(isTabDragActive ? 1 : 0)"
             )
 #endif
@@ -356,13 +355,12 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         guard !shouldHandleFileDrop(info, zone: defaultZone) else {
             return defaultZone
         }
-        guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
-              let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
+        guard let dragSession = controller.tabDragSession else {
             return defaultZone
         }
         guard let adjacentPaneMoveZone = adjacentPaneMoveZone(
-            for: draggedTab,
-            sourcePaneId: sourcePaneId,
+            for: dragSession.tab,
+            sourcePaneId: dragSession.sourcePaneId,
             defaultZone: defaultZone
         ) else {
             return defaultZone
@@ -403,9 +401,8 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 #if DEBUG
         dlog(
             "pane.drop pane=\(pane.id.id.uuidString.prefix(5)) zone=\(zone) " +
-            "source=\(controller.dragSourcePaneId?.id.uuidString.prefix(5) ?? "nil") " +
-            "hasDrag=\(controller.draggingTab != nil ? 1 : 0) " +
-            "hasActive=\(controller.activeDragTab != nil ? 1 : 0)"
+            "source=\(controller.tabDragSession?.sourcePaneId.id.uuidString.prefix(5) ?? "nil") " +
+            "hasDrag=\(controller.tabDragSession != nil ? 1 : 0)"
         )
 #endif
 
@@ -429,22 +426,19 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         }
         guard !hasTabTransfer || tabTransferPermitted else { return false }
 
-        // Read from non-observable drag state. @Observable writes from createItemProvider
-        // may not have propagated yet when performDrop runs.
+        // Read the controller's single drag session synchronously; SwiftUI view
+        // invalidation may be deferred, but the model write is immediately visible.
         if Self.shouldUseLocalTabDrag(
             hasTabTransfer: hasTabTransfer,
             hasFileURL: hasFileURL,
-            hasLocalTabDrag: controller.activeDragTab != nil || controller.draggingTab != nil
+            hasLocalTabDrag: controller.tabDragSession != nil
         ),
-           let draggedTab = controller.activeDragTab ?? controller.draggingTab,
-           let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId {
-            // Clear both observable and non-observable drag state.
+           let dragSession = controller.tabDragSession {
+            let draggedTab = dragSession.tab
+            let sourcePaneId = dragSession.sourcePaneId
             dropLifecycle = .idle
             activeDropZone = nil
-            controller.draggingTab = nil
-            controller.dragSourcePaneId = nil
-            controller.activeDragTab = nil
-            controller.activeDragSourcePaneId = nil
+            controller.clearTabDragState()
 
             if zone == .center {
                 if sourcePaneId != pane.id {
@@ -518,8 +512,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 #if DEBUG
         dlog(
             "pane.dropEntered pane=\(pane.id.id.uuidString.prefix(5)) zone=\(zone) " +
-            "hasDrag=\(controller.draggingTab != nil ? 1 : 0) " +
-            "hasActive=\(controller.activeDragTab != nil ? 1 : 0)"
+            "hasDrag=\(controller.tabDragSession != nil ? 1 : 0)"
         )
 #endif
     }
@@ -592,7 +585,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             }
         } else if !tabTransferPermitted {
             return false
-        } else if controller.activeDragTab != nil || controller.draggingTab != nil {
+        } else if controller.tabDragSession != nil {
             // Local tab drags use in-memory state and are always same-process.
             return true
         } else if hasTabTransfer {
@@ -603,12 +596,11 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             }
         }
 #if DEBUG
-        let hasDrag = controller.draggingTab != nil
-        let hasActive = controller.activeDragTab != nil
+        let hasDrag = controller.tabDragSession != nil
         dlog(
             "pane.validateDrop pane=\(pane.id.id.uuidString.prefix(5)) " +
             "hasTab=\(hasTabTransfer ? 1 : 0) hasFile=\(hasFileURL ? 1 : 0) " +
-            "hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
+            "hasDrag=\(hasDrag ? 1 : 0)"
         )
 #endif
         return true
@@ -677,7 +669,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 
     private func permitsTabTransfer(hasTabTransfer: Bool, zone: DropZone) -> Bool {
         guard hasTabTransfer else { return false }
-        let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId
+        let sourcePaneId = controller.tabDragSession?.sourcePaneId
         if zone == .center, sourcePaneId == pane.id {
             return true
         }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -828,7 +828,7 @@ struct TabBarView: View {
 
     /// Whether this tab bar should show full saturation (focused or drag source)
     private var shouldShowFullSaturation: Bool {
-        isFocused || splitViewController.dragSourcePaneId == pane.id
+        isFocused || splitViewController.tabDragSession?.sourcePaneId == pane.id
     }
 
     private var tabBarSaturation: Double {
@@ -1158,12 +1158,11 @@ struct TabBarView: View {
             }
         }
         // Clear drop state when drag ends elsewhere (cancelled, dropped in another pane, etc.)
-        .onChange(of: splitViewController.draggingTab) { _, newValue in
+        .onChange(of: splitViewController.tabDragSession?.generation) { _, newValue in
 #if DEBUG
             dlog(
                 "tab.dragState pane=\(pane.id.id.uuidString.prefix(5)) " +
-                "draggingTab=\(newValue != nil ? 1 : 0) " +
-                "activeDragTab=\(splitViewController.activeDragTab != nil ? 1 : 0)"
+                "tabDragSession=\(newValue != nil ? 1 : 0)"
             )
 #endif
             if newValue == nil {
@@ -2913,10 +2912,9 @@ struct TabDropDelegate: DropDelegate {
             }
         }
 
-        // Read from non-observable drag state — @Observable writes from createItemProvider
-        // may not have propagated yet when performDrop runs.
-        guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
-              let sourcePaneId = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId else {
+        // Read the controller's single drag session synchronously; SwiftUI view
+        // invalidation may be deferred, but the model write is immediately visible.
+        guard let dragSession = controller.tabDragSession else {
             if let transfer = decodeTransfer(from: info) {
                 if transfer.isFromCurrentProcess {
                     return performSameProcessTransfer(transfer)
@@ -2926,6 +2924,8 @@ struct TabDropDelegate: DropDelegate {
             return performFileDrop(info: info)
         }
 
+        let draggedTab = dragSession.tab
+        let sourcePaneId = dragSession.sourcePaneId
         if sourcePaneId == pane.id {
             guard bonsplitController.configuration.allowTabReordering else { return false }
         } else {
@@ -2959,8 +2959,7 @@ struct TabDropDelegate: DropDelegate {
         NSLog("[Bonsplit Drag] dropEntered at index: \(targetIndex)")
         dlog(
             "tab.dropEntered pane=\(pane.id.id.uuidString.prefix(5)) targetIndex=\(targetIndex) " +
-            "hasDrag=\(controller.draggingTab != nil ? 1 : 0) " +
-            "hasActive=\(controller.activeDragTab != nil ? 1 : 0)"
+            "hasDrag=\(controller.tabDragSession != nil ? 1 : 0)"
         )
         #endif
         dropLifecycle = .hovering
@@ -3015,8 +3014,8 @@ struct TabDropDelegate: DropDelegate {
         }
 
         // Local drags use in-memory state and are always same-process.
-        if controller.activeDragTab != nil || controller.draggingTab != nil {
-            let sourcePaneID = controller.activeDragSourcePaneId ?? controller.dragSourcePaneId
+        if let dragSession = controller.tabDragSession {
+            let sourcePaneID = dragSession.sourcePaneId
             if sourcePaneID == pane.id {
                 return bonsplitController.configuration.allowTabReordering
             }
@@ -3036,11 +3035,10 @@ struct TabDropDelegate: DropDelegate {
             guard bonsplitController.configuration.allowCrossPaneTabMove else { return false }
         }
 #if DEBUG
-        let hasDrag = controller.draggingTab != nil
-        let hasActive = controller.activeDragTab != nil
+        let hasDrag = controller.tabDragSession != nil
         dlog(
             "tab.validateDrop pane=\(pane.id.id.uuidString.prefix(5)) " +
-            "allowed=\(hasTabTransfer ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0) hasActive=\(hasActive ? 1 : 0)"
+            "allowed=\(hasTabTransfer ? 1 : 0) hasDrag=\(hasDrag ? 1 : 0)"
         )
 #endif
         return true
@@ -3052,10 +3050,7 @@ struct TabDropDelegate: DropDelegate {
     }
 
     private func clearControllerDragState() {
-        controller.draggingTab = nil
-        controller.dragSourcePaneId = nil
-        controller.activeDragTab = nil
-        controller.activeDragSourcePaneId = nil
+        controller.clearTabDragState()
     }
 
     static func samePaneDropTarget(sourceIndex: Int, targetIndex: Int) -> Int? {
@@ -3196,11 +3191,11 @@ struct TabDropDelegate: DropDelegate {
     }
 
     private func samePaneLocalDragSourceIndex() -> Int? {
-        guard let draggedTab = controller.activeDragTab ?? controller.draggingTab,
-              (controller.activeDragSourcePaneId ?? controller.dragSourcePaneId) == pane.id else {
+        guard let dragSession = controller.tabDragSession,
+              dragSession.sourcePaneId == pane.id else {
             return nil
         }
-        return pane.tabs.firstIndex(where: { $0.id == draggedTab.id })
+        return pane.tabs.firstIndex(where: { $0.id == dragSession.tab.id })
     }
 
     private func shouldSuppressIndicatorForNoopSamePaneDrop() -> Bool {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1741,6 +1741,33 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testAppResignClearsTabDragLifecycle() async {
+        let controller = SplitViewController()
+        let pane = controller.focusedPane!
+        let tab = pane.selectedTab!
+
+        _ = controller.makeTabDragItemProvider(
+            for: tab,
+            from: pane.id,
+            clearDropState: {}
+        )
+        XCTAssertNotNil(controller.draggingTab)
+        XCTAssertNotNil(controller.activeDragTab)
+
+        NotificationCenter.default.post(
+            name: NSApplication.didResignActiveNotification,
+            object: nil
+        )
+        await Task.yield()
+
+        XCTAssertNil(
+            controller.draggingTab,
+            "A tab drag must not keep pane hit-testing disabled after the app resigns active."
+        )
+        XCTAssertNil(controller.activeDragTab)
+    }
+
+    @MainActor
     func testRequestTabContextActionForwardsToDelegate() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1695,17 +1695,13 @@ final class BonsplitTests: XCTestCase {
         let generation = controller.beginTabDrag(tab, from: pane.id)
 
         XCTAssertEqual(controller.dragGeneration, generation)
-        XCTAssertEqual(controller.draggingTab?.id, tab.id)
-        XCTAssertEqual(controller.dragSourcePaneId, pane.id)
-        XCTAssertEqual(controller.activeDragTab?.id, tab.id)
-        XCTAssertEqual(controller.activeDragSourcePaneId, pane.id)
+        XCTAssertEqual(controller.tabDragSession?.tab.id, tab.id)
+        XCTAssertEqual(controller.tabDragSession?.sourcePaneId, pane.id)
+        XCTAssertEqual(controller.tabDragSession?.generation, generation)
 
         controller.cancelTabDragIfGenerationMatches(generation)
 
-        XCTAssertNil(controller.draggingTab)
-        XCTAssertNil(controller.dragSourcePaneId)
-        XCTAssertNil(controller.activeDragTab)
-        XCTAssertNil(controller.activeDragSourcePaneId)
+        XCTAssertNil(controller.tabDragSession)
     }
 
     @MainActor
@@ -1734,10 +1730,9 @@ final class BonsplitTests: XCTestCase {
         controller.cancelTabDragIfGenerationMatches(staleGeneration)
 
         XCTAssertEqual(controller.dragGeneration, currentGeneration)
-        XCTAssertEqual(controller.draggingTab?.id, secondTab.id)
-        XCTAssertEqual(controller.dragSourcePaneId, secondPane.id)
-        XCTAssertEqual(controller.activeDragTab?.id, secondTab.id)
-        XCTAssertEqual(controller.activeDragSourcePaneId, secondPane.id)
+        XCTAssertEqual(controller.tabDragSession?.tab.id, secondTab.id)
+        XCTAssertEqual(controller.tabDragSession?.sourcePaneId, secondPane.id)
+        XCTAssertEqual(controller.tabDragSession?.generation, currentGeneration)
     }
 
     @MainActor
@@ -1751,8 +1746,7 @@ final class BonsplitTests: XCTestCase {
             from: pane.id,
             clearDropState: {}
         )
-        XCTAssertNotNil(controller.draggingTab)
-        XCTAssertNotNil(controller.activeDragTab)
+        XCTAssertNotNil(controller.tabDragSession)
 
         NotificationCenter.default.post(
             name: NSApplication.didResignActiveNotification,
@@ -1761,10 +1755,9 @@ final class BonsplitTests: XCTestCase {
         await Task.yield()
 
         XCTAssertNil(
-            controller.draggingTab,
+            controller.tabDragSession,
             "A tab drag must not keep pane hit-testing disabled after the app resigns active."
         )
-        XCTAssertNil(controller.activeDragTab)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- replace four independently mutable tab-drag fields with one `TabDragSession`
- make the split controller own local/global mouse-up, Escape, and app-deactivation cleanup
- use generation identity so a late callback cannot clear a newer drag

## Regression coverage

The first commit adds `testAppResignClearsTabDragLifecycle` and fails against the prior implementation because the local-only mouse-up cleanup leaves drag state set after app deactivation. The second commit makes that test pass.

Part of manaflow-ai/cmux#9521.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tab drag teardown authoritative by centralizing state in a single `TabDragSession` and adding a controller-owned lifecycle monitor. Drags now always end on mouse up (local/global), Escape, or app deactivation, fixing sticky drag latches. Part of `manaflow-ai/cmux#9521`.

- **Bug Fixes**
  - End drags on local/global mouse up, Escape, and app resign to prevent stuck hit-testing.
  - Added a regression test that reproduces the app-resign sticky state; now passes.

- **Refactors**
  - Replaced four drag fields with a single `TabDragSession` seeded by `dragGeneration`.
  - Introduced `TabDragLifecycleMonitor`; controller starts/stops it and it ignores stale callbacks via generation.
  - Views and drop delegates read `tabDragSession` synchronously; removed ad-hoc monitors and updated tests/logging.

<sup>Written for commit 770d12e1f4b206b0b1621ec177228aaf8cc98bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

