### PR TITLE
Label split action buttons for accessibility

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1524,9 +1524,11 @@ struct TabBarView: View {
         HStack(spacing: TabBarStyling.splitButtonsSpacing) {
             ForEach(buttons.indices, id: \.self) { index in
                 let button = buttons[index]
+                let tooltip = splitActionButtonTooltip(button, tooltips: tooltips)
                 splitActionButton(button, tooltips: tooltips)
-                .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
-                .safeHelp(splitActionButtonTooltip(button, tooltips: tooltips))
+                    .accessibilityIdentifier(splitActionButtonAccessibilityIdentifier(button))
+                    .accessibilityLabel(tooltip)
+                    .safeHelp(tooltip)
             }
         }
         .padding(.leading, TabBarStyling.splitButtonsLeadingPadding)
@@ -1551,7 +1553,6 @@ struct TabBarView: View {
                     }
                 )
                 .accessibilityElement(children: .ignore)
-                .accessibilityLabel(splitActionButtonTooltip(button, tooltips: tooltips))
                 .accessibilityAddTraits(.isButton)
         } else {
             Button {


### PR DESCRIPTION
## Summary
- apply the resolved split-action tooltip as the shared accessibility label
- cover both normal Button and mouse-down activation paths from one modifier site

## Testing
- `swift test --package-path vendor/bonsplit` compiled and ran 208 tests
- 206 passed; existing `testTrailingTabBarChromeDropDestinationStaysOffTabPixels` failed two geometry assertions
- actual cmux accessibility verification follows in the parent tagged build

## Test limitation
A focused in-process SwiftUI accessibility-tree test was attempted, but SwiftPM test runners are not Accessibility-trusted (`AXError -25208`) and `NSHostingView` does not expose SwiftUI semantic children internally. The permission-dependent harness was removed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788927802&installation_model_id=21920&pr_number=211&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F211&signature=c0772f48b7d8f96cdab340f9dd2cb0aa10ddafb506db0eb8a8165b751eafe3e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a single, clear accessibility label on split action buttons using the existing tooltip, so screen readers announce actions consistently across interaction paths. Centralizes the label and help text to avoid duplicate or missing announcements.

- **Bug Fixes**
  - Use the tooltip as the shared accessibility label and help text for split action buttons.
  - Apply from one modifier site to cover both standard button taps and the mouse-down path.
  - Keep identifiers and button traits; ignore child elements to prevent duplicate reads.

<sup>Written for commit 8230030608931784878dc46b8b8581756e7a2d69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved split-button tooltips for more consistent accessibility labels and help text.
  * Removed a duplicate accessibility label to prevent redundant announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->