### PR TITLE
Filter modifier-hold tab hints by configured modifier

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -2763,12 +2763,33 @@ enum TabControlShortcutHintPolicy {
         TabControlShortcutSettings.surfaceByNumberShortcut(defaults: defaults).modifierSymbol
     }
 
+    /// The hold monitor recognizes an exact base Command/Control hold. Extra
+    /// Shift/Option modifiers in the configured completion are rendered in the
+    /// hint label, but do not change which hold family reveals the hints.
+    private static func configuredShortcutUsesHeldModifier(
+        _ shortcut: TabControlShortcutStoredShortcut,
+        heldFlags: NSEvent.ModifierFlags
+    ) -> Bool {
+        switch heldFlags {
+        case [.command]:
+            return shortcut.command
+        case [.control]:
+            return shortcut.control
+        default:
+            return false
+        }
+    }
+
     private static func triggerAllowsHintReveal(
         for modifierFlags: NSEvent.ModifierFlags,
         defaults: UserDefaults = .standard
     ) -> Bool {
         let flags = modifierFlags.intersection(.deviceIndependentFlagsMask)
             .subtracting([.numericPad, .function, .capsLock])
+        let shortcut = TabControlShortcutSettings.surfaceByNumberShortcut(defaults: defaults)
+        guard configuredShortcutUsesHeldModifier(shortcut, heldFlags: flags) else {
+            return false
+        }
         switch flags {
         case [.command]:
             return showHintsOnCommandHoldEnabled(defaults: defaults)

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -742,12 +742,12 @@ struct TabItemView: View {
         .onDisappear {
             globeFallbackScheduler.cancel()
         }
-        .onChange(of: tab.isLoading) { _ in updateGlobeFallback() }
-        .onChange(of: tab.iconImageData) { _ in
+        .onChange(of: tab.isLoading) { _, _ in updateGlobeFallback() }
+        .onChange(of: tab.iconImageData) { _, _ in
             updateRenderedFaviconImage()
             updateGlobeFallback()
         }
-        .onChange(of: tab.icon) { _ in updateGlobeFallback() }
+        .onChange(of: tab.icon) { _, _ in updateGlobeFallback() }
     }
 
     /// Small corner badge for icon-only pinned tabs, preserving the audio/unread/

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2934,28 +2934,27 @@ final class BonsplitTests: XCTestCase {
         withShortcutHintDefaultsSuite { defaults in
             defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
             defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
-
-            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
-            XCTAssertEqual(
-                TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
-                "⌃"
-            )
-
-            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
-            defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
-
             defaults.set(
                 shortcutData(
                     key: "1",
                     command: true,
                     shift: false,
                     option: false,
-                    control: false
+                    control: true
                 ),
                 forKey: "shortcut.selectSurfaceByNumber"
             )
 
-            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol, "⌘")
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
+                "⌃⌘"
+            )
+
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
+
+            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol, "⌃⌘")
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
         }
     }

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2855,10 +2855,7 @@ final class BonsplitTests: XCTestCase {
                 TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
                 "⌃"
             )
-            XCTAssertEqual(
-                TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
-                "⌃"
-            )
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
             XCTAssertEqual(
                 TabControlShortcutHintPolicy.configuredShortcutModifierSymbol(defaults: defaults),
                 "⌃"
@@ -2888,10 +2885,48 @@ final class BonsplitTests: XCTestCase {
                 TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
                 "⌥⌘"
             )
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
+        }
+    }
+
+    func testTabControlShortcutHintPolicyFollowsConfiguredCommandOrControlModifier() {
+        withShortcutHintDefaultsSuite { defaults in
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
+
+            defaults.set(
+                shortcutData(
+                    key: "1",
+                    command: true,
+                    shift: false,
+                    option: true,
+                    control: false
+                ),
+                forKey: "shortcut.selectSurfaceByNumber"
+            )
+
             XCTAssertEqual(
-                TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
+                TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
                 "⌥⌘"
             )
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
+
+            defaults.set(
+                shortcutData(
+                    key: "1",
+                    command: false,
+                    shift: true,
+                    option: false,
+                    control: true
+                ),
+                forKey: "shortcut.selectSurfaceByNumber"
+            )
+
+            XCTAssertEqual(
+                TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol,
+                "⌃⇧"
+            )
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
         }
     }
 
@@ -2909,10 +2944,18 @@ final class BonsplitTests: XCTestCase {
             defaults.set(true, forKey: TabControlShortcutHintPolicy.showHintsOnCommandHoldKey)
             defaults.set(false, forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
 
-            XCTAssertEqual(
-                TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol,
-                "⌃"
+            defaults.set(
+                shortcutData(
+                    key: "1",
+                    command: true,
+                    shift: false,
+                    option: false,
+                    control: false
+                ),
+                forKey: "shortcut.selectSurfaceByNumber"
             )
+
+            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol, "⌘")
             XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults))
         }
     }
@@ -2923,7 +2966,7 @@ final class BonsplitTests: XCTestCase {
             defaults.removeObject(forKey: TabControlShortcutHintPolicy.showHintsOnControlHoldKey)
 
             XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.control], defaults: defaults)?.symbol, "⌃")
-            XCTAssertEqual(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults)?.symbol, "⌃")
+            XCTAssertNil(TabControlShortcutHintPolicy.hintModifier(for: [.command], defaults: defaults))
         }
     }
 


### PR DESCRIPTION
Fixes the surface tab shortcut hint policy so a held Command or Control key only reveals hints when that modifier family is present in the configured surface-number binding.

The regression test and fix are intentionally separate commits:
- `7602c24` test: filter tab hints by held modifier
- `daaf5b9` Fix tab hint filtering by held modifier

Validation: `swift test --disable-sandbox` (222 XCTest cases and 27 Swift Testing cases passed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790329742&installation_model_id=21920&pr_number=225&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F225&signature=cf21c819f26257ddc1f6f83a342dceb77272a6a8f3cbb078f6c2795b21ab8e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->