### PR TITLE
Keep exactly one pane visually active after tab drops

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
@@ -7,6 +7,7 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
     private let transferRegistration: TabDragTransferRegistration
     private let transferRegistry: TabDragTransferRegistry
     private weak var controller: SplitViewController?
+    private var didFinish = false
 
     init(
         generation: Int,
@@ -18,6 +19,10 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         self.transferRegistration = transferRegistration
         self.transferRegistry = transferRegistry
         self.controller = controller
+        super.init()
+        transferRegistry.attachSourceCompletion(to: transferRegistration) { [weak self] in
+            self?.finishDrag()
+        }
     }
 
     func draggingSession(
@@ -36,6 +41,8 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
     }
 
     func finishDrag() {
+        guard !didFinish else { return }
+        didFinish = true
         transferRegistry.end(transferRegistration)
         controller?.nativeTabDragSessionDidEnd(generation: generation)
     }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -473,6 +473,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 #endif
             }
 
+            controller.tabDragTransferRegistry.finish(from: NSPasteboard(name: .drag))
             return true
         }
 
@@ -491,6 +492,7 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             if handled {
                 dropLifecycle = .idle
                 activeDropZone = nil
+                controller.tabDragTransferRegistry.finish(from: NSPasteboard(name: .drag))
             }
             return handled
         }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -436,7 +436,6 @@ struct UnifiedPaneDropDelegate: DropDelegate {
            let dragSession = controller.tabDragSession {
             dropLifecycle = .idle
             activeDropZone = nil
-            controller.clearTabDragState()
             return performLocalTabDrop(dragSession, zone: zone)
         }
 
@@ -477,16 +476,21 @@ struct UnifiedPaneDropDelegate: DropDelegate {
     ) -> Bool {
         let draggedTab = dragSession.tab
         let sourcePaneId = dragSession.sourcePaneId
+        let handled: Bool
 
         if zone == .center {
             if sourcePaneId != pane.id {
+                var moved = false
                 withTransaction(Transaction(animation: nil)) {
-                    _ = bonsplitController.moveTab(
+                    moved = bonsplitController.moveTab(
                         TabID(id: draggedTab.id),
                         toPane: pane.id,
                         atIndex: nil
                     )
                 }
+                handled = moved
+            } else {
+                handled = true
             }
         } else if let orientation = zone.orientation {
 #if DEBUG
@@ -509,8 +513,13 @@ struct UnifiedPaneDropDelegate: DropDelegate {
                 "newPane=\(newPaneId?.id.uuidString.prefix(5) ?? "nil")"
             )
 #endif
+            handled = newPaneId != nil
+        } else {
+            handled = false
         }
 
+        guard handled else { return false }
+        controller.clearTabDragState()
         controller.tabDragTransferRegistry.finish(from: pasteboard)
         return true
     }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -434,47 +434,10 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             hasLocalTabDrag: controller.tabDragSession != nil
         ),
            let dragSession = controller.tabDragSession {
-            let draggedTab = dragSession.tab
-            let sourcePaneId = dragSession.sourcePaneId
             dropLifecycle = .idle
             activeDropZone = nil
             controller.clearTabDragState()
-
-            if zone == .center {
-                if sourcePaneId != pane.id {
-                    withTransaction(Transaction(animation: nil)) {
-                        _ = bonsplitController.moveTab(
-                            TabID(id: draggedTab.id),
-                            toPane: pane.id,
-                            atIndex: nil
-                        )
-                    }
-                }
-            } else if let orientation = zone.orientation {
-#if DEBUG
-                dlog(
-                    "pane.drop.splitRequest targetPane=\(pane.id.id.uuidString.prefix(5)) " +
-                    "sourcePane=\(sourcePaneId.id.uuidString.prefix(5)) zone=\(zone) " +
-                    "orientation=\(orientation) insertFirst=\(zone.insertsFirst ? 1 : 0) " +
-                    "draggedTab=\(draggedTab.id.uuidString.prefix(5))"
-                )
-#endif
-                let newPaneId = bonsplitController.splitPane(
-                    pane.id,
-                    orientation: orientation,
-                    movingTab: TabID(id: draggedTab.id),
-                    insertFirst: zone.insertsFirst
-                )
-#if DEBUG
-                dlog(
-                    "pane.drop.splitResult targetPane=\(pane.id.id.uuidString.prefix(5)) " +
-                    "newPane=\(newPaneId?.id.uuidString.prefix(5) ?? "nil")"
-                )
-#endif
-            }
-
-            controller.tabDragTransferRegistry.finish(from: NSPasteboard(name: .drag))
-            return true
+            return performLocalTabDrop(dragSession, zone: zone)
         }
 
         if info.hasItemsConforming(to: [.tabTransfer]) {
@@ -504,6 +467,52 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             activeDropZone = nil
         }
         return handled
+    }
+
+    /// Applies a live in-controller tab drop and completes its native source.
+    func performLocalTabDrop(
+        _ dragSession: TabDragSession,
+        zone: DropZone,
+        pasteboard: NSPasteboard = NSPasteboard(name: .drag)
+    ) -> Bool {
+        let draggedTab = dragSession.tab
+        let sourcePaneId = dragSession.sourcePaneId
+
+        if zone == .center {
+            if sourcePaneId != pane.id {
+                withTransaction(Transaction(animation: nil)) {
+                    _ = bonsplitController.moveTab(
+                        TabID(id: draggedTab.id),
+                        toPane: pane.id,
+                        atIndex: nil
+                    )
+                }
+            }
+        } else if let orientation = zone.orientation {
+#if DEBUG
+            dlog(
+                "pane.drop.splitRequest targetPane=\(pane.id.id.uuidString.prefix(5)) " +
+                "sourcePane=\(sourcePaneId.id.uuidString.prefix(5)) zone=\(zone) " +
+                "orientation=\(orientation) insertFirst=\(zone.insertsFirst ? 1 : 0) " +
+                "draggedTab=\(draggedTab.id.uuidString.prefix(5))"
+            )
+#endif
+            let newPaneId = bonsplitController.splitPane(
+                pane.id,
+                orientation: orientation,
+                movingTab: TabID(id: draggedTab.id),
+                insertFirst: zone.insertsFirst
+            )
+#if DEBUG
+            dlog(
+                "pane.drop.splitResult targetPane=\(pane.id.id.uuidString.prefix(5)) " +
+                "newPane=\(newPaneId?.id.uuidString.prefix(5) ?? "nil")"
+            )
+#endif
+        }
+
+        controller.tabDragTransferRegistry.finish(from: pasteboard)
+        return true
     }
 
     func dropEntered(info: DropInfo) {

--- a/Sources/Bonsplit/Internal/Views/TabBarDropHandler.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarDropHandler.swift
@@ -69,7 +69,11 @@ struct TabBarDropHandler {
             return performFileDrop(from: pasteboard, at: targetIndex)
         }
         if hasLiveTabDrag || hasTabTransfer {
-            return performTabDrop(from: pasteboard, at: targetIndex)
+            let handled = performTabDrop(from: pasteboard, at: targetIndex)
+            if handled {
+                splitViewController.tabDragTransferRegistry.finish(from: pasteboard)
+            }
+            return handled
         }
         return false
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -825,13 +825,8 @@ struct TabBarView: View {
         return scrollOffset < tabsWidth - containerWidth
     }
 
-    /// Whether this tab bar should show full saturation (focused or drag source)
-    private var shouldShowFullSaturation: Bool {
-        isFocused || splitViewController.tabDragSession?.sourcePaneId == pane.id
-    }
-
     private var tabBarSaturation: Double {
-        shouldShowFullSaturation ? 1.0 : 0.0
+        isFocused ? 1.0 : 0.0
     }
 
     private var appearance: BonsplitConfiguration.Appearance {

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -13,6 +13,7 @@ public final class TabDragTransferRegistry {
     private final class Entry {
         weak var lifetime: TabDragTransferLifetime?
         let transfer: TabDragTransfer
+        var finishSource: (() -> Void)?
 
         init(lifetime: TabDragTransferLifetime, transfer: TabDragTransfer) {
             self.lifetime = lifetime
@@ -85,6 +86,34 @@ public final class TabDragTransferRegistry {
     public func end(from pasteboard: NSPasteboard) {
         guard let token = token(from: pasteboard) else { return }
         transfers[token] = nil
+    }
+
+    /// Finishes the live drag source represented by an accepted drop.
+    ///
+    /// The capability is revoked before the source callback runs, making this
+    /// safe when AppKit later delivers its native drag-ended callback too.
+    /// Rejected drops must not call this method.
+    ///
+    /// - Parameter pasteboard: The pasteboard presented by the accepted drop.
+    public func finish(from pasteboard: NSPasteboard) {
+        guard let token = token(from: pasteboard),
+              let entry = transfers.removeValue(forKey: token),
+              entry.lifetime != nil else {
+            return
+        }
+        entry.finishSource?()
+    }
+
+    /// Attaches the native source lifecycle to a registered capability.
+    func attachSourceCompletion(
+        to registration: TabDragTransferRegistration,
+        _ completion: @escaping () -> Void
+    ) {
+        guard let entry = transfers[registration.token],
+              entry.lifetime === registration.lifetime else {
+            return
+        }
+        entry.finishSource = completion
     }
 
     private func token(from pasteboard: NSPasteboard) -> UUID? {

--- a/Tests/BonsplitTests/TabActivePaneInvariantTests.swift
+++ b/Tests/BonsplitTests/TabActivePaneInvariantTests.swift
@@ -1,0 +1,89 @@
+import AppKit
+@testable import Bonsplit
+import SwiftUI
+import Testing
+
+@Suite("Active pane chrome")
+@MainActor
+struct TabActivePaneInvariantTests {
+    @Test("Only the focused pane renders active during a tab drag")
+    func onlyFocusedPaneRendersActiveDuringTabDrag() throws {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(appearance: .default)
+        )
+        controller.tabShortcutHintsEnabled = false
+
+        let sourcePane = try #require(controller.internalController.focusedPane)
+        let sourceTab = try #require(sourcePane.selectedTab)
+        let focusedPaneId = try #require(
+            controller.splitPane(sourcePane.id, orientation: .horizontal)
+        )
+        let focusedPane = try #require(
+            controller.internalController.paneState(for: focusedPaneId)
+        )
+        _ = controller.internalController.beginTabDrag(sourceTab, from: sourcePane.id)
+
+        #expect(controller.focusedPaneId == focusedPaneId)
+
+        let sourceColor = try indicatorColor(
+            controller: controller,
+            pane: sourcePane,
+            isFocused: false
+        )
+        let focusedColor = try indicatorColor(
+            controller: controller,
+            pane: focusedPane,
+            isFocused: true
+        )
+
+        #expect(saturation(of: sourceColor) < 0.1)
+        #expect(saturation(of: focusedColor) > 0.4)
+    }
+
+    private func indicatorColor(
+        controller: BonsplitController,
+        pane: PaneState,
+        isFocused: Bool
+    ) throws -> NSColor {
+        let hostingView = NSHostingView(
+            rootView: TabBarView(
+                pane: pane,
+                isFocused: isFocused,
+                showSplitButtons: false
+            )
+            .environment(controller)
+            .environment(controller.internalController)
+        )
+        hostingView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: 160,
+            height: TabBarMetrics.barHeight
+        )
+        hostingView.layoutSubtreeIfNeeded()
+
+        let chrome = try #require(
+            firstDescendant(
+                ofType: TabBarSelectionChromeView.ChromeNSView.self,
+                in: hostingView
+            )
+        )
+        return chrome.indicatorColor
+    }
+
+    private func saturation(of color: NSColor) -> CGFloat {
+        color.usingColorSpace(.deviceRGB)?.saturationComponent ?? 0
+    }
+
+    private func firstDescendant<T: NSView>(ofType type: T.Type, in root: NSView) -> T? {
+        if let match = root as? T {
+            return match
+        }
+        for subview in root.subviews {
+            if let match = firstDescendant(ofType: type, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 @testable import Bonsplit
+import SwiftUI
 import Testing
 
 @Suite("Native tab drag capabilities")
@@ -143,6 +144,58 @@ struct TabDragTransferRegistryTests {
         withExtendedLifetime(source) {}
     }
 
+    @Test("A failed local pane move keeps its native source live")
+    func failedLocalPaneMoveKeepsNativeSourceLive() throws {
+        let fixture = try makeLocalPaneDropFixture()
+        defer { fixture.source.finishDrag() }
+        let delegate = makePaneDropDelegate(
+            controller: fixture.controller,
+            pane: fixture.targetPane
+        )
+        #expect(fixture.controller.closeTab(TabID(id: fixture.dragSession.tab.id)))
+
+        let handled = withExtendedLifetime(fixture.source) {
+            delegate.performLocalTabDrop(
+                fixture.dragSession,
+                zone: .center,
+                pasteboard: fixture.pasteboard
+            )
+        }
+
+        #expect(!handled)
+        #expect(
+            fixture.controller.internalController.tabDragSession?.generation
+                == fixture.dragSession.generation
+        )
+        #expect(fixture.registry.resolve(from: fixture.pasteboard) != nil)
+    }
+
+    @Test("A failed local pane split keeps its native source live")
+    func failedLocalPaneSplitKeepsNativeSourceLive() throws {
+        let fixture = try makeLocalPaneDropFixture()
+        defer { fixture.source.finishDrag() }
+        let delegate = makePaneDropDelegate(
+            controller: fixture.controller,
+            pane: fixture.targetPane
+        )
+        fixture.controller.configuration.allowSplits = false
+
+        let handled = withExtendedLifetime(fixture.source) {
+            delegate.performLocalTabDrop(
+                fixture.dragSession,
+                zone: .left,
+                pasteboard: fixture.pasteboard
+            )
+        }
+
+        #expect(!handled)
+        #expect(
+            fixture.controller.internalController.tabDragSession?.generation
+                == fixture.dragSession.generation
+        )
+        #expect(fixture.registry.resolve(from: fixture.pasteboard) != nil)
+    }
+
     private func makeController(
         registry: TabDragTransferRegistry? = nil
     ) -> BonsplitController {
@@ -171,6 +224,59 @@ struct TabDragTransferRegistryTests {
         )
     }
 
+    private func makePaneDropDelegate(
+        controller: BonsplitController,
+        pane: PaneState
+    ) -> UnifiedPaneDropDelegate {
+        UnifiedPaneDropDelegate(
+            size: CGSize(width: 400, height: 300),
+            pane: pane,
+            controller: controller.internalController,
+            bonsplitController: controller,
+            activeDropZone: .constant(nil),
+            dropLifecycle: .constant(.hovering)
+        )
+    }
+
+    private func makeLocalPaneDropFixture() throws -> LocalPaneDropFixture {
+        let registry = TabDragTransferRegistry()
+        let controller = makeController(registry: registry)
+        let sourcePane = try #require(controller.internalController.focusedPane)
+        let draggedTab = try #require(sourcePane.selectedTab)
+        _ = try #require(controller.createTab(title: "Source survivor", inPane: sourcePane.id))
+        let targetPaneId = try #require(
+            controller.splitPane(sourcePane.id, orientation: .horizontal)
+        )
+        let targetPane = try #require(
+            controller.internalController.paneState(for: targetPaneId)
+        )
+        let generation = controller.internalController.beginTabDrag(
+            draggedTab,
+            from: sourcePane.id
+        )
+        let dragSession = try #require(controller.internalController.tabDragSession)
+        let registration = try #require(
+            registry.register(
+                TabDragTransfer(tab: Tab(from: draggedTab), sourcePaneId: sourcePane.id)
+            )
+        )
+        let source = TabDragSessionSource(
+            generation: generation,
+            transferRegistration: registration,
+            transferRegistry: registry,
+            controller: controller.internalController
+        )
+        let pasteboard = makePasteboard(item: registration.pasteboardItem)
+        return LocalPaneDropFixture(
+            registry: registry,
+            controller: controller,
+            targetPane: targetPane,
+            dragSession: dragSession,
+            source: source,
+            pasteboard: pasteboard
+        )
+    }
+
     private func makePasteboard(item: NSPasteboardItem) -> NSPasteboard {
         let pasteboard = emptyPasteboard()
         #expect(pasteboard.writeObjects([item]))
@@ -194,5 +300,14 @@ struct TabDragTransferRegistryTests {
         )
         pasteboard.clearContents()
         return pasteboard
+    }
+
+    private struct LocalPaneDropFixture {
+        let registry: TabDragTransferRegistry
+        let controller: BonsplitController
+        let targetPane: PaneState
+        let dragSession: TabDragSession
+        let source: TabDragSessionSource
+        let pasteboard: NSPasteboard
     }
 }

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -113,6 +113,36 @@ struct TabDragTransferRegistryTests {
         #expect(handler.operation(for: pasteboard).isEmpty)
     }
 
+    @Test("An accepted cross-controller drop finishes its native source")
+    func acceptedCrossControllerDropFinishesNativeSource() throws {
+        let registry = TabDragTransferRegistry()
+        let sourceController = makeController(registry: registry)
+        let targetController = makeController(registry: registry)
+        let sourcePane = try #require(sourceController.internalController.focusedPane)
+        let sourceTab = try #require(sourcePane.selectedTab)
+        let targetPane = try #require(targetController.internalController.focusedPane)
+        let generation = sourceController.internalController.beginTabDrag(sourceTab, from: sourcePane.id)
+        let registration = try #require(
+            registry.register(
+                TabDragTransfer(tab: Tab(from: sourceTab), sourcePaneId: sourcePane.id)
+            )
+        )
+        let source = TabDragSessionSource(
+            generation: generation,
+            transferRegistration: registration,
+            transferRegistry: registry,
+            controller: sourceController.internalController
+        )
+        let pasteboard = makePasteboard(item: registration.pasteboardItem)
+        let handler = makeHandler(controller: targetController, pane: targetPane)
+        targetController.onExternalTabDrop = { _ in true }
+
+        #expect(handler.performDrop(from: pasteboard, at: 0))
+        #expect(sourceController.internalController.tabDragSession == nil)
+        #expect(handler.operation(for: pasteboard).isEmpty)
+        withExtendedLifetime(source) {}
+    }
+
     private func makeController(
         registry: TabDragTransferRegistry? = nil
     ) -> BonsplitController {


### PR DESCRIPTION
## Summary

- derive active tab-bar saturation only from the focused pane
- synchronously finish the originating native drag when a destination accepts its transfer
- make source completion idempotent so the later AppKit callback is harmless

This fixes the duplicate blue active-pane state seen while dogfooding manaflow-ai/cmux#10033 and cmux PR #10038.

## Regression proof

- b3dfee5 adds the failing behavior tests only
- e52b0ef adds the fix

## Validation

- arch -arm64 swift test --filter TabActivePaneInvariantTests|TabDragTransferRegistryTests
- arch -arm64 swift test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789154718&installation_model_id=21920&pr_number=220&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F220&signature=16d1fed919433b01bdbe48dbcdf1a902e3bb0cb9832b154edffbd53fdd0e8ae1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep exactly one pane visually active during and after tab drops by deriving tab-bar saturation only from focus and finishing the native drag as soon as a destination accepts the transfer. Previously both the source and destination could appear active; now only the focused pane is active, and accepted drops close the source drag without waiting for AppKit.

- Active state: `TabBarView` removes the drag-source check; saturation depends only on focus.
- Drop acceptance: accepted drops (local moves/splits and external) call `TabDragTransferRegistry.finish(from:)`; rejected drops do not. `TabBarDropHandler` and `UnifiedPaneDropDelegate` invoke this on success.
- Local drops: `performLocalTabDrop(...)` centralizes moves/splits and finishes the native drag only if the mutation succeeds; failed moves/splits return false and keep the source drag/session live.
- Source lifecycle: `TabDragSessionSource` attaches a source-completion callback via the registry and guards double-finish.
- Tests: add `TabActivePaneInvariantTests`; extend `TabDragTransferRegistryTests` to cover accepted cross-controller drops finishing the source and failed local pane moves/splits preserving the source.

<sup>Written for commit a58ee1196980b8edb02b19bb04e8c41f62306110. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab drag-and-drop completion for local moves, splits, and external drops.
  * Prevented duplicate drag cleanup and ensured completed transfers are properly closed.
  * Restricted active drag indicators to the focused pane for clearer visual feedback.
* **Tests**
  * Added coverage for cross-pane drag completion, transfer cleanup, and active-pane drag styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->