### PR TITLE
Keep native tab drag metadata process-private

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import UniformTypeIdentifiers
 
 extension SplitViewController {
     @discardableResult
@@ -31,7 +30,6 @@ extension SplitViewController {
     func beginNativeTabDrag(
         _ tab: TabItem,
         from paneId: PaneID,
-        pasteboardItem: NSPasteboardItem,
         sourceView: NSView,
         event: NSEvent,
         draggingFrame: NSRect,
@@ -40,11 +38,20 @@ extension SplitViewController {
 #if DEBUG
         NSLog("[Bonsplit Drag] begin native session for tab: \(tab.title)")
 #endif
+        let transfer = TabTransferData(tab: tab, sourcePaneId: paneId.id)
+        guard let registration = tabDragTransferRegistry.register(transfer) else {
+            return false
+        }
         let generation = beginTabDrag(tab, from: paneId)
-        let source = TabDragSessionSource(generation: generation, controller: self)
+        let source = TabDragSessionSource(
+            generation: generation,
+            transferToken: registration.token,
+            transferRegistry: tabDragTransferRegistry,
+            controller: self
+        )
         nativeTabDragSources[generation] = source
 
-        let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+        let draggingItem = NSDraggingItem(pasteboardWriter: registration.pasteboardItem)
         draggingItem.setDraggingFrame(draggingFrame, contents: dragImage)
         sourceView.beginDraggingSession(
             with: [draggingItem],
@@ -52,14 +59,6 @@ extension SplitViewController {
             source: source
         )
         return true
-    }
-
-    func makeTabDragPasteboardItem(for tab: TabItem, from paneId: PaneID) -> NSPasteboardItem? {
-        let transfer = TabTransferData(tab: tab, sourcePaneId: paneId.id)
-        guard let data = try? JSONEncoder().encode(transfer) else { return nil }
-        let item = NSPasteboardItem()
-        item.setData(data, forType: NSPasteboard.PasteboardType(UTType.tabTransfer.identifier))
-        return item
     }
 
     func nativeTabDragSessionDidEnd(generation: Int) {

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -33,6 +33,9 @@ final class SplitViewController {
     /// Native sources stay alive independently of SwiftUI tab/view teardown.
     @ObservationIgnored var nativeTabDragSources: [Int: TabDragSessionSource] = [:]
 
+    /// Process-local capability store shared by tab-drag sources and destinations.
+    @ObservationIgnored let tabDragTransferRegistry: TabDragTransferRegistry
+
     /// When false, drop delegates reject all drags and NSViews are hidden.
     /// Mirrors BonsplitController.isInteractive. Must be observable so
     /// updateNSView is called to toggle isHidden on the AppKit containers.
@@ -95,7 +98,15 @@ final class SplitViewController {
         }
     }
 
-    init(rootNode: SplitNode? = nil) {
+    convenience init(rootNode: SplitNode? = nil) {
+        self.init(
+            rootNode: rootNode,
+            tabDragTransferRegistry: .process
+        )
+    }
+
+    init(rootNode: SplitNode? = nil, tabDragTransferRegistry: TabDragTransferRegistry) {
+        self.tabDragTransferRegistry = tabDragTransferRegistry
         let resolvedRoot: SplitNode
         let initialFocusedPaneId: PaneID?
         if let rootNode {

--- a/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
@@ -4,10 +4,19 @@ import AppKit
 @MainActor
 final class TabDragSessionSource: NSObject, NSDraggingSource {
     private let generation: Int
+    private let transferToken: UUID
+    private let transferRegistry: TabDragTransferRegistry
     private weak var controller: SplitViewController?
 
-    init(generation: Int, controller: SplitViewController) {
+    init(
+        generation: Int,
+        transferToken: UUID,
+        transferRegistry: TabDragTransferRegistry,
+        controller: SplitViewController
+    ) {
         self.generation = generation
+        self.transferToken = transferToken
+        self.transferRegistry = transferRegistry
         self.controller = controller
     }
 
@@ -23,6 +32,11 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         endedAt screenPoint: NSPoint,
         operation: NSDragOperation
     ) {
+        finishDrag()
+    }
+
+    func finishDrag() {
+        transferRegistry.end(token: transferToken)
         controller?.nativeTabDragSessionDidEnd(generation: generation)
     }
 }

--- a/Sources/Bonsplit/Internal/Controllers/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragTransferRegistry.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+/// Process-local capability store for transfers owned by live native tab drags.
+@MainActor
+final class TabDragTransferRegistry {
+    /// AppKit's drag pasteboard is process-wide, so controllers share one registry
+    /// to support cross-window moves while still allowing isolated registries in tests.
+    static let process = TabDragTransferRegistry()
+
+    static let pasteboardType = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+
+    private var transfers: [UUID: TabTransferData] = [:]
+
+    func register(_ transfer: TabTransferData) -> (token: UUID, pasteboardItem: NSPasteboardItem)? {
+        let token = UUID()
+        let item = NSPasteboardItem()
+        guard item.setString(token.uuidString, forType: Self.pasteboardType) else {
+            return nil
+        }
+        transfers[token] = transfer
+        return (token, item)
+    }
+
+    func resolve(from pasteboard: NSPasteboard) -> TabTransferData? {
+        guard let token = token(from: pasteboard) else { return nil }
+        return transfers[token]
+    }
+
+    func end(token: UUID) {
+        transfers[token] = nil
+    }
+
+    private func token(from pasteboard: NSPasteboard) -> UUID? {
+        guard let value = pasteboard.string(forType: Self.pasteboardType) else {
+            return nil
+        }
+        return UUID(uuidString: value)
+    }
+}

--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -134,44 +134,13 @@ extension TabItem: Transferable {
     }
 }
 
-/// Transfer data that includes source pane information for cross-pane moves
-struct TabTransferData: Codable, Transferable {
+/// Process-local transfer data resolved from an opaque live-drag capability.
+struct TabTransferData {
     let tab: TabItem
     let sourcePaneId: UUID
-    let sourceProcessId: Int32
 
-    init(tab: TabItem, sourcePaneId: UUID, sourceProcessId: Int32 = Int32(ProcessInfo.processInfo.processIdentifier)) {
+    init(tab: TabItem, sourcePaneId: UUID) {
         self.tab = tab
         self.sourcePaneId = sourcePaneId
-        self.sourceProcessId = sourceProcessId
-    }
-
-    var isFromCurrentProcess: Bool {
-        sourceProcessId == Int32(ProcessInfo.processInfo.processIdentifier)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case tab
-        case sourcePaneId
-        case sourceProcessId
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.tab = try container.decode(TabItem.self, forKey: .tab)
-        self.sourcePaneId = try container.decode(UUID.self, forKey: .sourcePaneId)
-        // Legacy payloads won't include this field. Treat as foreign process to reject cross-instance drops.
-        self.sourceProcessId = try container.decodeIfPresent(Int32.self, forKey: .sourceProcessId) ?? -1
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(tab, forKey: .tab)
-        try container.encode(sourcePaneId, forKey: .sourcePaneId)
-        try container.encode(sourceProcessId, forKey: .sourceProcessId)
-    }
-
-    static var transferRepresentation: some TransferRepresentation {
-        CodableRepresentation(contentType: .tabTransfer)
     }
 }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -477,8 +477,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         }
 
         if info.hasItemsConforming(to: [.tabTransfer]) {
-            guard let transfer = decodeTransfer(from: info),
-                  transfer.isFromCurrentProcess,
+            guard let transfer = resolveTransfer(),
                   let destination = destination(for: zone) else {
                 return false
             }
@@ -589,9 +588,8 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             // Local tab drags use in-memory state and are always same-process.
             return true
         } else if hasTabTransfer {
-            // External drags (another Bonsplit controller) must include a payload from this process.
-            guard let transfer = decodeTransfer(from: info),
-                  transfer.isFromCurrentProcess else {
+            // External drags must present a capability owned by a live source in this process.
+            guard resolveTransfer() != nil else {
                 return false
             }
         }
@@ -743,24 +741,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
         !fileURLs(from: pasteboard).isEmpty
     }
 
-    private func decodeTransfer(from string: String) -> TabTransferData? {
-        guard let data = string.data(using: .utf8),
-              let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) else {
-            return nil
-        }
-        return transfer
-    }
-
-    private func decodeTransfer(from info: DropInfo) -> TabTransferData? {
-        let pasteboard = NSPasteboard(name: .drag)
-        let type = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
-        if let data = pasteboard.data(forType: type),
-           let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) {
-            return transfer
-        }
-        if let raw = pasteboard.string(forType: type) {
-            return decodeTransfer(from: raw)
-        }
-        return nil
+    private func resolveTransfer() -> TabTransferData? {
+        controller.tabDragTransferRegistry.resolve(from: NSPasteboard(name: .drag))
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarDropHandler.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarDropHandler.swift
@@ -1,11 +1,10 @@
 import AppKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// Applies tab-strip drops through the controller's shared tab mutation APIs.
 @MainActor
 struct TabBarDropHandler {
-    static let tabTransferPasteboardType = NSPasteboard.PasteboardType(UTType.tabTransfer.identifier)
+    static let tabTransferPasteboardType = TabDragTransferRegistry.pasteboardType
 
     let pane: PaneState
     let bonsplitController: BonsplitController
@@ -39,7 +38,7 @@ struct TabBarDropHandler {
         }
 
         if hasTabTransfer {
-            guard let transfer = Self.decodeTransfer(from: pasteboard), transfer.isFromCurrentProcess else {
+            guard let transfer = splitViewController.tabDragTransferRegistry.resolve(from: pasteboard) else {
                 return []
             }
             let sourcePaneId = PaneID(id: transfer.sourcePaneId)
@@ -81,13 +80,12 @@ struct TabBarDropHandler {
         targetIndex == sourceIndex || targetIndex == sourceIndex + 1
     }
 
-    static func sameProcessFallbackRequest(
+    private static func externalFallbackRequest(
         transfer: TabTransferData,
         targetPane: PaneID,
         targetIndex: Int,
         allowCrossPaneTabMove: Bool
     ) -> BonsplitController.ExternalTabDropRequest? {
-        guard transfer.isFromCurrentProcess else { return nil }
         let sourcePaneId = PaneID(id: transfer.sourcePaneId)
         guard sourcePaneId != targetPane, allowCrossPaneTabMove else { return nil }
         return BonsplitController.ExternalTabDropRequest(
@@ -142,8 +140,8 @@ struct TabBarDropHandler {
             return handled
         }
 
-        guard let transfer = Self.decodeTransfer(from: pasteboard),
-              let request = Self.sameProcessFallbackRequest(
+        guard let transfer = splitViewController.tabDragTransferRegistry.resolve(from: pasteboard),
+              let request = Self.externalFallbackRequest(
                   transfer: transfer,
                   targetPane: pane.id,
                   targetIndex: targetIndex,
@@ -172,15 +170,4 @@ struct TabBarDropHandler {
         return splitViewController.onFileDrop?(urls, pane.id) ?? false
     }
 
-    private static func decodeTransfer(from pasteboard: NSPasteboard) -> TabTransferData? {
-        if let data = pasteboard.data(forType: tabTransferPasteboardType),
-           let transfer = try? JSONDecoder().decode(TabTransferData.self, from: data) {
-            return transfer
-        }
-        guard let rawValue = pasteboard.string(forType: tabTransferPasteboardType),
-              let data = rawValue.data(using: .utf8) else {
-            return nil
-        }
-        return try? JSONDecoder().decode(TabTransferData.self, from: data)
-    }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1008,18 +1008,13 @@ struct TabBarView: View {
             geometryRegistry: tabItemGeometryRegistry,
             tabIds: tabIds,
             onBeginTabDrag: { tabId, sourceView, event, draggingFrame, dragImage in
-                guard let tab = pane.tabs.first(where: { $0.id == tabId }),
-                      let pasteboardItem = splitViewController.makeTabDragPasteboardItem(
-                          for: tab,
-                          from: pane.id
-                      ) else {
+                guard let tab = pane.tabs.first(where: { $0.id == tabId }) else {
                     return false
                 }
                 dropTargetIndex = nil
                 return splitViewController.beginNativeTabDrag(
                     tab,
                     from: pane.id,
-                    pasteboardItem: pasteboardItem,
                     sourceView: sourceView,
                     event: event,
                     draggingFrame: draggingFrame,

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -119,6 +119,21 @@ public final class BonsplitController {
     public init(configuration: BonsplitConfiguration = .default) {
         self.configuration = configuration
         self.internalController = SplitViewController()
+        configureInternalController()
+    }
+
+    init(
+        configuration: BonsplitConfiguration = .default,
+        tabDragTransferRegistry: TabDragTransferRegistry
+    ) {
+        self.configuration = configuration
+        self.internalController = SplitViewController(
+            tabDragTransferRegistry: tabDragTransferRegistry
+        )
+        configureInternalController()
+    }
+
+    private func configureInternalController() {
         internalController.publicController = self
         internalController.onDividerDragSessionChange = { [weak self] active in
             guard let self else { return }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1759,6 +1759,21 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testNativeTabDragPasteboardDoesNotExposeSerializedTabMetadata() throws {
+        let controller = SplitViewController()
+        let pane = try XCTUnwrap(controller.focusedPane)
+        let tab = try XCTUnwrap(pane.selectedTab)
+        let item = try XCTUnwrap(
+            controller.makeTabDragPasteboardItem(for: tab, from: pane.id)
+        )
+        let data = try XCTUnwrap(
+            item.data(forType: NSPasteboard.PasteboardType(UTType.tabTransfer.identifier))
+        )
+
+        XCTAssertThrowsError(try JSONDecoder().decode(TabTransferData.self, from: data))
+    }
+
+    @MainActor
     func testRequestTabContextActionForwardsToDelegate() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1759,21 +1759,6 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
-    func testNativeTabDragPasteboardDoesNotExposeSerializedTabMetadata() throws {
-        let controller = SplitViewController()
-        let pane = try XCTUnwrap(controller.focusedPane)
-        let tab = try XCTUnwrap(pane.selectedTab)
-        let item = try XCTUnwrap(
-            controller.makeTabDragPasteboardItem(for: tab, from: pane.id)
-        )
-        let data = try XCTUnwrap(
-            item.data(forType: NSPasteboard.PasteboardType(UTType.tabTransfer.identifier))
-        )
-
-        XCTAssertThrowsError(try JSONDecoder().decode(TabTransferData.self, from: data))
-    }
-
-    @MainActor
     func testRequestTabContextActionForwardsToDelegate() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!

--- a/Tests/BonsplitTests/TabBarDropHandlerTests.swift
+++ b/Tests/BonsplitTests/TabBarDropHandlerTests.swift
@@ -40,7 +40,7 @@ final class TabBarDropHandlerTests: XCTestCase {
             harness.controller.internalController.paneState(for: targetPaneId)
         )
         let initialTargetIds = targetPane.tabs.map(\.id)
-        let pasteboard = try makePasteboard(for: movedTab, sourcePane: sourcePane)
+        let pasteboard = try makePasteboard(for: movedTab, in: harness)
         _ = harness.controller.internalController.beginTabDrag(movedTab, from: sourcePane.id)
 
         XCTAssertTrue(makeHandler(controller: harness.controller, pane: targetPane).performDrop(
@@ -146,7 +146,7 @@ final class TabBarDropHandlerTests: XCTestCase {
         let targetPane = try XCTUnwrap(
             harness.controller.internalController.paneState(for: targetPaneId)
         )
-        let pasteboard = try makePasteboard(for: sourcePane.tabs[1], sourcePane: sourcePane)
+        let pasteboard = try makePasteboard(for: sourcePane.tabs[1], in: harness)
         let handler = makeHandler(controller: harness.controller, pane: targetPane)
 
         XCTAssertEqual(handler.operation(for: pasteboard), [])
@@ -197,12 +197,14 @@ final class TabBarDropHandlerTests: XCTestCase {
     }
 
     private func makeHarness() throws -> Harness {
+        let registry = TabDragTransferRegistry()
         let controller = BonsplitController(
             configuration: BonsplitConfiguration(
                 allowTabReordering: true,
                 allowCrossPaneTabMove: true,
                 newTabPosition: .end
-            )
+            ),
+            tabDragTransferRegistry: registry
         )
         let paneId = try XCTUnwrap(controller.focusedPaneId)
         _ = controller.createTab(title: "Second")
@@ -210,7 +212,7 @@ final class TabBarDropHandlerTests: XCTestCase {
         _ = controller.createTab(title: "Fourth")
         let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
         XCTAssertEqual(pane.tabs.count, 4)
-        return Harness(controller: controller, pane: pane)
+        return Harness(controller: controller, pane: pane, registry: registry)
     }
 
     private func makeHandler(_ harness: Harness) -> TabBarDropHandler {
@@ -234,14 +236,10 @@ final class TabBarDropHandlerTests: XCTestCase {
     }
 
     private func makePasteboard(for tab: TabItem, in harness: Harness) throws -> NSPasteboard {
-        try makePasteboard(for: tab, sourcePane: harness.pane)
-    }
-
-    private func makePasteboard(for tab: TabItem, sourcePane: PaneState) throws -> NSPasteboard {
         let pasteboard = makeEmptyPasteboard()
-        let transfer = TabTransferData(tab: tab, sourcePaneId: sourcePane.id.id)
-        let data = try JSONEncoder().encode(transfer)
-        XCTAssertTrue(pasteboard.setData(data, forType: TabBarDropHandler.tabTransferPasteboardType))
+        let transfer = TabTransferData(tab: tab, sourcePaneId: harness.pane.id.id)
+        let registration = try XCTUnwrap(harness.registry.register(transfer))
+        XCTAssertTrue(pasteboard.writeObjects([registration.pasteboardItem]))
         return pasteboard
     }
 }
@@ -250,6 +248,7 @@ final class TabBarDropHandlerTests: XCTestCase {
 private struct Harness {
     let controller: BonsplitController
     let pane: PaneState
+    let registry: TabDragTransferRegistry
 }
 
 @MainActor

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -1,0 +1,146 @@
+import AppKit
+@testable import Bonsplit
+import Testing
+
+@Suite("Native tab drag capabilities")
+@MainActor
+struct TabDragTransferRegistryTests {
+    @Test("Pasteboard publishes only an opaque capability")
+    func pasteboardDoesNotExposeSerializedTabMetadata() throws {
+        let registry = TabDragTransferRegistry()
+        let controller = makeController(registry: registry)
+        let pane = try #require(controller.internalController.focusedPane)
+        let tab = try #require(pane.selectedTab)
+        let registration = try #require(
+            registry.register(TabTransferData(tab: tab, sourcePaneId: pane.id.id))
+        )
+        let value = try #require(
+            registration.pasteboardItem.string(forType: TabDragTransferRegistry.pasteboardType)
+        )
+
+        #expect(UUID(uuidString: value) != nil)
+        #expect(!value.contains(tab.title))
+        #expect(!value.contains(pane.id.id.uuidString))
+    }
+
+    @Test("A registered capability routes across controllers")
+    func registeredCapabilityRoutesAcrossControllers() throws {
+        let sourceController = makeController()
+        let targetController = makeController()
+        let registry = sourceController.internalController.tabDragTransferRegistry
+        let sourcePane = try #require(sourceController.internalController.focusedPane)
+        let sourceTab = try #require(sourcePane.selectedTab)
+        let targetPane = try #require(targetController.internalController.focusedPane)
+        let registration = try #require(
+            registry.register(TabTransferData(tab: sourceTab, sourcePaneId: sourcePane.id.id))
+        )
+        defer { registry.end(token: registration.token) }
+        let pasteboard = makePasteboard(item: registration.pasteboardItem)
+        let handler = makeHandler(controller: targetController, pane: targetPane)
+        var receivedRequest: BonsplitController.ExternalTabDropRequest?
+        targetController.onExternalTabDrop = { request in
+            receivedRequest = request
+            return true
+        }
+
+        #expect(handler.operation(for: pasteboard) == .move)
+        #expect(handler.performDrop(from: pasteboard, at: 0))
+        #expect(receivedRequest?.tabId == TabID(id: sourceTab.id))
+        #expect(receivedRequest?.sourcePaneId == sourcePane.id)
+    }
+
+    @Test("An unregistered capability is rejected")
+    func unregisteredCapabilityIsRejected() throws {
+        let registry = TabDragTransferRegistry()
+        let targetController = makeController(registry: registry)
+        let targetPane = try #require(targetController.internalController.focusedPane)
+        let pasteboard = makePasteboard(token: UUID())
+        let handler = makeHandler(controller: targetController, pane: targetPane)
+        targetController.onExternalTabDrop = { _ in true }
+
+        #expect(handler.operation(for: pasteboard).isEmpty)
+        #expect(!handler.performDrop(from: pasteboard, at: 0))
+    }
+
+    @Test("Native source completion revokes its capability")
+    func sourceCompletionRevokesCapability() throws {
+        let registry = TabDragTransferRegistry()
+        let sourceController = makeController(registry: registry)
+        let targetController = makeController(registry: registry)
+        let sourcePane = try #require(sourceController.internalController.focusedPane)
+        let sourceTab = try #require(sourcePane.selectedTab)
+        let targetPane = try #require(targetController.internalController.focusedPane)
+        let generation = sourceController.internalController.beginTabDrag(sourceTab, from: sourcePane.id)
+        let registration = try #require(
+            registry.register(TabTransferData(tab: sourceTab, sourcePaneId: sourcePane.id.id))
+        )
+        let source = TabDragSessionSource(
+            generation: generation,
+            transferToken: registration.token,
+            transferRegistry: registry,
+            controller: sourceController.internalController
+        )
+        let pasteboard = makePasteboard(item: registration.pasteboardItem)
+        let handler = makeHandler(controller: targetController, pane: targetPane)
+        targetController.onExternalTabDrop = { _ in true }
+        #expect(handler.operation(for: pasteboard) == .move)
+
+        source.finishDrag()
+
+        #expect(sourceController.internalController.tabDragSession == nil)
+        #expect(handler.operation(for: pasteboard).isEmpty)
+    }
+
+    private func makeController(
+        registry: TabDragTransferRegistry? = nil
+    ) -> BonsplitController {
+        let configuration = BonsplitConfiguration(
+            allowTabReordering: true,
+            allowCrossPaneTabMove: true,
+            newTabPosition: .end
+        )
+        if let registry {
+            return BonsplitController(
+                configuration: configuration,
+                tabDragTransferRegistry: registry
+            )
+        }
+        return BonsplitController(configuration: configuration)
+    }
+
+    private func makeHandler(
+        controller: BonsplitController,
+        pane: PaneState
+    ) -> TabBarDropHandler {
+        TabBarDropHandler(
+            pane: pane,
+            bonsplitController: controller,
+            splitViewController: controller.internalController
+        )
+    }
+
+    private func makePasteboard(item: NSPasteboardItem) -> NSPasteboard {
+        let pasteboard = emptyPasteboard()
+        #expect(pasteboard.writeObjects([item]))
+        return pasteboard
+    }
+
+    private func makePasteboard(token: UUID) -> NSPasteboard {
+        let pasteboard = emptyPasteboard()
+        #expect(
+            pasteboard.setString(
+                token.uuidString,
+                forType: TabDragTransferRegistry.pasteboardType
+            )
+        )
+        return pasteboard
+    }
+
+    private func emptyPasteboard() -> NSPasteboard {
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("TabDragTransferRegistryTests.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        return pasteboard
+    }
+}


### PR DESCRIPTION
## Summary

- replace serialized tab metadata on the native drag pasteboard with an opaque random capability
- resolve capabilities only through a live process-local `@MainActor` registry shared by Bonsplit controllers
- revoke each capability from AppKit native source completion, including when the originating controller view disappears
- remove PID-based authorization because pasteboard payloads can forge it

Follow-up to #205 and manaflow-ai/cmux#9787.

## Regression coverage

Commit `8ce0df7` adds the failing privacy regression before the fix. The focused Swift Testing suite verifies:

- pasteboard data contains only an opaque UUID
- a registered capability routes across default cross-controller runtime instances
- an unregistered capability is rejected
- native source completion revokes the capability and stale pasteboard data is rejected

## Testing

- `arch -arm64 swift test --filter TabDragTransferRegistryTests`
- `arch -arm64 swift test` (217 XCTest + 11 Swift Testing passed)
- `git diff --check`

No new Swift warnings were introduced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788691772&installation_model_id=21920&pr_number=206&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F206&signature=ebe42528f12ef8853240faef668976ab3e4bbd8fb19a5d2bf9c50e3329d0ef71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced serialized tab metadata on the drag pasteboard with an opaque capability token resolved via a process-local registry, keeping native tab drags private and preventing stale drops. This also addresses sticky drag latches from issue 9521 by revoking capabilities when drags end.

- **Bug Fixes**
  - Added `TabDragTransferRegistry` to register, resolve, and revoke process-local capabilities shared across controllers.
  - Pasteboard now carries only a UUID token; no tab titles or IDs are exposed.
  - Revoked capabilities on native source completion and when the source view disappears.
  - Removed PID-based checks and JSON decoding; drop handlers now require a live capability.
  - Added focused tests covering opaque pasteboard payloads, cross-controller routing, rejection of unregistered tokens, and revocation after drag end.

<sup>Written for commit 33969f29a9b8e77df1f609fe851c491d762580fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

