### PR TITLE
feat: cloud terminal detach/kill tab context actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `TabContextAction.detachCloudTerminal` / `.killCloudTerminal` and
+  `BonsplitController.tabContextCloudTerminalAvailabilityProvider`: hosts that project a
+  remote terminal into a tab can offer "Detach Terminal" and "Kill Process" in the tab
+  context menu, so closing the tab and ending the remote process are separate verbs.
 - `BonsplitConfiguration.Appearance.tabWidthMode` (`TabWidthMode`) to control tab sizing.
   - `.fixed` (default) keeps the historical fixed-width + horizontal-scroll layout unchanged.
   - `.fill` stretches tabs to fill the pane's available tab-bar width, distributing the

--- a/Sources/Bonsplit/Internal/Views/TabBarView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabBarView.swift
@@ -697,6 +697,7 @@ struct TabContextMenuState {
     let hasSplits: Bool
     let shortcuts: [TabContextAction: KeyboardShortcut]
     var canDisconnectRemote: Bool = false
+    var canDetachCloudTerminal: Bool = false
 
     var canMarkAsUnread: Bool {
         !isUnread
@@ -724,7 +725,8 @@ struct TabContextMenuState {
         isFullWidthTabMode: Bool = false,
         hasSplits: Bool,
         shortcuts: [TabContextAction: KeyboardShortcut],
-        canDisconnectRemote: Bool = false
+        canDisconnectRemote: Bool = false,
+        canDetachCloudTerminal: Bool = false
     ) {
         self.isPinned = isPinned
         self.isUnread = isUnread
@@ -744,6 +746,7 @@ struct TabContextMenuState {
         self.hasSplits = hasSplits
         self.shortcuts = shortcuts
         self.canDisconnectRemote = canDisconnectRemote
+        self.canDetachCloudTerminal = canDetachCloudTerminal
     }
 
     @MainActor
@@ -785,7 +788,8 @@ struct TabContextMenuState {
             isFullWidthTabMode: pane.isFullWidthTabMode,
             hasSplits: splitViewController.rootNode.allPaneIds.count > 1,
             shortcuts: controller.contextMenuShortcuts,
-            canDisconnectRemote: controller.tabContextDisconnectRemoteAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false
+            canDisconnectRemote: controller.tabContextDisconnectRemoteAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false,
+            canDetachCloudTerminal: controller.tabContextCloudTerminalAvailabilityProvider?(TabID(id: tab.id), pane.id) ?? false
         )
     }
 }

--- a/Sources/Bonsplit/Internal/Views/TabItemView.swift
+++ b/Sources/Bonsplit/Internal/Views/TabItemView.swift
@@ -1509,6 +1509,24 @@ enum TabContextMenuBuilder {
             )
         }
 
+        if state.canDetachCloudTerminal {
+            menu.addItem(.separator())
+            addAction(
+                title: localized("tabContext.detachCloudTerminal", defaultValue: "Detach Terminal"),
+                action: .detachCloudTerminal,
+                state: state,
+                target: target,
+                to: menu
+            )
+            addAction(
+                title: localized("tabContext.killCloudTerminal", defaultValue: "Kill Process"),
+                action: .killCloudTerminal,
+                state: state,
+                target: target,
+                to: menu
+            )
+        }
+
         menu.addItem(.separator())
 
         if state.hasSplits {
@@ -1766,7 +1784,9 @@ enum TabContextMenuBuilder {
              .markAsUnread,
              .toggleZoom,
              .toggleFullWidthTab,
-             .disconnectRemote:
+             .disconnectRemote,
+             .detachCloudTerminal,
+             .killCloudTerminal:
             assertionFailure("Non-fork action cannot be the default fork destination: \(action)")
             return localized(
                 "tabContext.forkConversation.default.right",

--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -97,6 +97,13 @@ public final class BonsplitController {
     /// the provider) to hide it.
     @ObservationIgnored public var tabContextDisconnectRemoteAvailabilityProvider: ((TabID, PaneID) -> Bool)?
 
+    /// Host-provided synchronous check that decides whether the tab context menu should
+    /// surface the cloud terminal pair "Detach Terminal" / "Kill Process" for the tab
+    /// (a terminal surface that projects a terminal running on a remote machine, where
+    /// closing the tab and ending the process are different things). Return `true` to
+    /// show both items, `false` (or omit the provider) to hide them.
+    @ObservationIgnored public var tabContextCloudTerminalAvailabilityProvider: ((TabID, PaneID) -> Bool)?
+
     /// Called when the user explicitly requests to close a tab from the tab strip UI.
     /// Internal host-driven closes should not use this hook.
     @ObservationIgnored public var onTabCloseRequest: ((_ tabId: TabID, _ paneId: PaneID, _ source: TabCloseRequestSource) -> Void)?

--- a/Sources/Bonsplit/Public/Types/TabContextAction.swift
+++ b/Sources/Bonsplit/Public/Types/TabContextAction.swift
@@ -30,6 +30,10 @@ public enum TabContextAction: String, CaseIterable, Sendable {
     case toggleZoom
     case toggleFullWidthTab
     case disconnectRemote
+    /// Close the local tab while the host keeps the remote terminal running.
+    case detachCloudTerminal
+    /// End the remote terminal's process on its machine, then close the tab.
+    case killCloudTerminal
     case forkConversation
     case forkConversationRight
     case forkConversationLeft

--- a/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/en.lproj/Localizable.strings
@@ -40,4 +40,6 @@
 "tabContext.forkConversation.newTab" = "New Tab";
 "tabContext.forkConversation.newWorkspace" = "New Workspace";
 "tabContext.disconnectRemote" = "Disconnect SSH";
+"tabContext.detachCloudTerminal" = "Detach Terminal";
+"tabContext.killCloudTerminal" = "Kill Process";
 "tabContext.remoteConnectedAccessibility" = "Connected over SSH";

--- a/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
+++ b/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings
@@ -40,4 +40,6 @@
 "tabContext.forkConversation.newTab" = "新規タブ";
 "tabContext.forkConversation.newWorkspace" = "新規ワークスペース";
 "tabContext.disconnectRemote" = "SSH接続を解除";
+"tabContext.detachCloudTerminal" = "ターミナルをデタッチ";
+"tabContext.killCloudTerminal" = "プロセスを終了";
 "tabContext.remoteConnectedAccessibility" = "SSH接続中";

--- a/Tests/BonsplitTests/BonsplitTests.swift
+++ b/Tests/BonsplitTests/BonsplitTests.swift
@@ -2393,6 +2393,60 @@ final class BonsplitTests: XCTestCase {
     }
 
     @MainActor
+    func testTabContextMenuShowsCloudTerminalActionsOnlyWhenAvailable() throws {
+        let target = TabContextMenuActionTarget()
+        var selectedActions: [TabContextAction] = []
+        target.onContextAction = { selectedActions.append($0) }
+        func makeState(canDetachCloudTerminal: Bool) -> TabContextMenuState {
+            TabContextMenuState(
+                isPinned: false,
+                isUnread: false,
+                isBrowser: false,
+                isAudioMuted: false,
+                isTerminal: true,
+                hasCustomTitle: false,
+                canCloseToLeft: false,
+                canCloseToRight: false,
+                canCloseOthers: false,
+                canMoveToNewWorkspace: false,
+                canMoveToLeftPane: false,
+                canMoveToRightPane: false,
+                forkConversationDefaultAction: .forkConversationRight,
+                isZoomed: false,
+                hasSplits: false,
+                shortcuts: [:],
+                canDetachCloudTerminal: canDetachCloudTerminal
+            )
+        }
+
+        let local = TabContextMenuBuilder.makeMenu(
+            snapshot: TabContextMenuSnapshot(
+                tabId: UUID(),
+                state: makeState(canDetachCloudTerminal: false),
+                moveDestinationsProvider: { [] },
+                forkConversationAvailabilityProvider: { .available }
+            ),
+            target: target
+        )
+        XCTAssertFalse(local.items.contains { $0.title == "Detach Terminal" || $0.title == "Kill Process" })
+
+        let cloud = TabContextMenuBuilder.makeMenu(
+            snapshot: TabContextMenuSnapshot(
+                tabId: UUID(),
+                state: makeState(canDetachCloudTerminal: true),
+                moveDestinationsProvider: { [] },
+                forkConversationAvailabilityProvider: { .available }
+            ),
+            target: target
+        )
+        let detachItem = try XCTUnwrap(cloud.items.first { $0.title == "Detach Terminal" })
+        let killItem = try XCTUnwrap(cloud.items.first { $0.title == "Kill Process" })
+        target.performContextAction(detachItem)
+        target.performContextAction(killItem)
+        XCTAssertEqual(selectedActions, [.detachCloudTerminal, .killCloudTerminal])
+    }
+
+    @MainActor
     func testDoubleClickingEmptyTrailingTabBarSpaceRequestsNewTerminalTab() {
         let appearance = BonsplitConfiguration.Appearance()
         let configuration = BonsplitConfiguration(appearance: appearance)


### PR DESCRIPTION
Adds `TabContextAction.detachCloudTerminal` / `.killCloudTerminal` and `BonsplitController.tabContextCloudTerminalAvailabilityProvider`, so a host that projects a remote terminal into a tab can offer "Detach Terminal" and "Kill Process" in the tab context menu. Closing the tab and ending the remote process become separate verbs. Consumed by the cmux PR for `app.closeCloudTerminal`.

https://claude.ai/code/session_01GQmDjyqqNB2WvycYdaM64v

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cloud terminal detach/kill actions to the tab context menu, so hosts can separate closing a tab from ending the remote process.

- Hosts opt in via `BonsplitController.tabContextCloudTerminalAvailabilityProvider`; omitting it keeps the menu unchanged.
- Adds `TabContextAction.detachCloudTerminal` and `.killCloudTerminal` for the "Detach Terminal" and "Kill Process" items.
- Consumed by the `cmux` PR for `app.closeCloudTerminal`.

<sup>Written for commit d024529ae12c35870dd0aa7de77f24f92154b252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Detach Terminal** and **Kill Process** actions to tab context menus for remote terminals.
  - Hosts can control when these actions appear, allowing users to close a tab without necessarily ending the remote process.

- **Localization**
  - Added English and Japanese translations for the new actions.

- **Tests**
  - Added coverage confirming the actions appear only when available and trigger the correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->