### PR TITLE
Keep native tab drag ownership until AppKit endedAt

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -58,6 +58,7 @@ extension SplitViewController {
             event: event,
             source: source
         )
+        source.bind(nativeSession: session, sourceView: sourceView)
         // A tab drag is owned by the source lifecycle. Avoid AppKit's return
         // animation delaying (or suppressing) `endedAt` when the pointer is
         // released without a valid destination, so transfer state is revoked

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -9,9 +9,22 @@ extension SplitViewController {
 #endif
         clearTabDragState()
         dragGeneration += 1
+        reclaimSupersededNativeTabDragSources()
         let session = TabDragSession(tab: tab, sourcePaneId: paneId, generation: dragGeneration)
         tabDragSession = session
         return dragGeneration
+    }
+
+    /// Releases native source holds from older generations after a new tab
+    /// drag boundary. AppKit cannot begin the new gesture while an older native
+    /// session is still active, so a source whose `endedAt` callback was lost
+    /// is safe to retire here; any late callback remains idempotent.
+    private func reclaimSupersededNativeTabDragSources() {
+        let superseded = nativeTabDragSources.filter { $0.key < dragGeneration }
+        for (generation, source) in superseded {
+            nativeTabDragSources[generation] = nil
+            source.finishAfterNativeBoundary()
+        }
     }
 
     func clearTabDragState() {

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -53,7 +53,7 @@ extension SplitViewController {
 
         let draggingItem = NSDraggingItem(pasteboardWriter: registration.pasteboardItem)
         draggingItem.setDraggingFrame(draggingFrame, contents: dragImage)
-        sourceView.beginDraggingSession(
+        let session = sourceView.beginDraggingSession(
             with: [draggingItem],
             event: event,
             source: source

--- a/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
+++ b/Sources/Bonsplit/Internal/Controllers/SplitViewController+TabDrag.swift
@@ -53,12 +53,12 @@ extension SplitViewController {
 
         let draggingItem = NSDraggingItem(pasteboardWriter: registration.pasteboardItem)
         draggingItem.setDraggingFrame(draggingFrame, contents: dragImage)
-        let session = sourceView.beginDraggingSession(
+        sourceView.beginDraggingSession(
             with: [draggingItem],
             event: event,
             source: source
         )
-        source.bind(nativeSession: session, sourceView: sourceView)
+        source.bind(sourceView: sourceView)
         // A tab drag is owned by the source lifecycle. Avoid AppKit's return
         // animation delaying (or suppressing) `endedAt` when the pointer is
         // released without a valid destination, so transfer state is revoked

--- a/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
@@ -8,6 +8,12 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
     private let transferRegistry: TabDragTransferRegistry
     private weak var controller: SplitViewController?
     private var didFinish = false
+    // Keep the exact AppKit session and source view owned until `endedAt`.
+    // AppKit's drag manager may outlive the SwiftUI tab view that initiated the
+    // drag; releasing either object during an accepted drop can strand the
+    // WindowManager drag connection.
+    private var nativeSession: NSDraggingSession?
+    private var sourceView: NSView?
 
     init(
         generation: Int,
@@ -20,9 +26,12 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         self.transferRegistry = transferRegistry
         self.controller = controller
         super.init()
-        transferRegistry.attachSourceCompletion(to: transferRegistration) { [weak self] in
-            self?.finishDrag()
-        }
+    }
+
+    func bind(nativeSession: NSDraggingSession, sourceView: NSView) {
+        guard !didFinish else { return }
+        self.nativeSession = nativeSession
+        self.sourceView = sourceView
     }
 
     func draggingSession(
@@ -41,7 +50,7 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         // The system drag pasteboard advertises this session's transfer type
         // until another drag replaces it, which keeps host drop-capture
         // hit-testing armed forever and blocks the next tab drag from starting.
-        transferRegistration.clearResidualCapability(from: NSPasteboard(name: .drag))
+        transferRegistration.clearResidualCapability(from: session.draggingPasteboard)
     }
 
     func finishDrag() {
@@ -49,5 +58,7 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         didFinish = true
         transferRegistry.end(transferRegistration)
         controller?.nativeTabDragSessionDidEnd(generation: generation)
+        nativeSession = nil
+        sourceView = nil
     }
 }

--- a/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
@@ -34,6 +34,12 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         self.sourceView = sourceView
     }
 
+    /// Completes a superseded source after a later native pointer boundary
+    /// proves that AppKit has left this source's drag loop.
+    func finishAfterNativeBoundary() {
+        finishDrag()
+    }
+
     func draggingSession(
         _ session: NSDraggingSession,
         sourceOperationMaskFor context: NSDraggingContext

--- a/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
@@ -8,11 +8,11 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
     private let transferRegistry: TabDragTransferRegistry
     private weak var controller: SplitViewController?
     private var didFinish = false
-    // Keep the exact AppKit session and source view owned until `endedAt`.
+    // Keep the source view owned until `endedAt`; AppKit owns the session and
+    // retains this source while its native drag is active.
     // AppKit's drag manager may outlive the SwiftUI tab view that initiated the
     // drag; releasing either object during an accepted drop can strand the
     // WindowManager drag connection.
-    private var nativeSession: NSDraggingSession?
     private var sourceView: NSView?
 
     init(
@@ -28,9 +28,9 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         super.init()
     }
 
-    func bind(nativeSession: NSDraggingSession, sourceView: NSView) {
+    /// Retains the source view until AppKit delivers this source's `endedAt` callback.
+    func bind(sourceView: NSView) {
         guard !didFinish else { return }
-        self.nativeSession = nativeSession
         self.sourceView = sourceView
     }
 
@@ -58,7 +58,6 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
         didFinish = true
         transferRegistry.end(transferRegistration)
         controller?.nativeTabDragSessionDidEnd(generation: generation)
-        nativeSession = nil
         sourceView = nil
     }
 }

--- a/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/PaneContainerView.swift
@@ -454,6 +454,8 @@ struct UnifiedPaneDropDelegate: DropDelegate {
             if handled {
                 dropLifecycle = .idle
                 activeDropZone = nil
+                // Revoke destination routing without releasing the native
+                // source; its `endedAt` callback owns terminal cleanup.
                 controller.tabDragTransferRegistry.finish(from: NSPasteboard(name: .drag))
             }
             return handled
@@ -520,6 +522,8 @@ struct UnifiedPaneDropDelegate: DropDelegate {
 
         guard handled else { return false }
         controller.clearTabDragState()
+        // The accepted drop only revokes routing. Native source ownership ends
+        // when AppKit calls the source's `endedAt` callback.
         controller.tabDragTransferRegistry.finish(from: pasteboard)
         return true
     }

--- a/Sources/Bonsplit/Internal/Views/TabBarDropHandler.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarDropHandler.swift
@@ -71,6 +71,8 @@ struct TabBarDropHandler {
         if hasLiveTabDrag || hasTabTransfer {
             let handled = performTabDrop(from: pasteboard, at: targetIndex)
             if handled {
+                // Acceptance revokes routing only. The native source remains
+                // retained until AppKit sends its terminal `endedAt` callback.
                 splitViewController.tabDragTransferRegistry.finish(from: pasteboard)
             }
             return handled

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -101,8 +101,7 @@ public final class TabDragTransferRegistry {
     /// - Parameter pasteboard: The pasteboard presented by the accepted drop.
     public func finish(from pasteboard: NSPasteboard) {
         guard let token = token(from: pasteboard),
-              let entry = transfers[token],
-              entry.lifetime != nil else {
+              let entry = transfers[token] else {
             return
         }
         // Accepted routing is revoked immediately, but the source object and
@@ -110,6 +109,7 @@ public final class TabDragTransferRegistry {
         // Keep this mutation explicit: a later destination must not resolve the
         // accepted capability a second time while AppKit finishes the source.
         transfers[token] = nil
+        guard entry.lifetime != nil else { return }
     }
 
     private func token(from pasteboard: NSPasteboard) -> UUID? {

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -107,6 +107,8 @@ public final class TabDragTransferRegistry {
         }
         // Accepted routing is revoked immediately, but the source object and
         // native AppKit session remain owned by their source until `endedAt`.
+        // Keep this mutation explicit: a later destination must not resolve the
+        // accepted capability a second time while AppKit finishes the source.
         transfers[token] = nil
     }
 

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -101,10 +101,13 @@ public final class TabDragTransferRegistry {
     /// - Parameter pasteboard: The pasteboard presented by the accepted drop.
     public func finish(from pasteboard: NSPasteboard) {
         guard let token = token(from: pasteboard),
-              let entry = transfers.removeValue(forKey: token),
+              let entry = transfers[token],
               entry.lifetime != nil else {
             return
         }
+        // Accepted routing is revoked immediately, but the source object and
+        // native AppKit session remain owned by their source until `endedAt`.
+        transfers[token] = nil
     }
 
     private func token(from pasteboard: NSPasteboard) -> UUID? {

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -13,7 +13,6 @@ public final class TabDragTransferRegistry {
     private final class Entry {
         weak var lifetime: TabDragTransferLifetime?
         let transfer: TabDragTransfer
-        var finishSource: (() -> Void)?
 
         init(lifetime: TabDragTransferLifetime, transfer: TabDragTransfer) {
             self.lifetime = lifetime
@@ -88,10 +87,15 @@ public final class TabDragTransferRegistry {
         transfers[token] = nil
     }
 
-    /// Finishes the live drag source represented by an accepted drop.
+    /// Revokes routing for the capability represented by an accepted drop.
     ///
-    /// The capability is revoked before the source callback runs, making this
-    /// safe when AppKit later delivers its native drag-ended callback too.
+    /// This method deliberately does not finish or release the native source.
+    /// AppKit owns the native drag session until it delivers the source's
+    /// `draggingSession(_:endedAt:operation:)` callback; that callback must
+    /// remain the sole terminal transition. Releasing a source here can leave
+    /// CoreDrag/WindowManager in an active drag state when the accepted drop
+    /// callback arrives before AppKit's source completion.
+    ///
     /// Rejected drops must not call this method.
     ///
     /// - Parameter pasteboard: The pasteboard presented by the accepted drop.
@@ -101,19 +105,6 @@ public final class TabDragTransferRegistry {
               entry.lifetime != nil else {
             return
         }
-        entry.finishSource?()
-    }
-
-    /// Attaches the native source lifecycle to a registered capability.
-    func attachSourceCompletion(
-        to registration: TabDragTransferRegistration,
-        _ completion: @escaping () -> Void
-    ) {
-        guard let entry = transfers[registration.token],
-              entry.lifetime === registration.lifetime else {
-            return
-        }
-        entry.finishSource = completion
     }
 
     private func token(from pasteboard: NSPasteboard) -> UUID? {

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -101,7 +101,7 @@ public final class TabDragTransferRegistry {
     /// - Parameter pasteboard: The pasteboard presented by the accepted drop.
     public func finish(from pasteboard: NSPasteboard) {
         guard let token = token(from: pasteboard),
-              let entry = transfers[token] else {
+              transfers[token] != nil else {
             return
         }
         // Accepted routing is revoked immediately, but the source object and
@@ -109,7 +109,6 @@ public final class TabDragTransferRegistry {
         // Keep this mutation explicit: a later destination must not resolve the
         // accepted capability a second time while AppKit finishes the source.
         transfers[token] = nil
-        guard entry.lifetime != nil else { return }
     }
 
     private func token(from pasteboard: NSPasteboard) -> UUID? {

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -150,6 +150,41 @@ struct TabDragTransferRegistryTests {
         withExtendedLifetime(source) {}
     }
 
+    @Test("A new tab drag reclaims a superseded native source")
+    func newTabDragReclaimsSupersededNativeSource() throws {
+        let registry = TabDragTransferRegistry()
+        let controller = makeController(registry: registry)
+        let split = controller.internalController
+        let pane = try #require(split.focusedPane)
+        let firstTab = try #require(pane.selectedTab)
+        let firstGeneration = split.beginTabDrag(firstTab, from: pane.id)
+        let firstRegistration = try #require(
+            registry.register(
+                TabDragTransfer(tab: Tab(from: firstTab), sourcePaneId: pane.id)
+            )
+        )
+        let firstSource = TabDragSessionSource(
+            generation: firstGeneration,
+            transferRegistration: firstRegistration,
+            transferRegistry: registry,
+            controller: split
+        )
+        split.nativeTabDragSources[firstGeneration] = firstSource
+        let firstPasteboard = makePasteboard(item: firstRegistration.pasteboardItem)
+        #expect(registry.resolve(from: firstPasteboard) != nil)
+
+        let secondTab = TabItem(title: "Second drag", icon: "star")
+        let secondGeneration = split.beginTabDrag(secondTab, from: pane.id)
+
+        // A new threshold-crossing native gesture is an authoritative boundary:
+        // AppKit cannot deliver it while the older native drag is still live.
+        #expect(secondGeneration > firstGeneration)
+        #expect(split.tabDragSession?.generation == secondGeneration)
+        #expect(registry.resolve(from: firstPasteboard) == nil)
+
+        firstSource.finishDrag()
+    }
+
     @Test("A failed local pane move keeps its native source live")
     func failedLocalPaneMoveKeepsNativeSourceLive() throws {
         let fixture = try makeLocalPaneDropFixture()

--- a/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
+++ b/Tests/BonsplitTests/TabDragTransferRegistryTests.swift
@@ -114,8 +114,8 @@ struct TabDragTransferRegistryTests {
         #expect(handler.operation(for: pasteboard).isEmpty)
     }
 
-    @Test("An accepted cross-controller drop finishes its native source")
-    func acceptedCrossControllerDropFinishesNativeSource() throws {
+    @Test("An accepted drop leaves native source completion to AppKit")
+    func acceptedCrossControllerDropWaitsForNativeSourceCompletion() throws {
         let registry = TabDragTransferRegistry()
         let sourceController = makeController(registry: registry)
         let targetController = makeController(registry: registry)
@@ -139,8 +139,14 @@ struct TabDragTransferRegistryTests {
         targetController.onExternalTabDrop = { _ in true }
 
         #expect(handler.performDrop(from: pasteboard, at: 0))
-        #expect(sourceController.internalController.tabDragSession == nil)
+        // Accepting a destination only revokes routing. The native source must
+        // remain retained and its `endedAt` callback is the sole terminal
+        // transition, otherwise AppKit can be left in an active drag state.
+        #expect(sourceController.internalController.tabDragSession != nil)
         #expect(handler.operation(for: pasteboard).isEmpty)
+
+        source.finishDrag()
+        #expect(sourceController.internalController.tabDragSession == nil)
         withExtendedLifetime(source) {}
     }
 


### PR DESCRIPTION
Required by manaflow-ai/cmux#9860 and cmux#11186. Accepted Bonsplit drops must revoke routing without releasing TabDragSessionSource before AppKit invokes draggingSession(_:endedAt:operation:). This branch retains the source view until endedAt, removes the source-side native-session cycle, and makes finish(from:) perform explicit capability revocation. Focused regression tests cover accepted-drop ownership and terminal cleanup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790650239&installation_model_id=21920&pr_number=229&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F229&signature=d887184a3fa9d878b4ce291be91ec49c5ddd203132b05656bf2b5265e6807696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps native tab drag ownership until AppKit's `endedAt` callback so accepted drops no longer strand WindowManager in an active drag state.

- The source binds its source view so the native source and session stay retained until AppKit delivers `draggingSession(_:endedAt:operation:)`; accepted drops revoke routing immediately.
- `finish(from:)` no longer releases the source and now explicitly revokes the accepted capability so a later destination can't resolve it twice; early release could block the next tab drag.
- Clears residual drag capability from the session's actual pasteboard instead of a new drag pasteboard.
- New tab drags reclaim superseded native sources from older generations, which is safe because AppKit can't begin a new gesture while an older native session is still live.
- Regression tests verify source-side ownership survives an accepted drop, ends only after `finishDrag()`, and a new drag reclaims a superseded source.

<sup>Written for commit 0501fed692b23bf793b60b046caccc08332b3d0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

