### PR TITLE
Make tab drag lifecycle cleanup synchronous

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/TabDragLifecycleMonitor.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragLifecycleMonitor.swift
@@ -1,18 +1,41 @@
 import AppKit
 
 /// Ground-truth exits for a tab drag that never reaches a SwiftUI drop callback.
-/// Event callbacks enqueue cancellation after returning so AppKit can finish
-/// delivering a real drop first; the session generation rejects stale callbacks.
+/// AppKit delivers event-monitor callbacks on the main thread, so one synchronous
+/// bridge ends the matching generation without a deferred cleanup race.
 @MainActor
 final class TabDragLifecycleMonitor {
+    private struct Registrations {
+        var appResignObserver: (any NSObjectProtocol)?
+        var keyDownMonitor: Any?
+        var localMouseUpMonitor: Any?
+        var globalMouseUpMonitor: Any?
+
+        mutating func removeAll() {
+            if let appResignObserver {
+                NotificationCenter.default.removeObserver(appResignObserver)
+                self.appResignObserver = nil
+            }
+            if let keyDownMonitor {
+                NSEvent.removeMonitor(keyDownMonitor)
+                self.keyDownMonitor = nil
+            }
+            if let localMouseUpMonitor {
+                NSEvent.removeMonitor(localMouseUpMonitor)
+                self.localMouseUpMonitor = nil
+            }
+            if let globalMouseUpMonitor {
+                NSEvent.removeMonitor(globalMouseUpMonitor)
+                self.globalMouseUpMonitor = nil
+            }
+        }
+    }
+
     private static let escapeKeyCode: UInt16 = 53
 
     private let generation: Int
     private let onRequestEnd: @MainActor (Int) -> Void
-    private var appResignObserver: (any NSObjectProtocol)?
-    private var keyDownMonitor: Any?
-    private var localMouseUpMonitor: Any?
-    private var globalMouseUpMonitor: Any?
+    private var registrations = Registrations()
     private var endRequested = false
     private var isStopped = false
 
@@ -21,55 +44,48 @@ final class TabDragLifecycleMonitor {
         self.onRequestEnd = onRequestEnd
     }
 
+    isolated deinit {
+        registrations.removeAll()
+    }
+
     func start() {
-        appResignObserver = NotificationCenter.default.addObserver(
+        registrations.appResignObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didResignActiveNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.requestEnd()
+            self?.requestEndFromMainThreadCallback()
         }
-        keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        registrations.keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == Self.escapeKeyCode {
-                self?.requestEnd()
+                self?.requestEndFromMainThreadCallback()
             }
             return event
         }
-        localMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
-            self?.requestEnd()
+        registrations.localMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+            self?.requestEndFromMainThreadCallback()
             return event
         }
-        globalMouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { [weak self] _ in
-            self?.requestEnd()
+        registrations.globalMouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { [weak self] _ in
+            self?.requestEndFromMainThreadCallback()
         }
     }
 
     func stop() {
         guard !isStopped else { return }
         isStopped = true
-        if let appResignObserver {
-            NotificationCenter.default.removeObserver(appResignObserver)
-            self.appResignObserver = nil
-        }
-        if let keyDownMonitor {
-            NSEvent.removeMonitor(keyDownMonitor)
-            self.keyDownMonitor = nil
-        }
-        if let localMouseUpMonitor {
-            NSEvent.removeMonitor(localMouseUpMonitor)
-            self.localMouseUpMonitor = nil
-        }
-        if let globalMouseUpMonitor {
-            NSEvent.removeMonitor(globalMouseUpMonitor)
-            self.globalMouseUpMonitor = nil
+        registrations.removeAll()
+    }
+
+    private nonisolated func requestEndFromMainThreadCallback() {
+        MainActor.assumeIsolated {
+            requestEnd()
         }
     }
 
-    private nonisolated func requestEnd() {
-        Task { @MainActor [weak self] in
-            guard let self, !self.isStopped, !self.endRequested else { return }
-            self.endRequested = true
-            self.onRequestEnd(self.generation)
-        }
+    private func requestEnd() {
+        guard !isStopped, !endRequested else { return }
+        endRequested = true
+        onRequestEnd(generation)
     }
 }

--- a/Sources/Bonsplit/Internal/Controllers/TabDragLifecycleMonitor.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragLifecycleMonitor.swift
@@ -5,37 +5,17 @@ import AppKit
 /// bridge ends the matching generation without a deferred cleanup race.
 @MainActor
 final class TabDragLifecycleMonitor {
-    private struct Registrations {
-        var appResignObserver: (any NSObjectProtocol)?
-        var keyDownMonitor: Any?
-        var localMouseUpMonitor: Any?
-        var globalMouseUpMonitor: Any?
-
-        mutating func removeAll() {
-            if let appResignObserver {
-                NotificationCenter.default.removeObserver(appResignObserver)
-                self.appResignObserver = nil
-            }
-            if let keyDownMonitor {
-                NSEvent.removeMonitor(keyDownMonitor)
-                self.keyDownMonitor = nil
-            }
-            if let localMouseUpMonitor {
-                NSEvent.removeMonitor(localMouseUpMonitor)
-                self.localMouseUpMonitor = nil
-            }
-            if let globalMouseUpMonitor {
-                NSEvent.removeMonitor(globalMouseUpMonitor)
-                self.globalMouseUpMonitor = nil
-            }
-        }
-    }
-
     private static let escapeKeyCode: UInt16 = 53
 
     private let generation: Int
     private let onRequestEnd: @MainActor (Int) -> Void
-    private var registrations = Registrations()
+    // Registration tokens are mutated only by main-actor start/stop. Deinit
+    // reads them after the monitor's last owner has released it, when no
+    // actor-isolated access can remain in flight.
+    private nonisolated(unsafe) var appResignObserver: (any NSObjectProtocol)?
+    private nonisolated(unsafe) var keyDownMonitor: Any?
+    private nonisolated(unsafe) var localMouseUpMonitor: Any?
+    private nonisolated(unsafe) var globalMouseUpMonitor: Any?
     private var endRequested = false
     private var isStopped = false
 
@@ -44,29 +24,34 @@ final class TabDragLifecycleMonitor {
         self.onRequestEnd = onRequestEnd
     }
 
-    isolated deinit {
-        registrations.removeAll()
+    deinit {
+        Self.removeRegistrations(
+            appResignObserver: appResignObserver,
+            keyDownMonitor: keyDownMonitor,
+            localMouseUpMonitor: localMouseUpMonitor,
+            globalMouseUpMonitor: globalMouseUpMonitor
+        )
     }
 
     func start() {
-        registrations.appResignObserver = NotificationCenter.default.addObserver(
+        appResignObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didResignActiveNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             self?.requestEndFromMainThreadCallback()
         }
-        registrations.keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             if event.keyCode == Self.escapeKeyCode {
                 self?.requestEndFromMainThreadCallback()
             }
             return event
         }
-        registrations.localMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+        localMouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
             self?.requestEndFromMainThreadCallback()
             return event
         }
-        registrations.globalMouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { [weak self] _ in
+        globalMouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { [weak self] _ in
             self?.requestEndFromMainThreadCallback()
         }
     }
@@ -74,7 +59,16 @@ final class TabDragLifecycleMonitor {
     func stop() {
         guard !isStopped else { return }
         isStopped = true
-        registrations.removeAll()
+        Self.removeRegistrations(
+            appResignObserver: appResignObserver,
+            keyDownMonitor: keyDownMonitor,
+            localMouseUpMonitor: localMouseUpMonitor,
+            globalMouseUpMonitor: globalMouseUpMonitor
+        )
+        appResignObserver = nil
+        keyDownMonitor = nil
+        localMouseUpMonitor = nil
+        globalMouseUpMonitor = nil
     }
 
     private nonisolated func requestEndFromMainThreadCallback() {
@@ -87,5 +81,25 @@ final class TabDragLifecycleMonitor {
         guard !isStopped, !endRequested else { return }
         endRequested = true
         onRequestEnd(generation)
+    }
+
+    private nonisolated static func removeRegistrations(
+        appResignObserver: (any NSObjectProtocol)?,
+        keyDownMonitor: Any?,
+        localMouseUpMonitor: Any?,
+        globalMouseUpMonitor: Any?
+    ) {
+        if let appResignObserver {
+            NotificationCenter.default.removeObserver(appResignObserver)
+        }
+        if let keyDownMonitor {
+            NSEvent.removeMonitor(keyDownMonitor)
+        }
+        if let localMouseUpMonitor {
+            NSEvent.removeMonitor(localMouseUpMonitor)
+        }
+        if let globalMouseUpMonitor {
+            NSEvent.removeMonitor(globalMouseUpMonitor)
+        }
     }
 }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1736,7 +1736,7 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testAppResignClearsTabDragLifecycle() async {
+    func testAppResignClearsTabDragLifecycleSynchronously() {
         let controller = SplitViewController()
         let pane = controller.focusedPane!
         let tab = pane.selectedTab!
@@ -1752,7 +1752,6 @@ final class BonsplitTests: XCTestCase {
             name: NSApplication.didResignActiveNotification,
             object: nil
         )
-        await Task.yield()
 
         XCTAssertNil(
             controller.tabDragSession,


### PR DESCRIPTION
Follow-up for manaflow-ai/cmux#9521.

- invoke drag lifecycle cleanup synchronously from AppKit main-thread callbacks
- make monitor registration cleanup survive controller teardown via isolated deinit
- assert app-resign teardown completes before notification posting returns

Validation: `arch -arm64 swift test` (217 XCTest + 7 Swift Testing passed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788684278&installation_model_id=21920&pr_number=204&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F204&signature=55932bcc9c4b6bbf7d1fc30beb274d23ff03c47806e040d31a9c32673fdd11c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tab drag cleanup synchronous to prevent sticky drag latches and stale session callbacks. Event monitors and app-resign handling now end the drag immediately on main-thread callbacks and during controller teardown, addressing issue 9521.

- **Bug Fixes**
  - End the active drag generation synchronously from AppKit main-thread monitors (ESC, mouseUp, app resign) via `MainActor.assumeIsolated` (no deferred `Task`).
  - Make teardown synchronous during `stop()` and `deinit`: store monitor tokens as `nonisolated(unsafe)` and remove them via a static helper, avoiding an isolated-deinit runtime dependency.
  - Update test to assert immediate cleanup on app resign (no `Task.yield`).

<sup>Written for commit 6a9b467125e23705b92987145be61efb0b563b7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

