### PR TITLE
Allow hosts to enable sole-tab Move Tab to New Workspace

### DIFF
--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -777,7 +777,10 @@ struct TabContextMenuState {
             canCloseToLeft: canCloseToLeft,
             canCloseToRight: canCloseToRight,
             canCloseOthers: canCloseOthers,
-            canMoveToNewWorkspace: controller.allTabIds.count > 1,
+            canMoveToNewWorkspace: controller.tabContextMoveToNewWorkspaceAvailabilityProvider?(
+                TabID(id: tab.id),
+                pane.id
+            ) ?? (controller.allTabIds.count > 1),
             canMoveToLeftPane: controller.adjacentPane(to: pane.id, direction: .left) != nil,
             canMoveToRightPane: controller.adjacentPane(to: pane.id, direction: .right) != nil,
             forkConversationDefaultAction: controller.tabContextForkConversationDefaultActionProvider?(TabID(id: tab.id), pane.id) ?? .defaultForkConversationDestination,

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -77,6 +77,12 @@ public final class BonsplitController {
     /// Host-provided destinations for the tab context menu's Move Tab submenu.
     @ObservationIgnored public var tabContextMoveDestinationsProvider: ((TabID, PaneID) -> [TabContextMoveDestination])?
 
+    /// Host-provided availability for the built-in Move Tab to New Workspace
+    /// action. When unset, Bonsplit keeps its default policy of requiring more
+    /// than one tab in the controller. Hosts whose container may become empty
+    /// (for example, a detachable Dock) can return `true` for the affected tab.
+    @ObservationIgnored public var tabContextMoveToNewWorkspaceAvailabilityProvider: ((TabID, PaneID) -> Bool)?
+
     /// Host-provided state evaluated when the tab context menu opens. Refreshing actions
     /// remain visible but disabled; hidden actions are omitted.
     @ObservationIgnored public var tabContextForkConversationAvailabilityProvider: ((TabID, PaneID) -> TabContextForkConversationAvailability)?

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2013,7 +2013,7 @@ final class BonsplitTests: XCTestCase {
     func testTabContextMenuMoveToNewWorkspaceUsesHostAvailabilityForSoleTab() throws {
         let controller = BonsplitController()
         let paneId = try XCTUnwrap(controller.focusedPaneId)
-        let tabId = try XCTUnwrap(controller.createTab(title: "Only tab", kind: "terminal"))
+        let tabId = try XCTUnwrap(controller.allTabIds.first)
         let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
         let tab = try XCTUnwrap(pane.tabs.first(where: { $0.id == tabId.id }))
 

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2010,6 +2010,36 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabContextMenuMoveToNewWorkspaceUsesHostAvailabilityForSoleTab() throws {
+        let controller = BonsplitController()
+        let paneId = try XCTUnwrap(controller.focusedPaneId)
+        let tabId = try XCTUnwrap(controller.createTab(title: "Only tab", kind: "terminal"))
+        let pane = try XCTUnwrap(controller.internalController.paneState(for: paneId))
+        let tab = try XCTUnwrap(pane.tabs.first(where: { $0.id == tabId.id }))
+
+        let defaultState = TabContextMenuState(
+            tab: tab,
+            index: 0,
+            pane: pane,
+            controller: controller,
+            splitViewController: controller.internalController
+        )
+        XCTAssertFalse(defaultState.canMoveToNewWorkspace)
+
+        controller.tabContextMoveToNewWorkspaceAvailabilityProvider = { requestedTab, requestedPane in
+            requestedTab == tabId && requestedPane == paneId
+        }
+        let hostEnabledState = TabContextMenuState(
+            tab: tab,
+            index: 0,
+            pane: pane,
+            controller: controller,
+            splitViewController: controller.internalController
+        )
+        XCTAssertTrue(hostEnabledState.canMoveToNewWorkspace)
+    }
+
+    @MainActor
     func testBrowserTabContextMenuCreatesAudioMuteToggle() throws {
         let target = TabContextMenuActionTarget()
         var selectedAction: TabContextAction?


### PR DESCRIPTION
## Summary

Add a host-provided availability hook for Bonsplit's built-in **Move Tab to New Workspace** context-menu action. The existing default (`allTabIds.count > 1`) remains unchanged, while detachable containers such as cmux's Dock can explicitly allow moving their final tab and leaving an empty pane.

This is stacked for cmux [#11191](https://github.com/manaflow-ai/cmux/issues/11191) / [cmux#11194](https://github.com/manaflow-ai/cmux/pull/11194), which needs the built-in Dock context-menu item to be enabled for a sole Dock tab.

## Changes

- Add `tabContextMoveToNewWorkspaceAvailabilityProvider` to `BonsplitController`.
- Use the provider when constructing tab context-menu state, with the existing multi-tab rule as the fallback.
- Add a regression test covering default behavior and host-enabled sole-tab behavior.

## Verification

`swift test --jobs 1 --filter BonsplitTests.testTabContextMenuMoveToNewWorkspaceUsesHostAvailabilityForSoleTab` builds the package and reaches the test bundle; this host's SwiftPM XCTest loader reports the pre-existing arm64/x86_64 bundle-architecture warning and executes zero XCTest cases. The focused source compiles successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790913707&installation_model_id=21920&pr_number=231&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F231&signature=45a1c62735f57c544b5b541e87ff14dc7515bd865f41a53002750f8203dbb58d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host-provided hook so containers like cmux's Dock can enable Move Tab to New Workspace for a sole tab. The default rule (only when more than one tab exists) is unchanged.

**Behavior**

- New `tabContextMoveToNewWorkspaceAvailabilityProvider` on `BonsplitController` lets hosts override the default availability.
- Unset providers fall back to the existing multi-tab rule.
- Adds a regression test covering default and host-enabled sole-tab behavior.

<sup>Written for commit bd9c06198d79a428cef6bca11da80eba9a159f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

