### PR TITLE
feat: per-tab custom color marker and context-menu actions

### DIFF
--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -30,6 +30,7 @@ struct TabItem: Identifiable, Hashable, Codable {
     /// consumer-defined meaning, e.g. a browser page playing sound).
     var isAudioPlaying: Bool
     var isPinned: Bool
+    var customColor: String?
     var showsRemoteIndicator: Bool
 
     init(
@@ -46,6 +47,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         isAudioMuted: Bool = false,
         isAudioPlaying: Bool = false,
         isPinned: Bool = false,
+        customColor: String? = nil,
         showsRemoteIndicator: Bool = false
     ) {
         self.id = id
@@ -61,6 +63,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.isAudioMuted = isAudioMuted
         self.isAudioPlaying = isAudioPlaying
         self.isPinned = isPinned
+        self.customColor = customColor
         self.showsRemoteIndicator = showsRemoteIndicator
     }
 
@@ -86,6 +89,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         case isAudioMuted
         case isAudioPlaying
         case isPinned
+        case customColor
         case showsRemoteIndicator
     }
 
@@ -104,6 +108,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         self.isAudioMuted = try c.decodeIfPresent(Bool.self, forKey: .isAudioMuted) ?? false
         self.isAudioPlaying = try c.decodeIfPresent(Bool.self, forKey: .isAudioPlaying) ?? false
         self.isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
+        self.customColor = try c.decodeIfPresent(String.self, forKey: .customColor)
         self.showsRemoteIndicator = try c.decodeIfPresent(Bool.self, forKey: .showsRemoteIndicator) ?? false
     }
 
@@ -122,6 +127,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         try c.encode(isAudioMuted, forKey: .isAudioMuted)
         try c.encode(isAudioPlaying, forKey: .isAudioPlaying)
         try c.encode(isPinned, forKey: .isPinned)
+        try c.encodeIfPresent(customColor, forKey: .customColor)
         try c.encode(showsRemoteIndicator, forKey: .showsRemoteIndicator)
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -685,6 +685,7 @@ struct TabContextMenuState {
     let isAudioMuted: Bool
     let isTerminal: Bool
     let hasCustomTitle: Bool
+    let hasCustomColor: Bool
     let canCloseToLeft: Bool
     let canCloseToRight: Bool
     let canCloseOthers: Bool
@@ -713,6 +714,7 @@ struct TabContextMenuState {
         isAudioMuted: Bool,
         isTerminal: Bool,
         hasCustomTitle: Bool,
+        hasCustomColor: Bool = false,
         canCloseToLeft: Bool,
         canCloseToRight: Bool,
         canCloseOthers: Bool,
@@ -732,6 +734,7 @@ struct TabContextMenuState {
         self.isAudioMuted = isAudioMuted
         self.isTerminal = isTerminal
         self.hasCustomTitle = hasCustomTitle
+        self.hasCustomColor = hasCustomColor
         self.canCloseToLeft = canCloseToLeft
         self.canCloseToRight = canCloseToRight
         self.canCloseOthers = canCloseOthers
@@ -774,6 +777,7 @@ struct TabContextMenuState {
             isAudioMuted: tab.isAudioMuted,
             isTerminal: tab.kind == "terminal",
             hasCustomTitle: tab.hasCustomTitle,
+            hasCustomColor: tab.customColor != nil,
             canCloseToLeft: canCloseToLeft,
             canCloseToRight: canCloseToRight,
             canCloseOthers: canCloseOthers,

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -533,6 +533,14 @@ struct TabItemView: View {
         HStack(spacing: 0) {
             // Icon + title block uses the standard spacing, but keep the close affordance tight.
             HStack(spacing: scaledContentSpacing) {
+                if let color = customColorMarker {
+                    Circle()
+                        .fill(color)
+                        .frame(width: 7, height: 7)
+                        .overlay(Circle().stroke(.primary.opacity(0.22), lineWidth: 0.5))
+                        .accessibilityHidden(true)
+                }
+
                 leadingIcon
 
                 Text(tab.title)
@@ -858,6 +866,17 @@ struct TabItemView: View {
     /// Spacing between the leading icon and the title, scaled to the font.
     private var scaledContentSpacing: CGFloat {
         TabBarMetrics.contentSpacing * fontScale
+    }
+
+    private var customColorMarker: Color? {
+        guard let raw = tab.customColor else { return nil }
+        let body = raw.hasPrefix("#") ? String(raw.dropFirst()) : raw
+        guard body.count == 6, let value = UInt64(body, radix: 16) else { return nil }
+        return Color(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
     }
 
     private func glyphSize(for iconName: String) -> CGFloat {
@@ -1387,6 +1406,23 @@ enum TabContextMenuBuilder {
             )
         }
 
+        addAction(
+            title: localized("tabContext.setTabColor", defaultValue: "Set Tab Color…"),
+            action: .setColor,
+            state: state,
+            target: target,
+            to: menu
+        )
+        if state.hasCustomColor {
+            addAction(
+                title: localized("tabContext.clearTabColor", defaultValue: "Clear Tab Color"),
+                action: .clearColor,
+                state: state,
+                target: target,
+                to: menu
+            )
+        }
+
         menu.addItem(.separator())
 
         addAction(
@@ -1759,6 +1795,8 @@ enum TabContextMenuBuilder {
              .moveToNewWorkspace,
              .moveToLeftPane,
              .moveToRightPane,
+             .setColor,
+             .clearColor,
              .newTerminalToRight,
              .newBrowserToRight,
              .reload,

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -215,6 +215,7 @@ public final class BonsplitController {
         isAudioMuted: Bool = false,
         isAudioPlaying: Bool = false,
         isPinned: Bool = false,
+        customColor: String? = nil,
         showsRemoteIndicator: Bool = false,
         inPane pane: PaneID? = nil
     ) -> TabID? {
@@ -233,6 +234,7 @@ public final class BonsplitController {
             isAudioMuted: isAudioMuted,
             isAudioPlaying: isAudioPlaying,
             isPinned: isPinned,
+            customColor: customColor,
             showsRemoteIndicator: showsRemoteIndicator
         )
         let targetPane = pane ?? focusedPaneId ?? PaneID(id: internalController.rootNode.allPaneIds.first!.id)
@@ -274,6 +276,7 @@ public final class BonsplitController {
             isAudioMuted: isAudioMuted,
             isAudioPlaying: isAudioPlaying,
             isPinned: isPinned,
+            customColor: customColor,
             showsRemoteIndicator: showsRemoteIndicator
         )
         internalController.addTab(tabItem, toPane: PaneID(id: targetPane.id), atIndex: insertIndex)
@@ -341,6 +344,7 @@ public final class BonsplitController {
         isAudioMuted: Bool? = nil,
         isAudioPlaying: Bool? = nil,
         isPinned: Bool? = nil,
+        customColor: String?? = nil,
         showsRemoteIndicator: Bool? = nil
     ) {
         guard let (pane, tabIndex) = findTabInternal(tabId) else { return }
@@ -358,6 +362,7 @@ public final class BonsplitController {
             isAudioMuted.map { currentTab.isAudioMuted != $0 } ?? false ||
             isAudioPlaying.map { currentTab.isAudioPlaying != $0 } ?? false ||
             isPinned.map { currentTab.isPinned != $0 } ?? false ||
+            customColor.map { currentTab.customColor != $0 } ?? false ||
             showsRemoteIndicator.map { currentTab.showsRemoteIndicator != $0 } ?? false
         guard didChange else { return }
 
@@ -396,6 +401,9 @@ public final class BonsplitController {
         }
         if let isPinned = isPinned {
             pane.tabs[tabIndex].isPinned = isPinned
+        }
+        if let customColor = customColor {
+            pane.tabs[tabIndex].customColor = customColor
         }
         if let showsRemoteIndicator = showsRemoteIndicator {
             pane.tabs[tabIndex].showsRemoteIndicator = showsRemoteIndicator
@@ -572,6 +580,7 @@ public final class BonsplitController {
                 isAudioMuted: tab.isAudioMuted,
                 isAudioPlaying: tab.isAudioPlaying,
                 isPinned: tab.isPinned,
+                customColor: tab.customColor,
                 showsRemoteIndicator: tab.showsRemoteIndicator
             )
         } else {
@@ -641,6 +650,7 @@ public final class BonsplitController {
             isAudioMuted: tab.isAudioMuted,
             isAudioPlaying: tab.isAudioPlaying,
             isPinned: tab.isPinned,
+            customColor: tab.customColor,
             showsRemoteIndicator: tab.showsRemoteIndicator
         )
 

--- a/Sources/Bonsplit/Public/Types/Tab.swift
+++ b/Sources/Bonsplit/Public/Types/Tab.swift
@@ -24,6 +24,8 @@ public struct Tab: Identifiable, Hashable, Sendable {
     public let isAudioPlaying: Bool
     /// Whether the tab is pinned in its pane.
     public let isPinned: Bool
+    /// Optional `#RRGGBB` color rendered as a leading tab marker.
+    public let customColor: String?
     /// Whether the tab should show a remote-connection indicator (library consumer-defined meaning, e.g. SSH).
     public let showsRemoteIndicator: Bool
 
@@ -41,6 +43,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         isAudioMuted: Bool = false,
         isAudioPlaying: Bool = false,
         isPinned: Bool = false,
+        customColor: String? = nil,
         showsRemoteIndicator: Bool = false
     ) {
         self.id = id
@@ -56,6 +59,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.isAudioMuted = isAudioMuted
         self.isAudioPlaying = isAudioPlaying
         self.isPinned = isPinned
+        self.customColor = customColor
         self.showsRemoteIndicator = showsRemoteIndicator
     }
 
@@ -73,6 +77,7 @@ public struct Tab: Identifiable, Hashable, Sendable {
         self.isAudioMuted = tabItem.isAudioMuted
         self.isAudioPlaying = tabItem.isAudioPlaying
         self.isPinned = tabItem.isPinned
+        self.customColor = tabItem.customColor
         self.showsRemoteIndicator = tabItem.showsRemoteIndicator
     }
 }

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -11,6 +11,8 @@ public enum TabContextForkConversationAvailability: Sendable {
 public enum TabContextAction: String, CaseIterable, Sendable {
     case rename
     case clearName
+    case setColor
+    case clearColor
     case copyIdentifiers
     case closeToLeft
     case closeToRight

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -5,6 +5,8 @@
 "command.moveTabToRightPane.title" = "Move to Right Pane";
 "tabContext.renameTab" = "Rename Tab…";
 "tabContext.removeCustomTabName" = "Remove Custom Tab Name";
+"tabContext.setTabColor" = "Set Tab Color…";
+"tabContext.clearTabColor" = "Clear Tab Color";
 "tabContext.closeTabsToLeft" = "Close Tabs to Left";
 "tabContext.closeTabsToRight" = "Close Tabs to Right";
 "tabContext.closeOtherTabs" = "Close Other Tabs";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -5,6 +5,8 @@
 "command.moveTabToRightPane.title" = "右のペインへ移動";
 "tabContext.renameTab" = "タブ名を変更…";
 "tabContext.removeCustomTabName" = "カスタムタブ名を削除";
+"tabContext.setTabColor" = "タブの色を設定…";
+"tabContext.clearTabColor" = "タブの色をクリア";
 "tabContext.closeTabsToLeft" = "左側のタブを閉じる";
 "tabContext.closeTabsToRight" = "右側のタブを閉じる";
 "tabContext.closeOtherTabs" = "他のタブを閉じる";


### PR DESCRIPTION
Adds an optional `customColor` (`#RRGGBB`) to `Tab`/`TabItem`, persisted via Codable, rendered as a small leading circle marker in `TabItemView`, with **Set Tab Color…** / **Clear Tab Color** context-menu actions (en/ja localized) routed through `TabContextAction` for the host app to handle.

All additions are backward compatible (defaulted parameters, optional field, `decodeIfPresent`).

Companion to the cmux surface-tab-colors PR (iTerm2-style per-surface-tab colors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788916763&installation_model_id=21920&pr_number=210&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F210&signature=1cbee5074c2b452808c1d3ae62c57314bc9563664422e67d86e8ee509e7e2623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-tab custom color markers and context menu actions to set or clear them. Tabs can now display a small leading color dot, stored as an optional `#RRGGBB` string.

- New Features
  - Optional `Tab.customColor: String?` (`#RRGGBB`), persisted via `Codable`.
  - Renders a small leading circle in `TabItemView` when set.
  - Context menu: “Set Tab Color…” and “Clear Tab Color” (en/ja), exposed as `TabContextAction.setColor` and `.clearColor`.
  - `BonsplitController` supports `customColor` on create/add, and update (including clearing).

- Migration
  - Backward compatible; no changes needed if you don’t use colors.
  - Handle `TabContextAction.setColor` / `.clearColor` in your host app and call `updateTab`.
  - To clear via API: call `updateTab(..., customColor: .some(nil))`.

<sup>Written for commit 60b245e026ede8a95e5686387b30828f9e437064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom colors for tabs.
  * Set a tab color from its context menu and clear it when needed.
  * Tabs with custom colors now display a visual color marker.
  * Custom tab colors are preserved when creating, updating, and restoring tabs.
  * Added English and Japanese translations for color actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->