### PR TITLE
Inject tab drag capability registries

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -101,7 +101,7 @@ final class SplitViewController {
     convenience init(rootNode: SplitNode? = nil) {
         self.init(
             rootNode: rootNode,
-            tabDragTransferRegistry: .process
+            tabDragTransferRegistry: TabDragTransferRegistry()
         )
     }
 

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -115,15 +115,30 @@ public final class BonsplitController {
 
     // MARK: - Initialization
 
-    /// Create a new controller with the specified configuration
+    /// Creates an isolated controller with the specified configuration.
+    ///
+    /// Use ``init(configuration:tabDragTransferRegistry:)`` when multiple
+    /// controllers may exchange tabs.
+    ///
+    /// - Parameter configuration: The controller's behavior and appearance.
     public init(configuration: BonsplitConfiguration = .default) {
         self.configuration = configuration
         self.internalController = SplitViewController()
         configureInternalController()
     }
 
-    init(
-        configuration: BonsplitConfiguration = .default,
+    /// Creates a controller with explicit ownership of its tab-drag capabilities.
+    ///
+    /// Controllers that exchange tabs must receive the same registry. Controllers
+    /// created without one are isolated, which keeps independent hosts and tests
+    /// from sharing hidden process state.
+    ///
+    /// - Parameters:
+    ///   - configuration: The controller's behavior and appearance.
+    ///   - tabDragTransferRegistry: The capability registry shared by controllers
+    ///     that may exchange tabs.
+    public init(
+        configuration: BonsplitConfiguration,
         tabDragTransferRegistry: TabDragTransferRegistry
     ) {
         self.configuration = configuration

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -5,12 +5,6 @@ import UniformTypeIdentifiers
 /// Process-local capability store shared by tab-drag sources and destinations.
 @MainActor
 public final class TabDragTransferRegistry {
-    /// The registry used by Bonsplit controllers created with the default initializer.
-    ///
-    /// AppKit exposes one drag pasteboard for the process, so the default registry
-    /// is process-wide as well. Construct a separate registry for isolated tests.
-    public static let process = TabDragTransferRegistry()
-
     /// The AppKit pasteboard type that carries opaque tab-drag capabilities.
     public static let pasteboardType = NSPasteboard.PasteboardType(
         UTType.tabTransfer.identifier

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -27,9 +27,9 @@ struct TabDragTransferRegistryTests {
 
     @Test("A registered capability routes across controllers")
     func registeredCapabilityRoutesAcrossControllers() throws {
-        let sourceController = makeController()
-        let targetController = makeController()
-        let registry = sourceController.internalController.tabDragTransferRegistry
+        let registry = TabDragTransferRegistry()
+        let sourceController = makeController(registry: registry)
+        let targetController = makeController(registry: registry)
         let sourcePane = try #require(sourceController.internalController.focusedPane)
         let sourceTab = try #require(sourcePane.selectedTab)
         let targetPane = try #require(targetController.internalController.focusedPane)

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -53,6 +53,17 @@ struct TabDragTransferRegistryTests {
         #expect(receivedRequest?.sourcePaneId == sourcePane.id)
     }
 
+    @Test("Controllers do not share an implicit capability registry")
+    func defaultControllersHaveIsolatedCapabilityRegistries() {
+        let firstController = makeController()
+        let secondController = makeController()
+
+        #expect(
+            firstController.internalController.tabDragTransferRegistry
+                !== secondController.internalController.tabDragTransferRegistry
+        )
+    }
+
     @Test("An unregistered capability is rejected")
     func unregisteredCapabilityIsRejected() throws {
         let registry = TabDragTransferRegistry()


### PR DESCRIPTION
## Summary

- remove the hidden process-wide `TabDragTransferRegistry` singleton
- make default controllers own isolated registries
- expose explicit registry injection for hosts that exchange tabs across controllers

## Testing

- commit `d48c582` adds the regression test first and demonstrates that default controllers incorrectly shared process state
- commit `a4f2d28` makes the capability tests pass with explicit sharing and default isolation

Parent fix: manaflow-ai/cmux#9787
Issue: manaflow-ai/cmux#9521

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788827793&installation_model_id=21920&pr_number=209&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F209&signature=328f8ac9f5dc9a7d17a5b76209606ca5f3f684a2a74393c366df0d45b0eadc40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the hidden process-wide tab drag registry and isolates controllers by default. Adds an initializer to share a registry when controllers need to exchange tabs (fixes manaflow-ai/cmux#9521).

- **Refactors**
  - Removed `TabDragTransferRegistry.process`.
  - `SplitViewController` now creates a fresh `TabDragTransferRegistry` by default.
  - Added `BonsplitController(configuration:tabDragTransferRegistry:)` for explicit registry sharing.

- **Migration**
  - For cross-controller tab exchange, create one `TabDragTransferRegistry()` and pass it to each controller via `BonsplitController(configuration:tabDragTransferRegistry:)`.
  - Keep using `BonsplitController(configuration:)` for isolated controllers.
  - Replace any `.process` references with an explicit `TabDragTransferRegistry()` instance.

<sup>Written for commit a4f2d28103cfb749a941c5de9219b21839f67764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Controllers can now explicitly share a tab-drag transfer registry for coordinated drag-and-drop across controllers.
  * Default controllers use isolated tab-drag capabilities automatically.
  * Registry instances remain publicly constructible for customized sharing.

* **Bug Fixes**
  * Prevented unintended process-wide sharing of tab-drag transfer capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->