### PR TITLE
Finish tab drags without return animation

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -53,11 +53,16 @@ extension SplitViewController {
 
         let draggingItem = NSDraggingItem(pasteboardWriter: registration.pasteboardItem)
         draggingItem.setDraggingFrame(draggingFrame, contents: dragImage)
-        sourceView.beginDraggingSession(
+        let session = sourceView.beginDraggingSession(
             with: [draggingItem],
             event: event,
             source: source
         )
+        // A tab drag is owned by the source lifecycle. Avoid AppKit's return
+        // animation delaying (or suppressing) `endedAt` when the pointer is
+        // released without a valid destination, so transfer state is revoked
+        // immediately and the next tab press can arm normally.
+        session.animatesToStartingPositionsOnCancelOrFail = false
         return true
     }
 


### PR DESCRIPTION
Follow-up to #217 for manaflow-ai/cmux#10033. When a tab drag is released without a valid destination, AppKit's snap-back return animation delays `draggingSession(_:endedAt:)`, which delays revoking the drag transfer state owned by the source lifecycle. Disable `animatesToStartingPositionsOnCancelOrFail` so the session ends immediately and the next tab press arms normally.

(Authored in a concurrent working session on the same checkout; landing it through a PR so the submodule pointer only references bonsplit main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789120093&installation_model_id=21920&pr_number=218&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F218&signature=7b05729e0fabfbfa246ff8b3283a79d68bb59468d3017f31443d1cd453f7e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable AppKit’s snap-back animation for tab drags so the session ends immediately when there’s no valid drop target. This makes `draggingSession(_:endedAt:)` fire right away, revokes the source transfer state promptly, and lets the next tab press arm normally.

<sup>Written for commit 3ffd1cadfb1bcaa09781502b9d37b0b26362108f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

