### PR TITLE
perf: memoize split-button SF Symbol resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   modifier-hold) with its width reserved so the tab never resizes. Pinned terminal (and
   other non-browser) tabs keep their titled layout.
 
+### Fixed
+- Split-button icons no longer re-resolve their SF Symbol on every tab bar body
+  evaluation. `TabBarStyling.splitActionSystemImage(for:)` tested whether a name
+  was a real symbol by allocating an `NSImage` and discarding it, which cost
+  ~27µs per call and ran once per button per evaluation. Results are now
+  memoized by name, which the symbol catalog makes safe: the answer cannot
+  change while the process runs.
+
 ## [1.1.1] - 2025-01-29
 
 ### Fixed

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -170,7 +170,23 @@ enum TabBarStyling {
         )
     }
 
+    /// Resolves a configured split-button icon name to the glyph the tab bar
+    /// should draw.
+    ///
+    /// Memoized, because `splitActionButtonIcon` calls this during every tab
+    /// bar body evaluation, once per split button, and resolving is far more
+    /// expensive than it looks. See ``resolveSplitActionSystemImage(for:)``.
     static func splitActionSystemImage(for name: String) -> SplitActionSystemImage {
+        SplitActionSystemImageCache.shared.image(for: name)
+    }
+
+    /// The uncached resolution.
+    ///
+    /// The only way to ask AppKit whether a name is a real SF Symbol is to load
+    /// the symbol image and throw it away, which walks the symbol catalog and
+    /// builds a representation. The answer cannot change while the process
+    /// runs, so it is worth remembering.
+    static func resolveSplitActionSystemImage(for name: String) -> SplitActionSystemImage {
         if NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil {
             return SplitActionSystemImage(name: name, rotationDegrees: 0, pointSize: 12)
         }
@@ -1754,6 +1770,53 @@ private struct TabBarLayerBackedColor: NSViewRepresentable {
             layer?.isOpaque = color.alphaComponent >= 1
             CATransaction.commit()
         }
+    }
+}
+
+/// Remembers ``TabBarStyling/splitActionSystemImage(for:)`` results by name.
+///
+/// Names come from host configuration, so the live set is a handful of entries
+/// and never turns over. The bound exists so a pathological host cannot grow
+/// this without limit.
+final class SplitActionSystemImageCache {
+    /// The instance the tab bar uses. Tests build their own so they never race
+    /// each other through shared state.
+    static let shared = SplitActionSystemImageCache()
+
+    private static let capacity = 256
+
+    private let lock = NSLock()
+    private var resolved: [String: TabBarStyling.SplitActionSystemImage] = [:]
+    private var resolutions = 0
+
+    init() {}
+
+    func image(for name: String) -> TabBarStyling.SplitActionSystemImage {
+        lock.lock()
+        if let hit = resolved[name] {
+            lock.unlock()
+            return hit
+        }
+        lock.unlock()
+
+        // Resolved outside the lock so a symbol lookup never blocks another
+        // caller. Two threads racing on the same name both resolve and agree.
+        let image = TabBarStyling.resolveSplitActionSystemImage(for: name)
+
+        lock.lock()
+        resolutions += 1
+        if resolved.count < Self.capacity {
+            resolved[name] = image
+        }
+        lock.unlock()
+        return image
+    }
+
+    /// How many times the uncached resolution has run. Tests only.
+    var resolutionCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return resolutions
     }
 }
 

--- a/Tests/BonsplitTests/SplitActionSystemImageCacheTests.swift
+++ b/Tests/BonsplitTests/SplitActionSystemImageCacheTests.swift
@@ -1,0 +1,84 @@
+import AppKit
+@testable import Bonsplit
+import Testing
+
+/// `splitActionButtonIcon` resolves every split button's icon during every tab
+/// bar body evaluation, and resolving asks AppKit whether a name is a real SF
+/// Symbol by loading the symbol image and discarding it. Under an animating tab
+/// title the tab bar re-evaluates ~20 times a second, so the resolution has to
+/// be memoized rather than repeated.
+@Suite("Split action symbol resolution")
+struct SplitActionSystemImageCacheTests {
+    private let names = ["plus", "square.split.2x1", "ellipsis.vertical", "not.a.real.symbol.name"]
+
+    @Test func repeatedLookupsResolveEachNameOnce() {
+        let cache = SplitActionSystemImageCache()
+
+        for _ in 0..<500 {
+            for name in names {
+                _ = cache.image(for: name)
+            }
+        }
+
+        #expect(cache.resolutionCount == names.count)
+    }
+
+    @Test func memoizingDoesNotChangeWhatIsResolved() {
+        let cache = SplitActionSystemImageCache()
+
+        // A real symbol keeps its own name and is drawn upright.
+        let real = cache.image(for: "plus")
+        #expect(real == TabBarStyling.resolveSplitActionSystemImage(for: "plus"))
+        #expect(real.name == "plus")
+        #expect(real.rotationDegrees == 0)
+
+        // `ellipsis.vertical` is not a symbol; it is a rotated `ellipsis`.
+        let rotated = cache.image(for: "ellipsis.vertical")
+        #expect(rotated == TabBarStyling.resolveSplitActionSystemImage(for: "ellipsis.vertical"))
+        #expect(rotated.name == "ellipsis")
+        #expect(rotated.rotationDegrees == 90)
+
+        // Anything else falls back rather than drawing nothing.
+        let unknown = cache.image(for: "not.a.real.symbol.name")
+        #expect(unknown == TabBarStyling.resolveSplitActionSystemImage(for: "not.a.real.symbol.name"))
+        #expect(unknown.name == "questionmark.circle")
+    }
+
+    @Test func theTabBarGoesThroughTheCache() {
+        // Two calls with no cache in between would resolve twice; the point of
+        // the accessor is that the second one costs a dictionary lookup.
+        let before = SplitActionSystemImageCache.shared.resolutionCount
+        for _ in 0..<200 {
+            _ = TabBarStyling.splitActionSystemImage(for: "square.split.2x1")
+        }
+        let resolutions = SplitActionSystemImageCache.shared.resolutionCount - before
+
+        #expect(resolutions <= 1)
+    }
+
+    /// A repeat lookup must not reach AppKit at all. Timed rather than counted
+    /// so the assertion still means something if the cache is later replaced by
+    /// a different mechanism. The bound is loose on purpose: the measured gap is
+    /// two to three orders of magnitude.
+    @Test func cachedLookupsAreOrdersOfMagnitudeCheaper() {
+        let iterations = 2_000
+        let name = "square.split.2x1"
+        let cache = SplitActionSystemImageCache()
+
+        let uncachedStart = ContinuousClock.now
+        for _ in 0..<iterations {
+            _ = TabBarStyling.resolveSplitActionSystemImage(for: name)
+        }
+        let uncached = ContinuousClock.now - uncachedStart
+
+        _ = cache.image(for: name)
+        let cachedStart = ContinuousClock.now
+        for _ in 0..<iterations {
+            _ = cache.image(for: name)
+        }
+        let cached = ContinuousClock.now - cachedStart
+
+        print("[split-action-symbol] \(iterations) lookups: uncached \(uncached), cached \(cached)")
+        #expect(cached < uncached / 10)
+    }
+}

--- a/Tests/BonsplitTests/SplitActionSystemImageCacheTests.swift
+++ b/Tests/BonsplitTests/SplitActionSystemImageCacheTests.swift
@@ -45,15 +45,18 @@ struct SplitActionSystemImageCacheTests {
     }
 
     @Test func theTabBarGoesThroughTheCache() {
-        // Two calls with no cache in between would resolve twice; the point of
-        // the accessor is that the second one costs a dictionary lookup.
+        // A name no other test in this file touches, so the shared cache has
+        // never seen it and the count below is exact. 200 says the accessor
+        // resolves every time; 0 says it went around the cache entirely.
+        let name = "rectangle.split.3x1"
+
         let before = SplitActionSystemImageCache.shared.resolutionCount
         for _ in 0..<200 {
-            _ = TabBarStyling.splitActionSystemImage(for: "square.split.2x1")
+            _ = TabBarStyling.splitActionSystemImage(for: name)
         }
         let resolutions = SplitActionSystemImageCache.shared.resolutionCount - before
 
-        #expect(resolutions <= 1)
+        #expect(resolutions == 1)
     }
 
     /// A repeat lookup must not reach AppKit at all. Timed rather than counted


### PR DESCRIPTION
This takes a symbol-catalog lookup out of the tab bar's render path - 219ms of a 20-second profile, 3.3% of the process's CPU. No behavior change: same glyphs, same sizes, same rotations.

`TabBarStyling.splitActionSystemImage(for:)` decided whether a name was a real SF Symbol by allocating an `NSImage` and discarding it:

```swift
if NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil {
    return SplitActionSystemImage(name: name, rotationDegrees: 0, pointSize: 12)
}
```

`splitActionButtonIcon` calls that once per split button, and `TabBarView.body` calls `splitActionButtonIcon`. So every body evaluation paid one catalog lookup per button.

## What it costs

Instruments Time Profiler, 20 seconds, attached to a host app whose tab titles carry agent spinners. That workload re-evaluates the tab bar about 20 times a second.

| Measurement | Time |
|---|---|
| Total process CPU sampled | 6726 ms (34% of one core) |
| Inside SF Symbol image creation | **219 ms, 3.3% of total** |
| └ `+[NSImage(NSSymbolImages) _imageWithSymbolName:inCatalog:...]` | 140 ms |
| └ `-[_NSSimpleLRUCache objectForKey:creationBlock:]` | 83 ms |

The stack it sits under:

```
TabBarView.splitButtonRow.getter
  TabBarView.splitActionButton(_:tooltips:)
    Button.init(action:label:)
      NSImage.__allocating_init(systemSymbolName:accessibilityDescription:)
        +[NSImage(NSSymbolImages) _imageWithSymbolName:inCatalog:variableValue:]
          -[NSImage bestRepresentationForHints:]
            -[_NSSimpleLRUCache objectForKey:creationBlock:]
```

AppKit already caches symbol images. `_NSSimpleLRUCache` is that cache, and most of the cost here is just getting to it.

## The change

Whether a name is a real SF Symbol is a pure function of the name, and the answer cannot change while the process runs. `SplitActionSystemImageCache` now remembers it, behind an `NSLock`, following `SplitActionButtonImageCache` in the same file. It resolves outside the lock, so a symbol lookup never blocks another caller. Two threads racing on one name both resolve and agree.

Measured over 2000 lookups of the same name:

| Path | Per lookup |
|---|---|
| Uncached | ~27 µs |
| Cached | ~0.1 µs |

The dictionary holds at most 256 entries. Names come from host configuration, so the live set is a handful and never turns over. The bound is there so a pathological host cannot grow it without limit.

## Tests

Four new tests in `SplitActionSystemImageCacheTests`. Each builds its own cache instance instead of reaching for `.shared`, so they do not race each other under parallel execution.

- Repeated lookups of four names resolve exactly four times.
- Memoizing returns what the uncached resolver returns, across all three branches: a real symbol, the rotated `ellipsis.vertical` special case, and the `questionmark.circle` fallback.
- `TabBarStyling.splitActionSystemImage(for:)` goes through the cache rather than around it.
- A repeat lookup costs at least ten times less than resolving. The bound is loose on purpose so the test still means something if the cache gets replaced later. Measured gap is closer to 280x.

Full suite green: 221 XCTest tests and 31 swift-testing tests. The four new ones are the only additions; nothing existing changed.
