### PR TITLE
Layout snapshot reports the rendered (zoomed) pane

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController.swift
@@ -203,6 +203,13 @@ final class SplitViewController {
         return .pane(pane)
     }
 
+    /// The node the split area actually renders: the zoomed pane alone when a
+    /// zoom is active, otherwise the whole split tree. Rendering and geometry
+    /// reporting both read this so they cannot disagree about pane frames.
+    var renderedRootNode: SplitNode {
+        zoomedNode ?? rootNode
+    }
+
     @discardableResult
     func clearPaneZoom() -> Bool {
         guard zoomedPaneId != nil else { return false }

--- a/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitViewContainer.swift
@@ -40,9 +40,8 @@ struct SplitViewContainer<Content: View, EmptyContent: View>: View {
 
     @ViewBuilder
     private var splitNodeContent: some View {
-        let nodeToRender = controller.zoomedNode ?? controller.rootNode
         SplitNodeView(
-            node: nodeToRender,
+            node: controller.renderedRootNode,
             contentBuilder: contentBuilder,
             emptyPaneBuilder: emptyPaneBuilder,
             appearance: appearance,

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -782,7 +782,9 @@ public final class BonsplitController {
 
     @discardableResult
     public func clearPaneZoom() -> Bool {
-        internalController.clearPaneZoom()
+        guard internalController.clearPaneZoom() else { return false }
+        notifyGeometryChange()
+        return true
     }
 
     /// Toggle zoom for a pane. When zoomed, only that pane is rendered in the split area.
@@ -791,7 +793,9 @@ public final class BonsplitController {
     public func togglePaneZoom(inPane paneId: PaneID? = nil) -> Bool {
         let targetPaneId = paneId ?? focusedPaneId
         guard let targetPaneId else { return false }
-        return internalController.togglePaneZoom(targetPaneId)
+        guard internalController.togglePaneZoom(targetPaneId) else { return false }
+        notifyGeometryChange()
+        return true
     }
 
     /// Request a tab-chrome zoom toggle for a specific tab.
@@ -920,10 +924,12 @@ public final class BonsplitController {
 
     // MARK: - Geometry Query API
 
-    /// Get current layout snapshot with pixel coordinates
+    /// Get the rendered layout with pixel coordinates. While a pane is zoomed
+    /// only that pane is rendered, so only it is reported (filling the
+    /// container); the other panes have no on-screen geometry.
     public func layoutSnapshot() -> LayoutSnapshot {
         let containerFrame = internalController.containerFrame
-        let paneBounds = internalController.rootNode.computePaneBounds()
+        let paneBounds = internalController.renderedRootNode.computePaneBounds()
 
         let paneGeometries = paneBounds.map { bounds -> PaneGeometry in
             let pane = internalController.paneState(for: bounds.paneId)

--- a/Sources/Bonsplit/Public/BonsplitDelegate.swift
+++ b/Sources/Bonsplit/Public/BonsplitDelegate.swift
@@ -71,7 +71,7 @@ public protocol BonsplitDelegate: AnyObject {
 
     // MARK: - Geometry
 
-    /// Called when any pane geometry changes (resize, split, close)
+    /// Called when any pane geometry changes (resize, split, close, zoom)
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot)
 
     /// Called to check if notifications should be sent during divider drag (opt-in for real-time sync)

--- a/Sources/Bonsplit/Public/Types/LayoutSnapshot.swift
+++ b/Sources/Bonsplit/Public/Types/LayoutSnapshot.swift
@@ -43,7 +43,7 @@ public struct PaneGeometry: Codable, Sendable, Equatable {
 
 // MARK: - Layout Snapshot
 
-/// Full tree snapshot with pixel coordinates
+/// Rendered layout snapshot with pixel coordinates (only the zoomed pane while zoomed)
 public struct LayoutSnapshot: Codable, Sendable, Equatable {
     public let containerFrame: PixelRect
     public let panes: [PaneGeometry]

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -1573,6 +1573,47 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testLayoutSnapshotReportsZoomedPaneFillingContainer() {
+        let controller = BonsplitController()
+        controller.setContainerFrame(CGRect(x: 10, y: 20, width: 800, height: 600))
+        guard let leftPane = controller.focusedPaneId,
+              let rightPane = controller.splitPane(leftPane, orientation: .horizontal) else {
+            return XCTFail("Expected a two-pane layout")
+        }
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: rightPane))
+
+        // Zoom renders only the zoomed pane, so the snapshot (what hosts draw
+        // pane overlays against) must report that pane at the full container.
+        let zoomed = controller.layoutSnapshot()
+        XCTAssertEqual(zoomed.panes.map(\.paneId), [rightPane.id.uuidString])
+        XCTAssertEqual(zoomed.panes.first?.frame, PixelRect(x: 10, y: 20, width: 800, height: 600))
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: rightPane))
+        let unzoomed = controller.layoutSnapshot()
+        XCTAssertEqual(Set(unzoomed.panes.map(\.paneId)), [leftPane.id.uuidString, rightPane.id.uuidString])
+        XCTAssertEqual(unzoomed.panes.first(where: { $0.paneId == rightPane.id.uuidString })?.frame.width, 400)
+    }
+
+    @MainActor
+    func testTogglePaneZoomReportsGeometryChange() {
+        let controller = BonsplitController()
+        let recorder = DividerDragEventRecorder()
+        controller.delegate = recorder
+        guard let leftPane = controller.focusedPaneId,
+              controller.splitPane(leftPane, orientation: .horizontal) != nil else {
+            return XCTFail("Expected a two-pane layout")
+        }
+        recorder.events.removeAll()
+
+        XCTAssertTrue(controller.togglePaneZoom(inPane: leftPane))
+        XCTAssertEqual(recorder.events, [.geometryChanged])
+
+        XCTAssertTrue(controller.clearPaneZoom())
+        XCTAssertEqual(recorder.events, [.geometryChanged, .geometryChanged])
+    }
+
+    @MainActor
     func testRequestTabZoomToggleUsesHostHandler() {
         let controller = BonsplitController()
         let pane = controller.focusedPaneId!


### PR DESCRIPTION
## Bug

`SplitViewContainer` renders `zoomedNode ?? rootNode`, but `layoutSnapshot()` computed pane frames from `rootNode`. While a pane is zoomed the snapshot reported the pre-zoom split frames for panes that are not on screen, and zoom toggles never reported `didChangeGeometry`.

In cmux this is the active-pane border staying at the old pane size after cmd-shift-enter: the overlay resolves the focused pane's rect from the snapshot, and the zoomed view's real rect gets rejected because it does not fit inside the stale pane frame.

## Fix

- One `renderedRootNode` (`zoomedNode ?? rootNode`) on `SplitViewController`, read by both the renderer and `layoutSnapshot()`, so the two cannot disagree. While zoomed the snapshot reports only the zoomed pane, filling the container.
- `togglePaneZoom` / `clearPaneZoom` call `notifyGeometryChange()` on success, matching `splitPane` / `closePane` and the delegate doc ("any pane geometry changes").

`treeSnapshot()` is unchanged: it describes the split tree, not what is rendered.

## Tests

- `testLayoutSnapshotReportsZoomedPaneFillingContainer`
- `testTogglePaneZoomReportsGeometryChange`

Both failed before the fix (first commit) and pass after; full suite green (223 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790357773&installation_model_id=21920&pr_number=228&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F228&signature=c60c23ebfb5fde8aad6187e0fd425f34474c2778f0311cbf650089dacf24c434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `layoutSnapshot()` so it reports the pane layout that is actually rendered while a pane is zoomed, instead of the stale pre-zoom split frames. Zoom toggles now also report `didChangeGeometry`, fixing overlays like cmux's active-pane border that stayed at the old pane rect after toggling zoom.

- `SplitViewController` now exposes a single `renderedRootNode` (`zoomedNode ?? rootNode`) that both the renderer and `layoutSnapshot()` read, so while zoomed only the zoomed pane is reported, filling the container.
- `togglePaneZoom` and `clearPaneZoom` call `notifyGeometryChange()` on success, matching `splitPane` and `closePane`.

<sup>Written for commit 088ffb485bb5f1b86a9eaaef219c6733046cd924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

