### PR TITLE
feat: support optional wrapping pane tabs

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarSelectionChromeView.swift
@@ -16,6 +16,23 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
     let indicatorColor: NSColor
     let separatorColor: NSColor
     let mask: TabBarSelectionChromeMask
+    let wrapsRows: Bool
+
+    init(
+        selectedTabId: UUID?,
+        geometryRegistry: TabBarItemGeometryRegistry,
+        indicatorColor: NSColor,
+        separatorColor: NSColor,
+        mask: TabBarSelectionChromeMask,
+        wrapsRows: Bool = false
+    ) {
+        self.selectedTabId = selectedTabId
+        self.geometryRegistry = geometryRegistry
+        self.indicatorColor = indicatorColor
+        self.separatorColor = separatorColor
+        self.mask = mask
+        self.wrapsRows = wrapsRows
+    }
 
     func makeNSView(context: Context) -> ChromeNSView {
         let view = ChromeNSView()
@@ -39,6 +56,7 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
         view.indicatorColor = indicatorColor
         view.separatorColor = separatorColor
         view.mask = mask
+        view.wrapsRows = wrapsRows
         view.needsDisplay = true
     }
 
@@ -55,6 +73,7 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
             actionLaneSeparatorSolidWidth: 0,
             actionLaneSeparatorFadeRampStartFraction: 0
         )
+        var wrapsRows = false
 
         override var isFlipped: Bool { true }
         override var isOpaque: Bool { false }
@@ -80,6 +99,12 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
         private func drawBottomSeparator(around selectedFrame: CGRect?) {
             separatorColor.setFill()
             let separatorY = max(bounds.minY, bounds.maxY - 1)
+            if wrapsRows {
+                NSBezierPath(
+                    rect: NSRect(x: bounds.minX, y: separatorY, width: bounds.width, height: 1)
+                ).fill()
+                return
+            }
             guard let selectedFrame else {
                 NSBezierPath(
                     rect: NSRect(x: bounds.minX, y: separatorY, width: bounds.width, height: 1)
@@ -153,7 +178,9 @@ struct TabBarSelectionChromeView: NSViewRepresentable {
 
         private func drawSelectedIndicator(in selectedFrame: CGRect?) {
             guard var frame = selectedFrame else { return }
-            frame.origin.y = bounds.minY
+            if !wrapsRows {
+                frame.origin.y = bounds.minY
+            }
             frame.size.width = max(0, frame.width - TabBarMetrics.activeIndicatorTrailingInset)
             frame.size.height = TabBarMetrics.activeIndicatorHeight
 

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -801,6 +801,9 @@ struct TabBarView: View {
 
     @AppStorage("workspacePresentationMode") private var presentationMode = "standard"
     @AppStorage("debugFadeColorStyle") private var fadeColorStyle = -1
+    /// Opt-in multi-row layout. The app settings catalog stores the same key so
+    /// cmux.json and the Settings UI both update mounted tab bars live.
+    @AppStorage("app.tabBarWrap") private var tabBarWrap = false
     @State private var isHoveringTabBar = false
     @State private var dropTargetIndex: Int?
     @State private var scrollOffset: CGFloat = 0
@@ -837,10 +840,14 @@ struct TabBarView: View {
         pane.isFullWidthTabMode && !pane.tabs.isEmpty
     }
 
+    private var isWrappingTabs: Bool {
+        tabBarWrap && !isFullWidthTabMode
+    }
+
     /// Whether tabs should stretch to fill the pane's available tab-bar width.
     /// Full-width mode uses the same flexible tab item chrome as configured fill mode.
     private var fillsTabsToWidth: Bool {
-        appearance.tabWidthMode == .fill || isFullWidthTabMode
+        !isWrappingTabs && (appearance.tabWidthMode == .fill || isFullWidthTabMode)
     }
 
     /// Minimum width to impose on the (already trailing-inset-padded) tab row when
@@ -975,7 +982,8 @@ struct TabBarView: View {
             geometryRegistry: tabItemGeometryRegistry,
             indicatorColor: TabBarColors.nsColorActiveIndicator(saturation: tabBarSaturation),
             separatorColor: TabBarColors.nsColorSeparator(for: appearance),
-            mask: selectionChromeMask
+            mask: selectionChromeMask,
+            wrapsRows: isWrappingTabs
         )
         .allowsHitTesting(false)
     }
@@ -1015,6 +1023,23 @@ struct TabBarView: View {
                     draggingFrame: draggingFrame,
                     dragImage: dragImage
                 )
+            },
+            onDoubleClick: {
+                performNewTerminalSplitButtonAction()
+            },
+            onHoverChanged: { updateTabBarHover($0) }
+        )
+    }
+
+    /// Keep title-bar dragging, hover state, and empty-space double-clicks in
+    /// wrapping mode while declining the native one-dimensional reorder drag.
+    private var wrappedDragAndHoverBackground: some View {
+        TabBarDragAndHoverView(
+            isMinimalMode: isMinimalMode,
+            geometryRegistry: tabItemGeometryRegistry,
+            tabIds: tabIds,
+            onBeginTabDrag: { _, _, _, _, _ in
+                false
             },
             onDoubleClick: {
                 performNewTerminalSplitButtonAction()
@@ -1083,6 +1108,15 @@ struct TabBarView: View {
     }
 
     var body: some View {
+        if isWrappingTabs {
+            wrappedBody
+        } else {
+            legacyBody
+        }
+    }
+
+    @ViewBuilder
+    private var legacyBody: some View {
         HStack(spacing: 0) {
             if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
                 TabBarDragZoneView(
@@ -1202,6 +1236,117 @@ struct TabBarView: View {
         .onDisappear {
             controlKeyMonitor.stop()
         }
+    }
+
+    /// The opt-in wrapping path deliberately omits the horizontal scroll view
+    /// and native tab-reorder drop destination. Context-menu moves remain
+    /// available while the layout can use the full pane height for rows.
+    @ViewBuilder
+    private var wrappedTabContent: some View {
+        TabBarWrappingLayout(horizontalSpacing: TabBarMetrics.tabSpacing) {
+            ForEach(visibleTabEntries, id: \.tab.id) { entry in
+                tabItem(for: entry.tab, at: entry.index)
+                    .id(entry.tab.id)
+            }
+
+            if !isFullWidthTabMode {
+                dropZoneAfterTabs
+            }
+        }
+        .padding(.horizontal, TabBarMetrics.barPadding)
+        .padding(.trailing, trailingTabContentInset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .animation(nil, value: pane.tabs.map(\.id))
+    }
+
+    @ViewBuilder
+    private var wrappedBody: some View {
+        HStack(spacing: 0) {
+            if appearance.tabBarLeadingInset > 0 && controller.internalController.rootNode.allPaneIds.first == pane.id {
+                TabBarDragZoneView(
+                    isMinimalMode: isMinimalMode,
+                    isFocusedPane: isFocused,
+                    onSingleClick: focusPaneFromTabBarChrome
+                ) { return false }
+                    .frame(width: appearance.tabBarLeadingInset)
+                    .frame(maxHeight: .infinity)
+            }
+
+            wrappedTabContent
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .coordinateSpace(name: "tabBar")
+        .background(TabBarLayerBackedColor(color: chromeSnapshot.barColor))
+        .background(wrappedDragAndHoverBackground)
+        .background(
+            GeometryReader { containerGeo in
+                Color.clear
+                    .onAppear {
+                        updateWrappedContainerWidth(containerGeo.size.width)
+                    }
+                    .onChange(of: containerGeo.size.width) { _, newWidth in
+                        updateWrappedContainerWidth(newWidth)
+                    }
+            }
+        )
+        .overlay(selectionChrome)
+        .overlay(alignment: .topTrailing) {
+            splitButtonBackdropChrome
+                .opacity(shouldShowSplitButtons ? 1 : 0)
+                .allowsHitTesting(false)
+                .tabBarButtonAnimationsDisabled()
+        }
+        .overlay(trailingEmptyChromeDragZone)
+        .overlay(alignment: .topTrailing) {
+            splitButtonChrome
+                .frame(width: splitButtonsBackdropWidth, height: tabBarHeight, alignment: .trailing)
+                .mask {
+                    Rectangle()
+                        .frame(width: splitButtonsBackdropWidth, height: tabBarHeight)
+                }
+                .clipped()
+        }
+        .overlay(TabBarHoverTrackingView { updateTabBarHover($0) })
+        .background {
+            if splitViewController.tabShortcutHintsEnabled {
+                TabBarHostWindowReader { window in
+                    controlKeyMonitor.setHostWindow(window)
+                }
+                .frame(width: 0, height: 0)
+            }
+        }
+        .onAppear {
+            dropTargetIndex = nil
+            tabItemGeometryRegistry.setTrailingObscuredWidth(trailingTabContentInset)
+            tabItemGeometryRegistry.revealSelection(pane.selectedTabId)
+            if splitViewController.tabShortcutHintsEnabled {
+                controlKeyMonitor.start()
+            }
+        }
+        .onChange(of: pane.selectedTabId) { _, newTabId in
+            tabItemGeometryRegistry.revealSelection(newTabId)
+        }
+        .onChange(of: trailingTabContentInset) { _, newWidth in
+            tabItemGeometryRegistry.setTrailingObscuredWidth(newWidth)
+        }
+        .onChange(of: splitViewController.tabShortcutHintsEnabled) { _, enabled in
+            if enabled {
+                controlKeyMonitor.start()
+            } else {
+                controlKeyMonitor.stop()
+            }
+        }
+        .onPreferenceChange(SplitButtonLaneWidthPreferenceKey.self) { width in
+            measuredSplitButtonLaneWidth = width
+        }
+        .onDisappear {
+            controlKeyMonitor.stop()
+        }
+    }
+
+    private func updateWrappedContainerWidth(_ width: CGFloat) {
+        guard width.isFinite, width > 0, abs(containerWidth - width) > 0.5 else { return }
+        containerWidth = width
     }
 
     // MARK: - Tab Item

--- a/Sources/Bonsplit/Internal/Views/TabBarWrappingLayout.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarWrappingLayout.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// A horizontal flow layout used by the opt-in multi-row tab bar.
+///
+/// The tab strip's normal path is an AppKit-backed horizontal scroll view. In
+/// wrapping mode the layout receives a finite viewport width and places each
+/// tab at its natural width, starting a new row when the next tab would not
+/// fit. The metrics are kept separate from SwiftUI so row placement remains
+/// deterministic and can be covered without mounting a window.
+struct TabBarWrappingLayout: Layout {
+    let horizontalSpacing: CGFloat
+    let verticalSpacing: CGFloat
+
+    init(horizontalSpacing: CGFloat = 0, verticalSpacing: CGFloat = 0) {
+        self.horizontalSpacing = max(0, horizontalSpacing)
+        self.verticalSpacing = max(0, verticalSpacing)
+    }
+
+    struct Cache {
+        var sizes: [CGSize] = []
+        var arrangement = TabBarWrapLayoutMetrics.Arrangement(
+            frames: [],
+            size: .zero,
+            rowCount: 0
+        )
+    }
+
+    func makeCache(subviews: Subviews) -> Cache {
+        Cache()
+    }
+
+    func updateCache(_ cache: inout Cache, subviews: Subviews) {
+        cache.sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+    }
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) -> CGSize {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let availableWidth = normalizedWidth(proposal.width)
+        let arrangement = TabBarWrapLayoutMetrics.arrangement(
+            sizes: sizes,
+            availableWidth: availableWidth,
+            horizontalSpacing: horizontalSpacing,
+            verticalSpacing: verticalSpacing
+        )
+        cache.sizes = sizes
+        cache.arrangement = arrangement
+
+        let width = availableWidth.isFinite ? availableWidth : arrangement.size.width
+        return CGSize(width: width, height: arrangement.size.height)
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout Cache
+    ) {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let arrangement = TabBarWrapLayoutMetrics.arrangement(
+            sizes: sizes,
+            availableWidth: max(0, bounds.width),
+            horizontalSpacing: horizontalSpacing,
+            verticalSpacing: verticalSpacing
+        )
+        cache.sizes = sizes
+        cache.arrangement = arrangement
+
+        for (index, subview) in subviews.enumerated() {
+            guard arrangement.frames.indices.contains(index) else { continue }
+            let frame = arrangement.frames[index].offsetBy(
+                dx: bounds.minX,
+                dy: bounds.minY
+            )
+            subview.place(
+                at: frame.origin,
+                anchor: .topLeading,
+                proposal: ProposedViewSize(frame.size)
+            )
+        }
+    }
+
+    private func normalizedWidth(_ width: CGFloat?) -> CGFloat {
+        guard let width, width.isFinite, width > 0 else { return .infinity }
+        return width
+    }
+}
+
+/// Pure row-placement metrics for ``TabBarWrappingLayout``.
+struct TabBarWrapLayoutMetrics {
+    struct Arrangement: Equatable {
+        let frames: [CGRect]
+        let size: CGSize
+        let rowCount: Int
+    }
+
+    static func arrangement(
+        sizes: [CGSize],
+        availableWidth: CGFloat,
+        horizontalSpacing: CGFloat,
+        verticalSpacing: CGFloat
+    ) -> Arrangement {
+        guard !sizes.isEmpty else {
+            let emptyWidth = availableWidth.isFinite ? max(0, availableWidth) : 0
+            return Arrangement(frames: [], size: CGSize(width: emptyWidth, height: 0), rowCount: 0)
+        }
+
+        let spacingX = max(0, horizontalSpacing)
+        let spacingY = max(0, verticalSpacing)
+        let widthLimit = availableWidth.isFinite && availableWidth > 0
+            ? availableWidth
+            : .infinity
+        var frames: [CGRect] = []
+        frames.reserveCapacity(sizes.count)
+
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var rowCount = 1
+        var contentWidth: CGFloat = 0
+
+        for size in sizes {
+            let width = min(max(0, size.width), widthLimit)
+            let height = max(0, size.height)
+            let wouldOverflow = x > 0 && x + spacingX + width > widthLimit + 0.001
+            if wouldOverflow {
+                contentWidth = max(contentWidth, x)
+                y += rowHeight + spacingY
+                x = 0
+                rowHeight = 0
+                rowCount += 1
+            }
+
+            if x > 0 {
+                x += spacingX
+            }
+            let frame = CGRect(x: x, y: y, width: width, height: height)
+            frames.append(frame)
+            x += width
+            rowHeight = max(rowHeight, height)
+        }
+
+        contentWidth = max(contentWidth, x)
+        let contentHeight = y + rowHeight
+        let resultWidth = widthLimit.isFinite ? widthLimit : contentWidth
+        return Arrangement(
+            frames: frames,
+            size: CGSize(width: resultWidth, height: contentHeight),
+            rowCount: rowCount
+        )
+    }
+}

--- a/Tests/BonsplitTests/TabBarWrappingLayoutTests.swift
+++ b/Tests/BonsplitTests/TabBarWrappingLayoutTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Bonsplit
+
+final class TabBarWrappingLayoutTests: XCTestCase {
+    func testItemsWrapIntoRowsWhenNaturalWidthsOverflow() {
+        let result = TabBarWrapLayoutMetrics.arrangement(
+            sizes: [
+                CGSize(width: 120, height: 30),
+                CGSize(width: 120, height: 30),
+                CGSize(width: 120, height: 30),
+            ],
+            availableWidth: 250,
+            horizontalSpacing: 0,
+            verticalSpacing: 0
+        )
+
+        XCTAssertEqual(result.rowCount, 2)
+        XCTAssertEqual(result.size.height, 60, accuracy: 0.001)
+        XCTAssertEqual(result.frames[0].minY, 0, accuracy: 0.001)
+        XCTAssertEqual(result.frames[1].minY, 0, accuracy: 0.001)
+        XCTAssertEqual(result.frames[2].minY, 30, accuracy: 0.001)
+    }
+
+    func testItemsStayOnOneRowWhenTheyFit() {
+        let result = TabBarWrapLayoutMetrics.arrangement(
+            sizes: [
+                CGSize(width: 120, height: 30),
+                CGSize(width: 120, height: 30),
+            ],
+            availableWidth: 250,
+            horizontalSpacing: 0,
+            verticalSpacing: 0
+        )
+
+        XCTAssertEqual(result.rowCount, 1)
+        XCTAssertEqual(result.size, CGSize(width: 250, height: 30))
+        XCTAssertEqual(result.frames.map(\.minX), [0, 120])
+    }
+
+    func testAnItemWiderThanTheViewportIsClampedToTheViewport() {
+        let result = TabBarWrapLayoutMetrics.arrangement(
+            sizes: [CGSize(width: 400, height: 30)],
+            availableWidth: 250,
+            horizontalSpacing: 0,
+            verticalSpacing: 0
+        )
+
+        XCTAssertEqual(result.rowCount, 1)
+        XCTAssertEqual(result.frames[0].width, 250, accuracy: 0.001)
+        XCTAssertEqual(result.size.width, 250, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

- add a pure wrapping layout model for natural-width pane tabs
- expand the tab bar to the intrinsic multi-row height when wrapping is enabled
- preserve the existing single-row scrolling behavior by default; disable native drag reorder in wrap mode while keeping context-menu moves

## Verification

- `swift test --package-path vendor/bonsplit` (224 tests passed)
- focused `TabBarWrappingLayoutTests` covers single-row, wrapped, and narrower-width layouts

Dependency for manaflow-ai/cmux#10719. The test-only commit precedes the implementation commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331016&installation_model_id=21920&pr_number=226&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F226&signature=ce9bdf562263d047a538e69ae1c7b8255df70780be1d005f458edf44d9adbc48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->