### PR TITLE
Restore 0.64.22 host drop-target payload contract

### DIFF
--- a/Sources/Bonsplit/Public/TabDragTransferRegistration.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistration.swift
@@ -21,9 +21,9 @@ public final class TabDragTransferRegistration {
     /// A pasteboard writer for AppKit-native dragging sessions.
     public let pasteboardItem: NSPasteboardItem
 
-    init(token: UUID, pasteboardItem: NSPasteboardItem) {
+    init(token: UUID, capabilityValue: String, pasteboardItem: NSPasteboardItem) {
         self.token = token
-        self.capabilityValue = token.uuidString
+        self.capabilityValue = capabilityValue
         self.pasteboardItem = pasteboardItem
     }
 

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -34,12 +34,16 @@ public final class TabDragTransferRegistry {
     ) -> TabDragTransferRegistration? {
         compactReleasedRegistrations()
         let token = UUID()
+        guard let capabilityValue = Self.capabilityValue(for: transfer, token: token) else {
+            return nil
+        }
         let item = NSPasteboardItem()
-        guard item.setString(token.uuidString, forType: Self.pasteboardType) else {
+        guard item.setString(capabilityValue, forType: Self.pasteboardType) else {
             return nil
         }
         let registration = TabDragTransferRegistration(
             token: token,
+            capabilityValue: capabilityValue,
             pasteboardItem: item
         )
         transfers[token] = Entry(
@@ -87,7 +91,50 @@ public final class TabDragTransferRegistry {
         guard let value = pasteboard.string(forType: Self.pasteboardType) else {
             return nil
         }
-        return UUID(uuidString: value)
+        if let token = UUID(uuidString: value) {
+            return token
+        }
+        guard let payload = try? JSONDecoder().decode(
+            CapabilityPayload.self,
+            from: Data(value.utf8)
+        ) else {
+            return nil
+        }
+        return payload.token
+    }
+
+    /// The pasteboard payload restores the 0.64.22 host drop-target contract:
+    /// host apps JSON-parse it for `tab.id`, `tab.kind`, `sourcePaneId`, and
+    /// `sourceProcessId` to render pane/browser drop targets, while the
+    /// registry resolves the live capability through the embedded `token`.
+    /// The tab title (and every other tab field) stays off the pasteboard.
+    private struct CapabilityPayload: Codable {
+        struct TabInfo: Codable {
+            let id: UUID
+            let kind: String?
+        }
+
+        let token: UUID
+        let tab: TabInfo
+        let sourcePaneId: UUID
+        let sourceProcessId: Int32
+    }
+
+    private static func capabilityValue(
+        for transfer: TabDragTransfer,
+        token: UUID
+    ) -> String? {
+        let payload = CapabilityPayload(
+            token: token,
+            tab: CapabilityPayload.TabInfo(
+                id: transfer.tab.id.uuid,
+                kind: transfer.tab.kind
+            ),
+            sourcePaneId: transfer.sourcePaneId.id,
+            sourceProcessId: Int32(ProcessInfo.processInfo.processIdentifier)
+        )
+        guard let data = try? JSONEncoder().encode(payload) else { return nil }
+        return String(decoding: data, as: UTF8.self)
     }
 
     private func compactReleasedRegistrations() {

--- a/Tests/BonsplitTests/PublicTabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/PublicTabDragTransferRegistryTests.swift
@@ -25,9 +25,7 @@ struct PublicTabDragTransferRegistryTests {
         let capability = try #require(
             pasteboard.string(forType: TabDragTransferRegistry.pasteboardType)
         )
-        #expect(UUID(uuidString: capability) != nil)
         #expect(!capability.contains(transfer.tab.title))
-        #expect(!capability.contains(transfer.sourcePaneId.id.uuidString))
     }
 
     @Test("Item providers publish the same capability as AppKit pasteboard writers")

--- a/Tests/BonsplitTests/PublicTabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/PublicTabDragTransferRegistryTests.swift
@@ -51,6 +51,46 @@ struct PublicTabDragTransferRegistryTests {
         #expect(registry.resolve(from: pasteboard) == transfer)
     }
 
+    @Test("Pasteboard payload keeps the 0.64.22 host drop-target contract")
+    func pasteboardPayloadRemainsLegacyJSONDecodable() throws {
+        // Regression (manaflow-ai/cmux#10033): host apps resolve pane/browser
+        // drop targets by JSON-parsing the tab-transfer pasteboard payload for
+        // tab.id, tab.kind, sourcePaneId, and sourceProcessId (the 0.64.22
+        // contract). Replacing the payload with a bare token blinded every
+        // host drop overlay: drags rendered but no drop targets appeared.
+        let registry = TabDragTransferRegistry()
+        let tabId = UUID()
+        let paneId = PaneID()
+        let transfer = TabDragTransfer(
+            tab: Tab(id: TabID(uuid: tabId), title: "Private tab title", kind: "terminal"),
+            sourcePaneId: paneId
+        )
+        let registration = try #require(registry.register(transfer))
+        let pasteboard = makePasteboard()
+        #expect(pasteboard.writeObjects([registration.pasteboardItem]))
+
+        let raw = try #require(
+            pasteboard.string(forType: TabDragTransferRegistry.pasteboardType)
+        )
+        let json = try #require(
+            try JSONSerialization.jsonObject(with: Data(raw.utf8)) as? [String: Any]
+        )
+        let tabJSON = try #require(json["tab"] as? [String: Any])
+        #expect((tabJSON["id"] as? String).flatMap(UUID.init(uuidString:)) == tabId)
+        #expect(tabJSON["kind"] as? String == "terminal")
+        #expect(
+            (json["sourcePaneId"] as? String).flatMap(UUID.init(uuidString:)) == paneId.id
+        )
+        #expect(
+            (json["sourceProcessId"] as? NSNumber)?.int32Value
+                == Int32(ProcessInfo.processInfo.processIdentifier)
+        )
+        // The tab title must stay off the pasteboard.
+        #expect(!raw.contains(transfer.tab.title))
+        // The registry still resolves its own capability from the same payload.
+        #expect(registry.resolve(from: pasteboard) == transfer)
+    }
+
     @Test("Ending or releasing a registration makes stale pasteboard data inert")
     func capabilityRequiresLiveRegistration() throws {
         let registry = TabDragTransferRegistry()

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("Native tab drag capabilities")
 @MainActor
 struct TabDragTransferRegistryTests {
-    @Test("Pasteboard publishes only an opaque capability")
+    @Test("Pasteboard payload keeps tab titles private")
     func pasteboardDoesNotExposeSerializedTabMetadata() throws {
         let registry = TabDragTransferRegistry()
         let controller = makeController(registry: registry)
@@ -20,9 +20,14 @@ struct TabDragTransferRegistryTests {
             registration.pasteboardItem.string(forType: TabDragTransferRegistry.pasteboardType)
         )
 
-        #expect(UUID(uuidString: value) != nil)
+        // Host drop targets parse tab.id / sourcePaneId / sourceProcessId from
+        // the payload (the 0.64.22 contract), but titles and every other tab
+        // field stay off the pasteboard.
         #expect(!value.contains(tab.title))
-        #expect(!value.contains(pane.id.id.uuidString))
+        let payload = try #require(
+            try JSONSerialization.jsonObject(with: Data(value.utf8)) as? [String: Any]
+        )
+        #expect((payload["token"] as? String).flatMap(UUID.init(uuidString:)) != nil)
     }
 
     @Test("A registered capability routes across controllers")


### PR DESCRIPTION
## Problem

manaflow-ai/cmux#10033, second half. `33969f2` (keep native tab drag data process-private) replaced the `com.splittabbar.tabtransfer` pasteboard payload with a bare capability token. cmux's pane and browser drop overlays (`PaneDragTransfer`, `BonsplitTabDragPayload`, `BrowserPaneDragTransfer`) resolve drop targets by JSON-parsing that payload — the 0.64.22 contract. With a bare token they decode nothing, so drags render a drag image but **no drop targets ever appear and drops do nothing**.

## Fix

Write the legacy JSON shape back (`tab.id`, `tab.kind`, `sourcePaneId`, `sourceProcessId`) with the capability `token` embedded:

- Host overlays decode drop targets again exactly as in 0.64.22.
- The registry resolves only through the embedded token — released/ended registrations stay inert (existing tests untouched).
- Tab titles and all other tab fields stay off the pasteboard, keeping most of the privacy win.
- Bare-UUID payloads from in-flight drags of older builds still resolve.

## Tests

Commit 1 adds the payload-contract test (mirrors cmux's exact parse; red on main), commit 2 makes it green. Two opacity assertions that codified the broken contract are updated to assert title privacy + token resolvability instead. Full suite: 23 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789121665&installation_model_id=21920&pr_number=219&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F219&signature=7933beb666f826d411bd7d680dc0cb1b4b3ad5f1bb18a045b554660ff66c7d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the 0.64.22 tab drag pasteboard contract so host apps show pane/browser drop targets again. Fixes drags that rendered an image but had no targets or actions.

- **Bug Fixes**
  - Publish a legacy JSON payload on `com.splittabbar.tabtransfer` with `tab.id`, `tab.kind`, `sourcePaneId`, `sourceProcessId`, and an embedded capability `token`.
  - Keep tab titles off the pasteboard; only the fields above are exposed.
  - Resolve capabilities only via the embedded `token`; stale payloads remain inert.
  - Continue to accept bare-UUID payloads from older drags.
  - Add tests that enforce the payload contract and title privacy.

<sup>Written for commit 4e5a3a15670f6656ced202ef8a9bcc7043ef2125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

