### PR TITLE
perf: make TabItem a reference so one title write wakes one tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   modifier-hold) with its width reserved so the tab never resizes. Pinned terminal (and
   other non-browser) tabs keep their titled layout.
 
+### Fixed
+- A tab title change no longer re-renders the whole tab bar. `TabItem` is now a
+  reference type, so writing one tab's title touches that object instead of the
+  `@Observable` `PaneState.tabs` array, and observation delivers the change to
+  the one `TabItemView` that reads the title. Inserting, removing, and moving
+  tabs still publish through `tabs`. Equality and hashing were already by `id`,
+  so identity comparisons are unaffected.
+
 ## [1.1.1] - 2025-01-29
 
 ### Fixed

--- a/Sources/Bonsplit/Internal/Models/TabItem.swift
+++ b/Sources/Bonsplit/Internal/Models/TabItem.swift
@@ -14,7 +14,19 @@ extension UTType {
 }
 
 /// Represents a single tab in a pane's tab bar (internal representation)
-struct TabItem: Identifiable, Hashable, Codable {
+///
+/// A reference type on purpose. `PaneState.tabs` is an `@Observable` property,
+/// so when tabs were values, writing one tab's title wrote the whole array and
+/// invalidated every view that had read it: all of `TabBarView`, not just the
+/// one tab that changed. As references, a per-tab write touches only this
+/// object, and observation delivers it to the `TabItemView` that read the
+/// property. `PaneState.tabs` still changes on insert, remove, and move, which
+/// is what `TabBarView` actually needs to see.
+///
+/// Equality and hashing are by `id`, as they were when this was a struct, so
+/// identity comparisons behave the same.
+@Observable
+final class TabItem: Identifiable, Hashable, Codable {
     let id: UUID
     var title: String
     var hasCustomTitle: Bool
@@ -89,7 +101,7 @@ struct TabItem: Identifiable, Hashable, Codable {
         case showsRemoteIndicator
     }
 
-    init(from decoder: Decoder) throws {
+    required init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try c.decode(UUID.self, forKey: .id)
         self.title = try c.decode(String.self, forKey: .title)

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -362,43 +362,43 @@ public final class BonsplitController {
         guard didChange else { return }
 
         if let title = title {
-            pane.tabs[tabIndex].title = title
+            currentTab.title = title
         }
         if let icon = icon {
-            pane.tabs[tabIndex].icon = icon
+            currentTab.icon = icon
         }
         if let iconImageData = iconImageData {
-            pane.tabs[tabIndex].iconImageData = iconImageData
+            currentTab.iconImageData = iconImageData
         }
         if let iconAsset = iconAsset {
-            pane.tabs[tabIndex].iconAsset = iconAsset
+            currentTab.iconAsset = iconAsset
         }
         if let kind = kind {
-            pane.tabs[tabIndex].kind = kind
+            currentTab.kind = kind
         }
         if let hasCustomTitle = hasCustomTitle {
-            pane.tabs[tabIndex].hasCustomTitle = hasCustomTitle
+            currentTab.hasCustomTitle = hasCustomTitle
         }
         if let isDirty = isDirty {
-            pane.tabs[tabIndex].isDirty = isDirty
+            currentTab.isDirty = isDirty
         }
         if let showsNotificationBadge = showsNotificationBadge {
-            pane.tabs[tabIndex].showsNotificationBadge = showsNotificationBadge
+            currentTab.showsNotificationBadge = showsNotificationBadge
         }
         if let isLoading = isLoading {
-            pane.tabs[tabIndex].isLoading = isLoading
+            currentTab.isLoading = isLoading
         }
         if let isAudioMuted = isAudioMuted {
-            pane.tabs[tabIndex].isAudioMuted = isAudioMuted
+            currentTab.isAudioMuted = isAudioMuted
         }
         if let isAudioPlaying = isAudioPlaying {
-            pane.tabs[tabIndex].isAudioPlaying = isAudioPlaying
+            currentTab.isAudioPlaying = isAudioPlaying
         }
         if let isPinned = isPinned {
-            pane.tabs[tabIndex].isPinned = isPinned
+            currentTab.isPinned = isPinned
         }
         if let showsRemoteIndicator = showsRemoteIndicator {
-            pane.tabs[tabIndex].showsRemoteIndicator = showsRemoteIndicator
+            currentTab.showsRemoteIndicator = showsRemoteIndicator
         }
     }
 

--- a/Tests/BonsplitTests/TabObservationScopeTests.swift
+++ b/Tests/BonsplitTests/TabObservationScopeTests.swift
@@ -1,0 +1,140 @@
+import Observation
+import XCTest
+@testable import Bonsplit
+
+/// `PaneState.tabs` is an `@Observable` property. `TabBarView.body` reads it to
+/// build its `ForEach`, and `TabItemView.body` reads a single tab's `title`.
+///
+/// When `TabItem` was a struct, `tabs[i].title = x` wrote the whole array, so a
+/// title change invalidated everything that had read `tabs`: every tab item, the
+/// scroll content, and the split button row. A host whose tab titles animate
+/// drove that about 20 times a second.
+///
+/// These tests pin who gets woken.
+final class TabObservationScopeTests: XCTestCase {
+    @MainActor
+    func testChangingOneTabTitleDoesNotInvalidateTheTabsArray() throws {
+        let controller = BonsplitController()
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+        let tabId = try XCTUnwrap(controller.createTab(title: "First"))
+
+        // Stand in for TabBarView.body, which reads the array to lay out tabs.
+        var tabsInvalidated = false
+        withObservationTracking {
+            _ = pane.tabs
+        } onChange: {
+            tabsInvalidated = true
+        }
+
+        controller.updateTab(tabId, title: "First (running)")
+
+        XCTAssertFalse(
+            tabsInvalidated,
+            "A title change must not invalidate readers of the tabs array"
+        )
+    }
+
+    @MainActor
+    func testChangingOneTabTitleInvalidatesThatTab() throws {
+        let controller = BonsplitController()
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+        let tabId = try XCTUnwrap(controller.createTab(title: "First"))
+        let tab = try XCTUnwrap(pane.tabs.first { $0.id == tabId.id })
+
+        // Stand in for TabItemView.body, which renders the title.
+        var titleInvalidated = false
+        withObservationTracking {
+            _ = tab.title
+        } onChange: {
+            titleInvalidated = true
+        }
+
+        controller.updateTab(tabId, title: "First (running)")
+
+        XCTAssertTrue(titleInvalidated, "The tab whose title changed must still redraw")
+        XCTAssertEqual(tab.title, "First (running)")
+    }
+
+    @MainActor
+    func testChangingOneTabTitleDoesNotInvalidateItsSiblings() throws {
+        let controller = BonsplitController()
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+        let firstId = try XCTUnwrap(controller.createTab(title: "First"))
+        let secondId = try XCTUnwrap(controller.createTab(title: "Second"))
+        let second = try XCTUnwrap(pane.tabs.first { $0.id == secondId.id })
+
+        var siblingInvalidated = false
+        withObservationTracking {
+            _ = second.title
+        } onChange: {
+            siblingInvalidated = true
+        }
+
+        controller.updateTab(firstId, title: "First (running)")
+
+        XCTAssertFalse(siblingInvalidated, "A sibling tab must not redraw for another tab's title")
+    }
+
+    /// The array must still publish the changes it is the right home for.
+    @MainActor
+    func testAddingATabStillInvalidatesTheTabsArray() throws {
+        let controller = BonsplitController()
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+
+        var tabsInvalidated = false
+        withObservationTracking {
+            _ = pane.tabs
+        } onChange: {
+            tabsInvalidated = true
+        }
+
+        _ = controller.createTab(title: "Second")
+
+        XCTAssertTrue(tabsInvalidated, "Adding a tab changes the layout and must invalidate the array")
+    }
+
+    @MainActor
+    func testRemovingATabStillInvalidatesTheTabsArray() throws {
+        let controller = BonsplitController()
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+        let tabId = try XCTUnwrap(controller.createTab(title: "Second"))
+
+        var tabsInvalidated = false
+        withObservationTracking {
+            _ = pane.tabs
+        } onChange: {
+            tabsInvalidated = true
+        }
+
+        _ = controller.closeTab(tabId)
+
+        XCTAssertTrue(tabsInvalidated, "Removing a tab changes the layout and must invalidate the array")
+    }
+
+    /// A no-op write stays a no-op. `updateTab` guards on `didChange`, and that
+    /// guard is what keeps a terminal re-emitting an unchanged title free.
+    @MainActor
+    func testWritingTheSameTitleWakesNobody() throws {
+        let controller = BonsplitController()
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+        let tabId = try XCTUnwrap(controller.createTab(title: "First"))
+        let tab = try XCTUnwrap(pane.tabs.first { $0.id == tabId.id })
+
+        var titleInvalidated = false
+        withObservationTracking {
+            _ = tab.title
+        } onChange: {
+            titleInvalidated = true
+        }
+
+        controller.updateTab(tabId, title: "First")
+
+        XCTAssertFalse(titleInvalidated)
+    }
+}


### PR DESCRIPTION
A tab title change currently re-renders the whole tab bar. This makes it re-render the one tab that changed.

`PaneState.tabs` is an `@Observable` property and `TabItem` is a value, so this line in `updateTab`:

```swift
pane.tabs[tabIndex].title = title
```

writes the array rather than the element. Observation invalidates every reader of `tabs`, which is all of `TabBarView.body`: `visibleTabEntries`, every `TabItemView`, `tabScrollContent`, and `splitButtonRow`.

Nothing observes the individual tab either. `TabItemView` gets `let tab: TabItem` by value, so the title it renders is a copy and no view is subscribed to it. Redraws happen only because the parent rebuilds.

## What it costs

The host is cmux, where agent tools write a spinner frame into the terminal title. Each frame is a title change. Instruments Time Profiler, 20 seconds, 8 animating tabs:

| Measurement | Value |
|---|---|
| Total process CPU | 6726 ms (34% of one core) |
| SwiftUI graph updates | 65% of it |
| Graph update episodes | 400, about 19.5 per second |
| Median episode | 9 ms on the main thread |
| **Episodes that touched the tab bar** | **294 of 400, 73.5%** |

The sidebar in the same profile is 0.6%, so the tab bar is where the time actually goes.

## The change

`TabItem` becomes an `@Observable final class`, and `updateTab` writes through the reference it already had:

```diff
 let currentTab = pane.tabs[tabIndex]
 ...
-pane.tabs[tabIndex].title = title
+currentTab.title = title
```

`pane.tabs` is now only read there, so readers of the array are not invalidated. Observation delivers the title to the `TabItemView` that reads it, which is the view that has to redraw anyway.

`tabs` still changes on insert, remove, and move. Those change layout, and `TabBarView` does need to see them.

### Why the diff is small

- `TabItem` already declared `==` and `hash(into:)` **by `id` alone**, so identity comparisons behave exactly as before.
- `Codable` was already hand-rolled with explicit `CodingKeys`, `init(from:)`, and `encode(to:)`. Only `required` was added.
- `updateTab` is the only place in the package that writes a tab field, and no local copy of a `TabItem` is mutated anywhere. Nothing depended on value semantics.
- `PaneState` and `BonsplitController` are already `@Observable`, so this brings `TabItem` in line with the models around it.

The whole diff is 35 added lines and 15 removed, most of it the doc comment.

## Tests

Two commits: the first adds the tests and is red, the second makes them green. Check out `24bdd8f` to see them fail.

Red on the first commit:

- `testChangingOneTabTitleDoesNotInvalidateTheTabsArray` - a `withObservationTracking` block reading `pane.tabs`, standing in for `TabBarView.body`, fires on a title change.
- `testChangingOneTabTitleInvalidatesThatTab` - a block reading `tab.title`, standing in for `TabItemView.body`, does not fire, and the tab it was handed still reads the old title.

Green on both commits, so they guard the parts that were already right:

- A sibling tab is not invalidated by another tab's title.
- Adding a tab still invalidates the array.
- Removing a tab still invalidates the array.
- Writing an unchanged title wakes nobody.

Full suite: 227 XCTest and 27 swift-testing tests, no failures, no changes to existing tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789679067&installation_model_id=21920&pr_number=222&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F222&signature=8c9ed8935f2aff9f6f8eb7423e279769fa287757b25f21dd5c472d3f8e44dd38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tab title changes now re-render only the affected tab. Previously, updating `PaneState.tabs[i].title` invalidated the entire `@Observable` array and redrew the whole tab bar.

- Convert `TabItem` to an `@Observable final class` and update `BonsplitController.updateTab` to write through `currentTab` instead of the `tabs` array. Structural changes (insert/remove/move) still publish via `tabs`.
- Keep equality and hashing by `id`; `Codable` remains hand-rolled (adds `required` init). No public API changes.
- Add tests that pin observation scope: array does not invalidate on a title change; only the changed tab’s readers update; array still invalidates on insert/remove; no-op title writes wake nobody.

<sup>Written for commit 89b4c441bc3072c692982210187d910d1831ce7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

