### PR TITLE
Clear residual drag pasteboard when a tab drag session ends

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
@@ -38,6 +38,10 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         operation: NSDragOperation
     ) {
         finishDrag()
+        // The system drag pasteboard advertises this session's transfer type
+        // until another drag replaces it, which keeps host drop-capture
+        // hit-testing armed forever and blocks the next tab drag from starting.
+        transferRegistration.clearResidualCapability(from: NSPasteboard(name: .drag))
     }
 
     func finishDrag() {

--- a/Sources/Bonsplit/Public/TabDragTransferRegistration.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistration.swift
@@ -60,4 +60,21 @@ public final class TabDragTransferRegistration {
             forType: TabDragTransferRegistry.pasteboardType
         )
     }
+
+    /// Clears a pasteboard that still advertises this ended drag's capability.
+    ///
+    /// The system drag pasteboard keeps its last session's types until another
+    /// drag replaces them, so hosts that key hit-testing or drop routing off
+    /// Bonsplit's transfer type would otherwise keep capturing pointer events
+    /// long after the drag ended. A pasteboard carrying any other value — for
+    /// example a newer drag's capability — is left untouched.
+    ///
+    /// - Parameter pasteboard: The pasteboard the ended drag session wrote to.
+    public func clearResidualCapability(from pasteboard: NSPasteboard) {
+        guard pasteboard.string(forType: TabDragTransferRegistry.pasteboardType)
+            == capabilityValue else {
+            return
+        }
+        pasteboard.clearContents()
+    }
 }

--- a/Tests/BonsplitTests/PublicTabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/PublicTabDragTransferRegistryTests.swift
@@ -119,6 +119,45 @@ struct PublicTabDragTransferRegistryTests {
         #expect(registry.resolve(from: pasteboard) == nil)
     }
 
+    @Test("An ended drag clears its residual capability from the pasteboard")
+    func endedDragClearsResidualCapability() throws {
+        let registry = TabDragTransferRegistry()
+        let transfer = TabDragTransfer(
+            tab: Tab(title: "Residual", kind: "markdown"),
+            sourcePaneId: PaneID()
+        )
+        let registration = try #require(registry.register(transfer))
+        let pasteboard = makePasteboard()
+        #expect(registration.write(to: pasteboard))
+
+        registry.end(registration)
+        registration.clearResidualCapability(from: pasteboard)
+
+        #expect(pasteboard.string(forType: TabDragTransferRegistry.pasteboardType) == nil)
+        #expect((pasteboard.types ?? []).isEmpty)
+    }
+
+    @Test("An ended drag never clears a newer drag's pasteboard capability")
+    func endedDragLeavesNewerCapabilityIntact() throws {
+        let registry = TabDragTransferRegistry()
+        let transfer = TabDragTransfer(
+            tab: Tab(title: "Newer", kind: "markdown"),
+            sourcePaneId: PaneID()
+        )
+        let firstRegistration = try #require(registry.register(transfer))
+        let pasteboard = makePasteboard()
+        #expect(firstRegistration.write(to: pasteboard))
+
+        let secondRegistration = try #require(registry.register(transfer))
+        pasteboard.clearContents()
+        #expect(secondRegistration.write(to: pasteboard))
+
+        firstRegistration.clearResidualCapability(from: pasteboard)
+
+        #expect(registry.resolve(from: pasteboard) == transfer)
+        #expect(pasteboard.string(forType: TabDragTransferRegistry.pasteboardType) != nil)
+    }
+
     private func makePasteboard() -> NSPasteboard {
         let pasteboard = NSPasteboard(
             name: NSPasteboard.Name("PublicTabDragTransferRegistryTests.\(UUID().uuidString)")


### PR DESCRIPTION
The system drag pasteboard keeps advertising `com.splittabbar.tabtransfer` after a native tab drag ends, until some other drag replaces it. Hosts (cmux) key drop-capture hit-testing off that type, so one completed or canceled tab drag left every later pointer drag/hover/up event captured by drop-target overlays: subsequent tab drags never armed and pointer routing degraded until an unrelated system drag rewrote the pasteboard. Repro observed in cmux dogfood: with two markdown tabs in one pane, the first drag works and every later tab drag is dead (manaflow-ai/cmux#10200 dogfood follow-up).

- `TabDragTransferRegistration.clearResidualCapability(from:)` (new public API) clears a pasteboard only while it still carries this lease's exact capability value, so a newer drag's contents are never clobbered.
- `TabDragSessionSource` calls it when its native dragging session ends.
- Tests cover both the residual clear and the newer-capability guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789797460&installation_model_id=21920&pr_number=223&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F223&signature=95e38c72b3bb15f113091ea0fcd24bb11ba6dd6c903c0d151f6ab106d60432df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops hosts from capturing pointer events after a tab drag ends by clearing the residual tab-drag type from the system drag pasteboard. Previously the pasteboard kept advertising com.splittabbar.tabtransfer after a drag ended; now we clear it only if it still matches the ended session so newer drags are never clobbered.

- Adds public API `TabDragTransferRegistration.clearResidualCapability(from:)` that clears the pasteboard only when it carries this registration’s capability value.
- `TabDragSessionSource` calls it when the native drag session ends.
- No migration for default Bonsplit tab drag; custom drag sources should call `clearResidualCapability(from:)` on session end.

<sup>Written for commit 2bf8d3891fea71a7af3367ce56f4f3014bea9e78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

