### PR TITLE
perf: add tabIds(inPane:) so callers stop building tabs to read ids

### DIFF
--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -927,6 +927,20 @@ public final class BonsplitController {
         return pane.tabs.map { Tab(from: $0) }
     }
 
+    /// Get the tab IDs in a specific pane, in tab order.
+    ///
+    /// Prefer this over `tabs(inPane:)` when only identity or ordering is
+    /// wanted. `Tab.init(from:)` copies all fourteen `TabItem` properties, so
+    /// a caller that asks for tabs to read their ids pays for thirteen fields
+    /// it discards, per tab, on every call. This reads the id and nothing
+    /// else.
+    public func tabIds(inPane paneId: PaneID) -> [TabID] {
+        guard let pane = internalController.paneState(for: paneId) else {
+            return []
+        }
+        return pane.tabs.map { TabID(id: $0.id) }
+    }
+
     /// Get the pane that currently owns a tab.
     ///
     /// This lookup is constant time and does not walk the split tree.

--- a/Tests/BonsplitTests/TabIdListingTests.swift
+++ b/Tests/BonsplitTests/TabIdListingTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Bonsplit
+
+/// `tabIds(inPane:)` exists so a caller that wants ordering or identity does
+/// not have to build a `Tab` per tab to get it. These pin it to the ordering
+/// `tabs(inPane:)` already produces, so the cheap call and the expensive one
+/// can never disagree.
+final class TabIdListingTests: XCTestCase {
+    @MainActor
+    func testTabIdsMatchTabsInOrderAcrossMovesAndCloses() {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let paneId = try! XCTUnwrap(controller.focusedPaneId)
+        let first = try! XCTUnwrap(controller.createTab(title: "First"))
+        let second = try! XCTUnwrap(controller.createTab(title: "Second"))
+
+        XCTAssertEqual(
+            controller.tabIds(inPane: paneId),
+            controller.tabs(inPane: paneId).map(\.id)
+        )
+        XCTAssertEqual(controller.tabIds(inPane: paneId).suffix(2), [first, second])
+
+        XCTAssertTrue(controller.moveTab(second, toPane: paneId, atIndex: 0))
+        XCTAssertEqual(controller.tabIds(inPane: paneId).first, second)
+        XCTAssertEqual(
+            controller.tabIds(inPane: paneId),
+            controller.tabs(inPane: paneId).map(\.id)
+        )
+
+        XCTAssertTrue(controller.closeTab(first))
+        XCTAssertFalse(controller.tabIds(inPane: paneId).contains(first))
+        XCTAssertEqual(
+            controller.tabIds(inPane: paneId),
+            controller.tabs(inPane: paneId).map(\.id)
+        )
+    }
+
+    /// A title write must not reorder or drop anything. The ids are the same
+    /// list before and after, which is the property callers depend on when
+    /// they stop reading titles they never wanted.
+    @MainActor
+    func testRenamingATabLeavesTheIdListingAlone() {
+        let controller = BonsplitController()
+        let paneId = try! XCTUnwrap(controller.focusedPaneId)
+        let tabId = try! XCTUnwrap(controller.createTab(title: "Before"))
+
+        let before = controller.tabIds(inPane: paneId)
+        controller.updateTab(tabId, title: "After")
+
+        XCTAssertEqual(controller.tabIds(inPane: paneId), before)
+        XCTAssertEqual(controller.tab(tabId)?.title, "After")
+    }
+
+    @MainActor
+    func testEmptyAndUnknownPanesListNoTabs() {
+        let controller = BonsplitController()
+        let originalPaneId = try! XCTUnwrap(controller.focusedPaneId)
+        let emptyPaneId = try! XCTUnwrap(
+            controller.splitPane(originalPaneId, orientation: .vertical)
+        )
+
+        XCTAssertEqual(controller.tabIds(inPane: emptyPaneId), [])
+        XCTAssertEqual(controller.tabIds(inPane: PaneID()), [])
+    }
+}

--- a/Tests/BonsplitTests/TabIdListingTests.swift
+++ b/Tests/BonsplitTests/TabIdListingTests.swift
@@ -52,6 +52,40 @@ final class TabIdListingTests: XCTestCase {
         XCTAssertEqual(controller.tab(tabId)?.title, "After")
     }
 
+    /// The point of the accessor. Timed rather than counted so the assertion
+    /// still means something if the implementation changes later. The bound is
+    /// loose on purpose: the measured gap is several times, not a few percent.
+    @MainActor
+    func testListingIdsIsSubstantiallyCheaperThanListingTabs() {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let paneId = try! XCTUnwrap(controller.focusedPaneId)
+        for index in 0..<12 {
+            _ = controller.createTab(title: "Tab \(index)")
+        }
+        let iterations = 2_000
+
+        // Warm both paths so neither pays first-call costs in its window.
+        _ = controller.tabs(inPane: paneId)
+        _ = controller.tabIds(inPane: paneId)
+
+        let tabsStart = ContinuousClock.now
+        for _ in 0..<iterations {
+            _ = controller.tabs(inPane: paneId).map(\.id)
+        }
+        let tabsElapsed = ContinuousClock.now - tabsStart
+
+        let idsStart = ContinuousClock.now
+        for _ in 0..<iterations {
+            _ = controller.tabIds(inPane: paneId)
+        }
+        let idsElapsed = ContinuousClock.now - idsStart
+
+        print("[tab-ids] \(iterations) listings of 13 tabs: tabs \(tabsElapsed), ids \(idsElapsed)")
+        XCTAssertLessThan(idsElapsed, tabsElapsed / 2)
+    }
+
     @MainActor
     func testEmptyAndUnknownPanesListNoTabs() {
         let controller = BonsplitController()

--- a/Tests/BonsplitTests/TabIdListingTests.swift
+++ b/Tests/BonsplitTests/TabIdListingTests.swift
@@ -55,6 +55,11 @@ final class TabIdListingTests: XCTestCase {
     /// The point of the accessor. Timed rather than counted so the assertion
     /// still means something if the implementation changes later. The bound is
     /// loose on purpose: the measured gap is several times, not a few percent.
+    ///
+    /// Sampled alternately and compared on medians. One sample each would let a
+    /// scheduler hiccup landing in the wrong window fail a correct build, and
+    /// alternating keeps a slow stretch of machine from landing entirely on one
+    /// of the two paths.
     @MainActor
     func testListingIdsIsSubstantiallyCheaperThanListingTabs() {
         let controller = BonsplitController(
@@ -65,25 +70,33 @@ final class TabIdListingTests: XCTestCase {
             _ = controller.createTab(title: "Tab \(index)")
         }
         let iterations = 2_000
+        let samples = 7
 
         // Warm both paths so neither pays first-call costs in its window.
         _ = controller.tabs(inPane: paneId)
         _ = controller.tabIds(inPane: paneId)
 
-        let tabsStart = ContinuousClock.now
-        for _ in 0..<iterations {
-            _ = controller.tabs(inPane: paneId).map(\.id)
+        func time(_ body: () -> Void) -> Duration {
+            let start = ContinuousClock.now
+            for _ in 0..<iterations { body() }
+            return ContinuousClock.now - start
         }
-        let tabsElapsed = ContinuousClock.now - tabsStart
 
-        let idsStart = ContinuousClock.now
-        for _ in 0..<iterations {
-            _ = controller.tabIds(inPane: paneId)
+        var tabsSamples: [Duration] = []
+        var idsSamples: [Duration] = []
+        for _ in 0..<samples {
+            tabsSamples.append(time { _ = controller.tabs(inPane: paneId).map(\.id) })
+            idsSamples.append(time { _ = controller.tabIds(inPane: paneId) })
         }
-        let idsElapsed = ContinuousClock.now - idsStart
 
-        print("[tab-ids] \(iterations) listings of 13 tabs: tabs \(tabsElapsed), ids \(idsElapsed)")
-        XCTAssertLessThan(idsElapsed, tabsElapsed / 2)
+        let tabsMedian = tabsSamples.sorted()[samples / 2]
+        let idsMedian = idsSamples.sorted()[samples / 2]
+
+        print("""
+        [tab-ids] \(samples) samples of \(iterations) listings of 13 tabs: \
+        tabs median \(tabsMedian), ids median \(idsMedian)
+        """)
+        XCTAssertLessThan(idsMedian, tabsMedian / 2)
     }
 
     @MainActor


### PR DESCRIPTION
Adds `tabIds(inPane:)`. Purely additive, nothing existing changes.

`tabs(inPane:)` is the only way to list a pane's tabs, and it maps every `TabItem` through `Tab.init(from:)`, which copies all fourteen properties. A caller that wants ordering or identity pays for thirteen fields it discards, per tab, on every call.

```swift
public func tabIds(inPane paneId: PaneID) -> [TabID] {
    guard let pane = internalController.paneState(for: paneId) else { return [] }
    return pane.tabs.map { TabID(id: $0.id) }
}
```

It sits next to `paneId(containing:)` and `selectedTabId(inPane:)`, which exist for the same reason.

## What it saves

Seven samples of 2000 listings of a 13-tab pane, taken alternately, from
`testListingIdsIsSubstantiallyCheaperThanListingTabs` in this PR:

| | median | per listing |
|---|---|---|
| `tabs(inPane:).map(\.id)` | 5.597 ms | 2.80 µs |
| `tabIds(inPane:)` | 2.122 ms | 1.06 µs |

The caller that prompted this is cmux's sidebar ordering, which builds a `Tab` per tab in every pane to read the ids. In a 20 second Instruments capture of the real app, `tabs(inPane:)` costs 68 ms, and 676 of its 677 samples come from that one function.

## Tests

Four, all new, nothing existing touched.

- `tabIds(inPane:)` equals `tabs(inPane:).map(\.id)` after a create, a move, and a close. The cheap call and the expensive one cannot drift apart.
- A rename leaves the id listing identical, which is the property a caller relies on when it stops reading titles it never wanted.
- An empty pane and an unknown pane both list nothing rather than trapping.
- The cost test above. It asserts a factor of two against a measured 2.64x on medians, so machine noise and a later reimplementation both survive it.

Full suite: 224 XCTest and 29 swift-testing. `TabBarDropHandlerTests.testTranslatedDestinationHitTestsInSuperviewCoordinates` fails, and it fails the same way on a clean checkout of `main`, so it is not from this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790339815&installation_model_id=21920&pr_number=227&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F227&signature=2a2942197b52cbd137be1f1321b4f57f540b130d832195ac3a9f11ac2d137a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to retrieve tab IDs in their current pane order.
  * Returns an empty list for panes with no tabs or unknown panes.
  * Tab ID ordering remains accurate after tabs are moved, closed, or renamed.
  * Retrieves identifiers efficiently without requiring full tab details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
