### PR TITLE
Add pane movement to root edges

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -418,6 +418,74 @@ final class SplitViewController {
         return min(max(position, 0), 1)
     }
 
+    /// Moves an existing pane leaf to an edge of the complete split tree.
+    @discardableResult
+    func movePane(
+        _ paneId: PaneID,
+        toRootEdge edge: RootSplitEdge,
+        dividerPosition: CGFloat
+    ) -> Bool {
+        guard paneStatesById.count > 1,
+              let pane = paneStatesById[paneId],
+              !isPaneDirectRootChild(paneId, on: edge),
+              let remainder = removingPane(paneId, from: rootNode) else {
+            return false
+        }
+
+        clearPaneZoom()
+        let movedPane = SplitNode.pane(pane)
+        let splitState = SplitState(
+            orientation: edge.orientation,
+            first: edge.insertsFirst ? movedPane : remainder,
+            second: edge.insertsFirst ? remainder : movedPane,
+            dividerPosition: normalizedInitialDividerPosition(dividerPosition)
+        )
+        rootNode = .split(splitState)
+        focusedPaneId = paneId
+        return true
+    }
+
+    private func isPaneDirectRootChild(
+        _ paneId: PaneID,
+        on edge: RootSplitEdge
+    ) -> Bool {
+        guard case .split(let rootSplit) = rootNode,
+              rootSplit.orientation == edge.orientation else {
+            return false
+        }
+
+        let edgeNode = edge.insertsFirst ? rootSplit.first : rootSplit.second
+        guard case .pane(let pane) = edgeNode else { return false }
+        return pane.id == paneId
+    }
+
+    private func removingPane(
+        _ paneId: PaneID,
+        from node: SplitNode
+    ) -> SplitNode? {
+        switch node {
+        case .pane(let pane):
+            return pane.id == paneId ? nil : node
+
+        case .split(let split):
+            let first = removingPane(paneId, from: split.first)
+            let second = removingPane(paneId, from: split.second)
+
+            switch (first, second) {
+            case (nil, nil):
+                return nil
+            case (nil, let second?):
+                return second
+            case (let first?, nil):
+                return first
+            case (let first?, let second?):
+                split.first = first
+                split.second = second
+                return .split(split)
+            }
+        }
+    }
+
     /// Close a pane and collapse the split
     func closePane(_ paneId: PaneID) {
         // Don't close the last pane

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -479,9 +479,17 @@ final class SplitViewController {
             case (let first?, nil):
                 return first
             case (let first?, let second?):
-                split.first = first
-                split.second = second
-                return .split(split)
+                let rebuilt = SplitState(
+                    id: split.id,
+                    orientation: split.orientation,
+                    first: first,
+                    second: second,
+                    dividerPosition: split.dividerPosition,
+                    animationOrigin: split.animationOrigin
+                )
+                rebuilt.imposedFirstExtent = split.imposedFirstExtent
+                rebuilt.imposedEpoch = split.imposedEpoch
+                return .split(rebuilt)
             }
         }
     }

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -749,6 +749,37 @@ public final class BonsplitController {
         return newPaneId
     }
 
+    /// Moves a pane and all of its tabs to an outer edge of the complete split tree.
+    ///
+    /// The pane retains its identity, selected tab, and tab ownership. Its former
+    /// branch is collapsed, the remaining tree keeps its relative topology, and a
+    /// new root split is created with the configured default divider position.
+    /// Moving the only pane, moving an unknown pane, or moving a pane that already
+    /// spans the requested edge is a no-op.
+    ///
+    /// - Parameters:
+    ///   - paneId: The pane to move.
+    ///   - edge: The outer edge where the pane should become a direct root child.
+    /// - Returns: `true` when the tree changed; otherwise `false`.
+    @discardableResult
+    public func movePane(
+        _ paneId: PaneID,
+        toRootEdge edge: RootSplitEdge
+    ) -> Bool {
+        guard configuration.allowSplits,
+              internalController.movePane(
+                paneId,
+                toRootEdge: edge,
+                dividerPosition: normalizedInitialDividerPosition(nil)
+              ) else {
+            return false
+        }
+
+        delegate?.splitTabBar(self, didFocusPane: paneId)
+        notifyGeometryChange()
+        return true
+    }
+
     /// Close a specific pane
     /// - Parameter paneId: The pane to close
     /// - Returns: true if the pane was closed, false if vetoed by delegate

--- a/Sources/Bonsplit/Public/Types/RootSplitEdge.swift
+++ b/Sources/Bonsplit/Public/Types/RootSplitEdge.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// An outer edge of the complete split tree.
+public enum RootSplitEdge: Sendable, Equatable {
+    /// The full-height leading edge.
+    case left
+    /// The full-height trailing edge.
+    case right
+    /// The full-width top edge.
+    case above
+    /// The full-width bottom edge.
+    case below
+}
+
+extension RootSplitEdge {
+    var orientation: SplitOrientation {
+        switch self {
+        case .left, .right: .horizontal
+        case .above, .below: .vertical
+        }
+    }
+
+    var insertsFirst: Bool {
+        switch self {
+        case .left, .above: true
+        case .right, .below: false
+        }
+    }
+}

--- a/Tests/BonsplitTests/PaneRootEdgeMovementTests.swift
+++ b/Tests/BonsplitTests/PaneRootEdgeMovementTests.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Testing
+@testable import Bonsplit
+
+@Suite("Pane movement to a root edge")
+@MainActor
+struct PaneRootEdgeMovementTests {
+    @Test(
+        "A nested pane becomes the requested root child without losing identity",
+        arguments: [
+            RootSplitEdge.left,
+            RootSplitEdge.right,
+            RootSplitEdge.above,
+            RootSplitEdge.below,
+        ]
+    )
+    func promotesNestedPane(edge: RootSplitEdge) throws {
+        let fixture = try Fixture()
+
+        let moved = fixture.controller.movePane(
+            fixture.targetPaneID,
+            toRootEdge: edge
+        )
+
+        #expect(moved)
+        #expect(fixture.controller.focusedPaneId == fixture.targetPaneID)
+        #expect(fixture.controller.allPaneIds == edge.expectedPaneOrder(
+            remainder: fixture.remainderPaneIDs,
+            moved: fixture.targetPaneID
+        ))
+        #expect(
+            fixture.controller.tabs(inPane: fixture.targetPaneID).map(\.id)
+                == fixture.targetTabIDs
+        )
+        #expect(
+            fixture.controller.selectedTabId(inPane: fixture.targetPaneID)
+                == fixture.selectedTargetTabID
+        )
+        for tabID in fixture.targetTabIDs {
+            #expect(fixture.controller.paneId(containing: tabID) == fixture.targetPaneID)
+        }
+
+        let root = try #require(fixture.controller.treeSnapshot().split)
+        #expect(root.orientation == edge.expectedOrientation)
+        #expect(root.dividerPosition == 0.5)
+        #expect(root.imposedFirstExtent == nil)
+        #expect(root.movedPaneID(on: edge) == fixture.targetPaneID.description)
+
+        let remainder = root.remainder(on: edge)
+        let preservedRoot = try #require(remainder.split)
+        #expect(preservedRoot.id == fixture.remainderRootID)
+        #expect(preservedRoot.dividerPosition == fixture.remainderRootDivider)
+        #expect(remainder.paneIDs == fixture.remainderPaneIDs.map(\.description))
+    }
+
+    @Test("A successful move clears zoom and publishes focus and geometry once")
+    func successfulMovePublishesOnce() throws {
+        let fixture = try Fixture()
+        let delegate = RecordingDelegate()
+        fixture.controller.delegate = delegate
+        #expect(fixture.controller.togglePaneZoom(inPane: fixture.targetPaneID))
+
+        #expect(fixture.controller.movePane(fixture.targetPaneID, toRootEdge: .right))
+
+        #expect(fixture.controller.zoomedPaneId == nil)
+        #expect(delegate.focusedPaneIDs == [fixture.targetPaneID])
+        #expect(delegate.geometryChangeCount == 1)
+    }
+
+    @Test("A pane already spanning the requested edge is a complete no-op")
+    func alreadyAtRequestedEdgeIsNoOp() throws {
+        let controller = BonsplitController()
+        let leftPaneID = try #require(controller.focusedPaneId)
+        let rightPaneID = try #require(
+            controller.splitPane(
+                leftPaneID,
+                orientation: .horizontal,
+                withTab: Tab(title: "Right")
+            )
+        )
+        #expect(controller.togglePaneZoom(inPane: rightPaneID))
+        let treeBefore = controller.treeSnapshot()
+        let delegate = RecordingDelegate()
+        controller.delegate = delegate
+
+        #expect(!controller.movePane(rightPaneID, toRootEdge: .right))
+
+        #expect(controller.treeSnapshot() == treeBefore)
+        #expect(controller.focusedPaneId == rightPaneID)
+        #expect(controller.zoomedPaneId == rightPaneID)
+        #expect(delegate.focusedPaneIDs.isEmpty)
+        #expect(delegate.geometryChangeCount == 0)
+    }
+
+    @Test("A direct root child can move across to the opposite edge")
+    func reordersDirectRootChildren() throws {
+        let controller = BonsplitController()
+        let leftPaneID = try #require(controller.focusedPaneId)
+        let rightPaneID = try #require(
+            controller.splitPane(
+                leftPaneID,
+                orientation: .horizontal,
+                withTab: Tab(title: "Right")
+            )
+        )
+
+        #expect(controller.movePane(leftPaneID, toRootEdge: .right))
+
+        let root = try #require(controller.treeSnapshot().split)
+        #expect(root.first.pane?.id == rightPaneID.description)
+        #expect(root.second.pane?.id == leftPaneID.description)
+        #expect(controller.focusedPaneId == leftPaneID)
+    }
+
+    @Test("Invalid, single-pane, and disabled-split moves do not mutate state")
+    func rejectsUnavailableMoves() throws {
+        let single = BonsplitController()
+        let onlyPaneID = try #require(single.focusedPaneId)
+        let singleTree = single.treeSnapshot()
+        #expect(!single.movePane(onlyPaneID, toRootEdge: .left))
+        #expect(!single.movePane(PaneID(), toRootEdge: .right))
+        #expect(single.treeSnapshot() == singleTree)
+
+        let fixture = try Fixture()
+        let treeBefore = fixture.controller.treeSnapshot()
+        fixture.controller.configuration.allowSplits = false
+        #expect(!fixture.controller.movePane(fixture.targetPaneID, toRootEdge: .above))
+        #expect(fixture.controller.treeSnapshot() == treeBefore)
+    }
+}
+
+@MainActor
+private extension PaneRootEdgeMovementTests {
+    struct Fixture {
+        let controller: BonsplitController
+        let targetPaneID: PaneID
+        let targetTabIDs: [TabID]
+        let selectedTargetTabID: TabID
+        let remainderPaneIDs: [PaneID]
+        let remainderRootID: String
+        let remainderRootDivider: Double
+
+        @MainActor
+        init() throws {
+            let controller = BonsplitController(
+                configuration: BonsplitConfiguration(newTabPosition: .end)
+            )
+            let leftPaneID = try #require(controller.focusedPaneId)
+            let rightTopPaneID = try #require(
+                controller.splitPane(
+                    leftPaneID,
+                    orientation: .horizontal,
+                    withTab: Tab(title: "Right top"),
+                    initialDividerPosition: 0.3
+                )
+            )
+            let targetPaneID = try #require(
+                controller.splitPane(
+                    rightTopPaneID,
+                    orientation: .vertical,
+                    withTab: Tab(title: "Target one"),
+                    initialDividerPosition: 0.7
+                )
+            )
+            let targetTabID = try #require(controller.tabs(inPane: targetPaneID).only?.id)
+            let selectedTargetTabID = try #require(
+                controller.createTab(title: "Target two", inPane: targetPaneID)
+            )
+            controller.selectTab(selectedTargetTabID)
+
+            let originalRoot = try #require(controller.treeSnapshot().split)
+            self.controller = controller
+            self.targetPaneID = targetPaneID
+            self.targetTabIDs = [targetTabID, selectedTargetTabID]
+            self.selectedTargetTabID = selectedTargetTabID
+            self.remainderPaneIDs = [leftPaneID, rightTopPaneID]
+            self.remainderRootID = originalRoot.id
+            self.remainderRootDivider = originalRoot.dividerPosition
+        }
+    }
+}
+
+@MainActor
+private final class RecordingDelegate: BonsplitDelegate {
+    var focusedPaneIDs: [PaneID] = []
+    var geometryChangeCount = 0
+
+    func splitTabBar(
+        _ controller: BonsplitController,
+        didFocusPane pane: PaneID
+    ) {
+        focusedPaneIDs.append(pane)
+    }
+
+    func splitTabBar(
+        _ controller: BonsplitController,
+        didChangeGeometry snapshot: LayoutSnapshot
+    ) {
+        geometryChangeCount += 1
+    }
+}
+
+private extension RootSplitEdge {
+    var expectedOrientation: String {
+        switch self {
+        case .left, .right: "horizontal"
+        case .above, .below: "vertical"
+        }
+    }
+
+    func expectedPaneOrder(
+        remainder: [PaneID],
+        moved: PaneID
+    ) -> [PaneID] {
+        switch self {
+        case .left, .above: [moved] + remainder
+        case .right, .below: remainder + [moved]
+        }
+    }
+}
+
+private extension ExternalTreeNode {
+    var pane: ExternalPaneNode? {
+        guard case .pane(let pane) = self else { return nil }
+        return pane
+    }
+
+    var split: ExternalSplitNode? {
+        guard case .split(let split) = self else { return nil }
+        return split
+    }
+
+    var paneIDs: [String] {
+        switch self {
+        case .pane(let pane): [pane.id]
+        case .split(let split): split.first.paneIDs + split.second.paneIDs
+        }
+    }
+}
+
+private extension ExternalSplitNode {
+    func movedPaneID(on edge: RootSplitEdge) -> String? {
+        switch edge {
+        case .left, .above: first.pane?.id
+        case .right, .below: second.pane?.id
+        }
+    }
+
+    func remainder(on edge: RootSplitEdge) -> ExternalTreeNode {
+        switch edge {
+        case .left, .above: second
+        case .right, .below: first
+        }
+    }
+}
+
+private extension Collection {
+    var only: Element? {
+        count == 1 ? first : nil
+    }
+}

--- a/Tests/BonsplitTests/PaneRootEdgeMovementTests.swift
+++ b/Tests/BonsplitTests/PaneRootEdgeMovementTests.swift
@@ -67,6 +67,21 @@ struct PaneRootEdgeMovementTests {
         #expect(delegate.geometryChangeCount == 1)
     }
 
+    @Test("A move publishes a rebuilt root without mutating the previous tree")
+    func moveDoesNotMutatePreviousTree() throws {
+        let fixture = try Fixture()
+        let previousRoot = try #require(fixture.controller.internalController.rootNode.splitState)
+        let previousFirstID = previousRoot.first.id
+        let previousSecondID = previousRoot.second.id
+        let previousDivider = previousRoot.dividerPosition
+
+        #expect(fixture.controller.movePane(fixture.targetPaneID, toRootEdge: .right))
+
+        #expect(previousRoot.first.id == previousFirstID)
+        #expect(previousRoot.second.id == previousSecondID)
+        #expect(previousRoot.dividerPosition == previousDivider)
+    }
+
     @Test("A pane already spanning the requested edge is a complete no-op")
     func alreadyAtRequestedEdgeIsNoOp() throws {
         let controller = BonsplitController()
@@ -235,6 +250,13 @@ private extension ExternalTreeNode {
         case .pane(let pane): [pane.id]
         case .split(let split): split.first.paneIDs + split.second.paneIDs
         }
+    }
+}
+
+private extension SplitNode {
+    var splitState: SplitState? {
+        guard case .split(let splitState) = self else { return nil }
+        return splitState
     }
 }
 


### PR DESCRIPTION
## Summary

- add a semantic RootSplitEdge interface and one atomic BonsplitController pane move
- preserve pane and tab identity while collapsing the old branch and wrapping the remainder at the requested root edge
- keep exact no-op, zoom, focus, geometry, divider-range, and ownership behavior behind the Bonsplit module seam
- cover all four directions plus invalid, disabled, already-spanning, and direct-root reorder cases

This is the Bonsplit prerequisite for manaflow-ai/cmux#10525.

## Testing

- full Swift package test suite
- 221 XCTest tests and 34 Swift Testing cases passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790322254&installation_model_id=21920&pr_number=224&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F224&signature=986b26249d118a474ac4d32dedca6ca4fc8b1be090fe971f9c922584e3e90e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->