### PR TITLE
Preserve focus when closing an unfocused pane

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -417,6 +417,7 @@ final class SplitViewController {
     func closePane(_ paneId: PaneID) {
         // Don't close the last pane
         guard paneStatesById.count > 1, paneStatesById[paneId] != nil else { return }
+        let shouldFocusSibling = focusedPaneId == paneId || focusedPaneId == nil
 
         let (newRoot, siblingPaneId) = closePaneRecursively(node: rootNode, targetPaneId: paneId)
 
@@ -425,11 +426,12 @@ final class SplitViewController {
         }
         unregisterPane(paneId)
 
-        // Focus the sibling or first available pane
-        if let siblingPaneId {
-            focusedPaneId = siblingPaneId
-        } else if let firstPane = rootNode.allPaneIds.first {
-            focusedPaneId = firstPane
+        // Only the pane that owned focus may transfer it to its sibling. Repair a
+        // stale focus independently so an unrelated close cannot choose its target.
+        if shouldFocusSibling {
+            focusedPaneId = siblingPaneId ?? rootNode.allPaneIds.first
+        } else if focusedPane == nil {
+            focusedPaneId = rootNode.allPaneIds.first
         }
 
         if let zoomedPaneId, paneStatesById[zoomedPaneId] == nil {

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1687,6 +1687,85 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testClosePanePreservesFocusOnSurvivingPane() {
+        let controller = SplitViewController()
+        let firstPane = controller.focusedPane!
+
+        controller.splitPaneWithTab(
+            firstPane.id,
+            orientation: .horizontal,
+            tab: TabItem(title: "Second"),
+            insertFirst: false
+        )
+        let secondPane = controller.focusedPane!
+        controller.splitPaneWithTab(
+            secondPane.id,
+            orientation: .vertical,
+            tab: TabItem(title: "Third"),
+            insertFirst: false
+        )
+        let focusedPane = controller.focusedPane!
+
+        controller.closePane(firstPane.id)
+
+        XCTAssertEqual(
+            controller.focusedPaneId,
+            focusedPane.id,
+            "Closing an unfocused pane must not change a valid surviving focus"
+        )
+    }
+
+    @MainActor
+    func testCloseFocusedPaneMovesFocusToSibling() {
+        let controller = SplitViewController()
+        let firstPane = controller.focusedPane!
+        controller.splitPaneWithTab(
+            firstPane.id,
+            orientation: .horizontal,
+            tab: TabItem(title: "Second"),
+            insertFirst: false
+        )
+        let focusedPane = controller.focusedPane!
+
+        controller.closePane(focusedPane.id)
+
+        XCTAssertEqual(
+            controller.focusedPaneId,
+            firstPane.id,
+            "Closing the focused pane should transfer focus to its sibling"
+        )
+    }
+
+    @MainActor
+    func testClosePaneRepairsStaleFocus() {
+        let controller = SplitViewController()
+        let firstPane = controller.focusedPane!
+        controller.splitPaneWithTab(
+            firstPane.id,
+            orientation: .horizontal,
+            tab: TabItem(title: "Second"),
+            insertFirst: false
+        )
+        let secondPane = controller.focusedPane!
+        controller.splitPaneWithTab(
+            secondPane.id,
+            orientation: .vertical,
+            tab: TabItem(title: "Third"),
+            insertFirst: false
+        )
+        let closingPane = controller.focusedPane!
+        controller.focusedPaneId = PaneID()
+
+        controller.closePane(closingPane.id)
+
+        XCTAssertEqual(
+            controller.focusedPaneId,
+            firstPane.id,
+            "Closing a pane should repair a focus reference that no longer names a live pane"
+        )
+    }
+
+    @MainActor
     func testBeginTabDragTracksStateAndCancelClearsMatchingGeneration() {
         let controller = SplitViewController()
         let pane = controller.focusedPane!

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1737,6 +1737,28 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testClosePaneWithNoFocusMovesFocusToSibling() {
+        let controller = SplitViewController()
+        let firstPane = controller.focusedPane!
+        controller.splitPaneWithTab(
+            firstPane.id,
+            orientation: .horizontal,
+            tab: TabItem(title: "Second"),
+            insertFirst: false
+        )
+        let closingPane = controller.focusedPane!
+        controller.focusedPaneId = nil
+
+        controller.closePane(closingPane.id)
+
+        XCTAssertEqual(
+            controller.focusedPaneId,
+            firstPane.id,
+            "Closing a pane with no current focus should adopt its sibling"
+        )
+    }
+
+    @MainActor
     func testClosePaneRepairsStaleFocus() {
         let controller = SplitViewController()
         let firstPane = controller.focusedPane!


### PR DESCRIPTION
## Summary

- preserve a valid surviving pane focus when a different pane closes
- transfer focus to the sibling only when the closing pane owned focus or focus was absent
- repair stale focus references to the first surviving pane
- add regression coverage as a separate failing-test commit, plus explicit nil-focus coverage

## Commits

- regression-test commit: `521cf5b`
- fix commit: `c37440b`
- nil-focus coverage: `2270bac`

## Testing

- `arch -arm64 /usr/bin/swift test --filter BonsplitTests.testClose` (5 tests passed)
- `arch -arm64 /usr/bin/swift test --skip BonsplitTests.testTrailingTabBarChromeDropDestinationStaysOffTabPixels` (211 XCTest cases and 1 Swift Testing case passed)
- the skipped test is unchanged from the cmux-pinned `1031b686` baseline and fails on this macOS 26 host; pull-request CI runs the complete suite on the repository runner
- verified the test-only commit fails for both unrelated-pane focus preservation and stale-focus repair before the fix

Fixes the Bonsplit root cause of https://github.com/manaflow-ai/cmux/issues/9797.