### PR TITLE
Fix tab drag never starting on second-click presses

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -1962,7 +1962,7 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
     typealias BeginTabDrag = @MainActor (
         _ tabId: UUID,
         _ sourceView: NSView,
-        _ mouseDownEvent: NSEvent,
+        _ dragEvent: NSEvent,
         _ draggingFrame: NSRect,
         _ dragImage: NSImage
     ) -> Bool
@@ -1997,7 +1997,6 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
     final class TabBarBackgroundNSView: NSView, BonsplitTabItemHitRegionProviding {
         private struct PendingTabDrag {
             let tabId: UUID
-            let mouseDownEvent: NSEvent
             let startPoint: NSPoint
             let frame: NSRect
         }
@@ -2179,8 +2178,12 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
 
         private func trackTabMouseDown(_ event: NSEvent) {
             pendingTabDrag = nil
-            guard event.clickCount == 1,
-                  !event.modifierFlags.contains(.control),
+            // Accept any clickCount: AppKit keeps counting presses that land
+            // near the same point inside the double-click interval, so the
+            // common "click to select, then drag" flow arrives as clickCount 2.
+            // A stationary double-click is unaffected because the drag only
+            // begins once the pointer crosses the movement threshold.
+            guard !event.modifierFlags.contains(.control),
                   let window,
                   event.windowNumber == window.windowNumber else {
                 return
@@ -2195,7 +2198,6 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
             }
             pendingTabDrag = PendingTabDrag(
                 tabId: tabId,
-                mouseDownEvent: event,
                 startPoint: point,
                 frame: frame
             )
@@ -2216,15 +2218,21 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
             }
             self.pendingTabDrag = nil
 
-            guard let dragImage = dragImage(for: pendingTabDrag.frame),
+            // Focus/hover can reveal an accessory or scroll the strip between
+            // the press and the threshold event. Refresh the source frame so
+            // AppKit's item and the destination's geometry snapshot agree at
+            // the moment the session starts.
+            let draggingFrame = geometryRegistry?.frame(for: pendingTabDrag.tabId, in: self)
+                ?? pendingTabDrag.frame
+            guard let dragImage = dragImage(for: draggingFrame),
                   let onBeginTabDrag else {
                 return event
             }
             _ = onBeginTabDrag(
                 pendingTabDrag.tabId,
                 self,
-                pendingTabDrag.mouseDownEvent,
-                pendingTabDrag.frame,
+                event,
+                draggingFrame,
                 dragImage
             )
             // SwiftUI already received the mouse-down. Forward the threshold-
@@ -2249,6 +2257,11 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
             return image
         }
 
+        /// Returns whether the pointer is over a native control that owns its
+        /// own gesture. SwiftUI renders static tab titles through AppKit text
+        /// controls too; treating every ``NSControl`` as interactive therefore
+        /// made drag arming depend on title width and renderer details. Only
+        /// controls that can actually consume the press veto the tab source.
         private static func isNativeInteraction(
             at windowPoint: NSPoint,
             in window: NSWindow
@@ -2257,7 +2270,19 @@ struct TabBarDragAndHoverView: NSViewRepresentable {
             let contentPoint = contentView.convert(windowPoint, from: nil)
             guard var candidate = contentView.hitTest(contentPoint) else { return false }
             while true {
-                if candidate is NSControl || candidate is NSTextView {
+                if let button = candidate as? NSButton, button.isEnabled {
+                    return true
+                }
+                if let textField = candidate as? NSTextField, textField.isEditable {
+                    return true
+                }
+                if let textView = candidate as? NSTextView, textView.isEditable {
+                    return true
+                }
+                if let control = candidate as? NSControl,
+                   control.isEnabled,
+                   control.target != nil,
+                   control.action != nil {
                     return true
                 }
                 guard let parent = candidate.superview else { return false }

--- a/Tests/BonsplitTests/TabBarDragEventRoutingTests.swift
+++ b/Tests/BonsplitTests/TabBarDragEventRoutingTests.swift
@@ -19,14 +19,16 @@ import Testing
         let tabId = UUID()
         let geometryRegistry = TabBarItemGeometryRegistry()
         var beganTabId: UUID?
+        var beganEvent: NSEvent?
 
         contentView.addSubview(sourceView)
         sourceView.addSubview(tabView)
         geometryRegistry.register(tabView, for: tabId)
         sourceView.geometryRegistry = geometryRegistry
         sourceView.tabIds = [tabId]
-        sourceView.onBeginTabDrag = { tabId, _, _, _, _ in
+        sourceView.onBeginTabDrag = { tabId, _, event, _, _ in
             beganTabId = tabId
+            beganEvent = event
             return true
         }
         window.makeKeyAndOrderFront(nil)
@@ -45,6 +47,102 @@ import Testing
         #expect(sourceView.handleTabDragEvent(mouseDown) === mouseDown)
         #expect(sourceView.handleTabDragEvent(mouseDragged) === mouseDragged)
         #expect(beganTabId == tabId)
+        #expect(beganEvent === mouseDragged)
+    }
+
+    @Test func staticTitleControlDoesNotBlockTabDragArming() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 80),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        let sourceView = TabBarDragAndHoverView.TabBarBackgroundNSView(frame: contentView.bounds)
+        let tabId = UUID()
+        let geometryRegistry = TabBarItemGeometryRegistry()
+        let tabView = NSView(frame: NSRect(x: 20, y: 20, width: 180, height: 30))
+        let title = NSTextField(labelWithString: "A very wide tab title")
+        title.frame = tabView.bounds.insetBy(dx: 8, dy: 4)
+        var began = false
+
+        contentView.addSubview(sourceView)
+        sourceView.addSubview(tabView)
+        tabView.addSubview(title)
+        geometryRegistry.register(tabView, for: tabId)
+        sourceView.geometryRegistry = geometryRegistry
+        sourceView.tabIds = [tabId]
+        sourceView.onBeginTabDrag = { _, _, _, _, _ in
+            began = true
+            return true
+        }
+        window.makeKeyAndOrderFront(nil)
+
+        let mouseDown = try mouseEvent(
+            type: .leftMouseDown,
+            in: sourceView,
+            at: NSPoint(x: 80, y: 35)
+        )
+        let mouseDragged = try mouseEvent(
+            type: .leftMouseDragged,
+            in: sourceView,
+            at: NSPoint(x: 92, y: 35)
+        )
+
+        _ = sourceView.handleTabDragEvent(mouseDown)
+        _ = sourceView.handleTabDragEvent(mouseDragged)
+
+        #expect(began)
+    }
+
+    @Test func actionableButtonKeepsOwnershipOfTabPress() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 80),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        let sourceView = TabBarDragAndHoverView.TabBarBackgroundNSView(frame: contentView.bounds)
+        let tabId = UUID()
+        let geometryRegistry = TabBarItemGeometryRegistry()
+        let tabView = NSView(frame: NSRect(x: 20, y: 20, width: 180, height: 30))
+        let button = NSButton(title: "Close", target: nil, action: nil)
+        button.frame = NSRect(x: 150, y: 4, width: 26, height: 22)
+        var began = false
+
+        contentView.addSubview(sourceView)
+        sourceView.addSubview(tabView)
+        tabView.addSubview(button)
+        geometryRegistry.register(tabView, for: tabId)
+        sourceView.geometryRegistry = geometryRegistry
+        sourceView.tabIds = [tabId]
+        sourceView.onBeginTabDrag = { _, _, _, _, _ in
+            began = true
+            return true
+        }
+        window.makeKeyAndOrderFront(nil)
+
+        let hitPoint = sourceView.convert(NSPoint(x: 183, y: 31), to: nil)
+        #expect(contentView.hitTest(contentView.convert(hitPoint, from: nil)) === button)
+
+        let mouseDown = try mouseEvent(
+            type: .leftMouseDown,
+            in: sourceView,
+            at: NSPoint(x: 183, y: 31)
+        )
+        let mouseDragged = try mouseEvent(
+            type: .leftMouseDragged,
+            in: sourceView,
+            at: NSPoint(x: 195, y: 31)
+        )
+
+        _ = sourceView.handleTabDragEvent(mouseDown)
+        _ = sourceView.handleTabDragEvent(mouseDragged)
+
+        #expect(!began)
     }
 
     private func mouseEvent(

--- a/Tests/BonsplitTests/TabBarDragEventRoutingTests.swift
+++ b/Tests/BonsplitTests/TabBarDragEventRoutingTests.swift
@@ -50,6 +50,55 @@ import Testing
         #expect(beganEvent === mouseDragged)
     }
 
+    @Test func secondClickOfDoubleClickStillArmsTabDrag() throws {
+        // Regression (issue 10033): selecting a tab and immediately dragging it
+        // delivers the press with clickCount == 2, because AppKit keeps counting
+        // clicks that land near the same point inside the double-click interval.
+        // Drag arming must accept those presses or the drag silently never starts.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 80),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let contentView = try #require(window.contentView)
+        let sourceView = TabBarDragAndHoverView.TabBarBackgroundNSView(frame: contentView.bounds)
+        let tabView = NSView(frame: NSRect(x: 20, y: 20, width: 120, height: 30))
+        let tabId = UUID()
+        let geometryRegistry = TabBarItemGeometryRegistry()
+        var beganTabId: UUID?
+
+        contentView.addSubview(sourceView)
+        sourceView.addSubview(tabView)
+        geometryRegistry.register(tabView, for: tabId)
+        sourceView.geometryRegistry = geometryRegistry
+        sourceView.tabIds = [tabId]
+        sourceView.onBeginTabDrag = { tabId, _, _, _, _ in
+            beganTabId = tabId
+            return true
+        }
+        window.makeKeyAndOrderFront(nil)
+
+        let mouseDown = try mouseEvent(
+            type: .leftMouseDown,
+            in: sourceView,
+            at: NSPoint(x: 40, y: 35),
+            clickCount: 2
+        )
+        let mouseDragged = try mouseEvent(
+            type: .leftMouseDragged,
+            in: sourceView,
+            at: NSPoint(x: 50, y: 45),
+            clickCount: 2
+        )
+
+        _ = sourceView.handleTabDragEvent(mouseDown)
+        _ = sourceView.handleTabDragEvent(mouseDragged)
+
+        #expect(beganTabId == tabId)
+    }
+
     @Test func staticTitleControlDoesNotBlockTabDragArming() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 240, height: 80),
@@ -148,7 +197,8 @@ import Testing
     private func mouseEvent(
         type: NSEvent.EventType,
         in view: NSView,
-        at point: NSPoint
+        at point: NSPoint,
+        clickCount: Int = 1
     ) throws -> NSEvent {
         let window = try #require(view.window)
         return try #require(NSEvent.mouseEvent(
@@ -159,7 +209,7 @@ import Testing
             windowNumber: window.windowNumber,
             context: nil,
             eventNumber: 0,
-            clickCount: 1,
+            clickCount: clickCount,
             pressure: 1
         ))
     }


### PR DESCRIPTION
## Problem

Regression from the native tab drag rewrite (`6bee68f`, after cmux 0.64.22): dragging a pane tab sporadically does nothing — no drag image, no session (manaflow-ai/cmux#10033).

Root cause: `trackTabMouseDown` only armed a drag when `event.clickCount == 1`. AppKit increments `clickCount` for any press that lands near the same point inside the double-click interval, so the extremely common flow **click a tab to select it, then press again and drag it** arrives with `clickCount == 2` and the drag was silently never armed. Waiting ~500ms before dragging made it work again, which is why it felt sporadic and why clicking first "fixed" it. The 0.64.22 SwiftUI `.onDrag` path armed on any press.

## Fix

Accept any clickCount when arming a pending tab drag (control-click still excluded for context menus). A stationary double-click is unaffected: the native session only begins after the pointer crosses the 4pt movement threshold.

## Tests

Commit 1 adds `secondClickOfDoubleClickStillArmsTabDrag` (fails on main), commit 2 fixes it. Also carries the prior session's static-title-control coverage. Full suite: 22 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789119882&installation_model_id=21920&pr_number=217&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F217&signature=45ebde2d8a506af7575ab39e56184aae2bb6c85936ce52eb210912c7bfc0226d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where dragging a tab after a quick second click wouldn’t start (fixes `cmux` #10033). Drags now arm on any click count and control hit-testing is tuned so labels don’t block drags while actionable controls keep ownership.

- Bug Fixes
  - Arm tab drags regardless of click count (control-click still excluded); stationary double-clicks remain unaffected by the movement threshold.
  - Recompute the dragging frame and image at threshold to reflect any UI changes before the drag starts.
  - Tighten native-control detection: static labels allow drags; editable/enabled controls keep presses. Begin callback now receives the threshold drag event; tests cover second-click drag, static label, and button ownership.

<sup>Written for commit 7679865adf79e50cafdea9d5be3beb1e11a71e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab dragging for click-then-drag interactions, including double-click-initiated drags.
  * Preserved standard double-click behavior when the tab remains stationary.
  * Improved handling of buttons, text fields, and other interactive controls during tab dragging.
  * Refreshed tab visuals before starting a drag for more accurate drag previews.

* **Tests**
  * Added coverage for double-click dragging, static title controls, actionable buttons, and forwarded drag events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->