### PR TITLE
Forward tab drag threshold events

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1957,7 +1957,7 @@ private struct TabBarHoverTrackingView: NSViewRepresentable {
 /// tracking, and one geometry-routed tab-drag source monitor. The monitor does
 /// not replace normal click dispatch; it consumes only the drag event that
 /// crosses the reorder threshold and starts an AppKit session.
-private struct TabBarDragAndHoverView: NSViewRepresentable {
+struct TabBarDragAndHoverView: NSViewRepresentable {
     typealias BeginTabDrag = @MainActor (
         _ tabId: UUID,
         _ sourceView: NSView,
@@ -2161,7 +2161,7 @@ private struct TabBarDragAndHoverView: NSViewRepresentable {
             pendingTabDrag = nil
         }
 
-        private func handleTabDragEvent(_ event: NSEvent) -> NSEvent? {
+        func handleTabDragEvent(_ event: NSEvent) -> NSEvent? {
             switch event.type {
             case .leftMouseDown:
                 trackTabMouseDown(event)

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1955,8 +1955,9 @@ private struct TabBarHoverTrackingView: NSViewRepresentable {
 
 /// Background view that provides window dragging from empty space, hover
 /// tracking, and one geometry-routed tab-drag source monitor. The monitor does
-/// not replace normal click dispatch; it consumes only the drag event that
-/// crosses the reorder threshold and starts an AppKit session.
+/// not replace normal click dispatch; it starts an AppKit session when a drag
+/// crosses the reorder threshold and forwards that event so SwiftUI can cancel
+/// the pending tab press.
 struct TabBarDragAndHoverView: NSViewRepresentable {
     typealias BeginTabDrag = @MainActor (
         _ tabId: UUID,
@@ -2219,14 +2220,17 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
                   let onBeginTabDrag else {
                 return event
             }
-            let didBegin = onBeginTabDrag(
+            _ = onBeginTabDrag(
                 pendingTabDrag.tabId,
                 self,
                 pendingTabDrag.mouseDownEvent,
                 pendingTabDrag.frame,
                 dragImage
             )
-            return didBegin ? nil : event
+            // SwiftUI already received the mouse-down. Forward the threshold-
+            // crossing move so its pending tap/press fails before AppKit owns
+            // the native drag session and terminal mouse-up.
+            return event
         }
 
         private func dragImage(for frame: NSRect) -> NSImage? {

--- a/Tests/BonsplitTests/TabBarDragEventRoutingTests.swift
+++ b/Tests/BonsplitTests/TabBarDragEventRoutingTests.swift
@@ -1,0 +1,68 @@
+import AppKit
+import Testing
+
+@testable import Bonsplit
+
+@MainActor
+@Suite struct TabBarDragEventRoutingTests {
+    @Test func dragStartForwardsThresholdMoveToCancelPendingSwiftUIPress() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 80),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        let sourceView = TabBarDragAndHoverView.TabBarBackgroundNSView(frame: contentView.bounds)
+        let tabView = NSView(frame: NSRect(x: 20, y: 20, width: 120, height: 30))
+        let tabId = UUID()
+        let geometryRegistry = TabBarItemGeometryRegistry()
+        var beganTabId: UUID?
+
+        contentView.addSubview(sourceView)
+        sourceView.addSubview(tabView)
+        geometryRegistry.register(tabView, for: tabId)
+        sourceView.geometryRegistry = geometryRegistry
+        sourceView.tabIds = [tabId]
+        sourceView.onBeginTabDrag = { tabId, _, _, _, _ in
+            beganTabId = tabId
+            return true
+        }
+        window.makeKeyAndOrderFront(nil)
+
+        let mouseDown = try mouseEvent(
+            type: .leftMouseDown,
+            in: sourceView,
+            at: NSPoint(x: 40, y: 35)
+        )
+        let mouseDragged = try mouseEvent(
+            type: .leftMouseDragged,
+            in: sourceView,
+            at: NSPoint(x: 50, y: 45)
+        )
+
+        #expect(sourceView.handleTabDragEvent(mouseDown) === mouseDown)
+        #expect(sourceView.handleTabDragEvent(mouseDragged) === mouseDragged)
+        #expect(beganTabId == tabId)
+    }
+
+    private func mouseEvent(
+        type: NSEvent.EventType,
+        in view: NSView,
+        at point: NSPoint
+    ) throws -> NSEvent {
+        let window = try #require(view.window)
+        return try #require(NSEvent.mouseEvent(
+            with: type,
+            location: view.convert(point, to: nil),
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- keep AppKit as the native tab-drag lifecycle owner
- forward the threshold-crossing mouse-drag event after starting the native session
- let SwiftUI cancel the pending tab tap/press before AppKit owns terminal mouse-up

## Regression coverage

Commit 6c436f2 adds a focused test that fails against the previous behavior because the threshold event is swallowed. Commit c39140f forwards the event and makes the test pass.

Related to manaflow-ai/cmux#9521 and manaflow-ai/cmux#9787.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788819579&installation_model_id=21920&pr_number=207&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F207&signature=3e5ce91f380d5f6237f4b1e3844a6dc03cdd45a53d9121b733e52ae780709109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward the threshold-crossing mouse-drag to SwiftUI when starting the native AppKit tab-drag session so SwiftUI cancels the pending tab tap/press. Prevents swallowed events and sticky drag latches; aligns with `manaflow-ai/cmux#9521` and `manaflow-ai/cmux#9787`.

- **Bug Fixes**
  - Start AppKit tab-drag on threshold and forward that same event instead of consuming it, letting SwiftUI fail the press before mouse-up.
  - Added `TabBarDragEventRoutingTests` to cover the regression.

<sup>Written for commit c39140fa8d78219c0859d0d6d4572aec49f9b365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab dragging so pending tab presses are correctly canceled when a drag begins.
  * Ensured the initial drag event is forwarded reliably, allowing native dragging to start smoothly.
* **Tests**
  * Added coverage for tab drag event routing and drag initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->