### PR TITLE
perf: add tabIds(inPane:) so callers stop building tabs to read ids

### DIFF
--- a/Sources/Bonsplit/Public/BonsplitController.swift
+++ b/Sources/Bonsplit/Public/BonsplitController.swift
@@ -927,6 +927,20 @@ public final class BonsplitController {
         return pane.tabs.map { Tab(from: $0) }
     }
 
+    /// Get the tab IDs in a specific pane, in tab order.
+    ///
+    /// Prefer this over `tabs(inPane:)` when only identity or ordering is
+    /// wanted. `Tab.init(from:)` copies all fourteen `TabItem` properties, so
+    /// a caller that asks for tabs to read their ids pays for thirteen fields
+    /// it discards, per tab, on every call. This reads the id and nothing
+    /// else.
+    public func tabIds(inPane paneId: PaneID) -> [TabID] {
+        guard let pane = internalController.paneState(for: paneId) else {
+            return []
+        }
+        return pane.tabs.map { TabID(id: $0.id) }
+    }
+
     /// Get the pane that currently owns a tab.
     ///
     /// This lookup is constant time and does not walk the split tree.

--- a/Tests/BonsplitTests/TabIdListingTests.swift
+++ b/Tests/BonsplitTests/TabIdListingTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Bonsplit
+
+/// `tabIds(inPane:)` exists so a caller that wants ordering or identity does
+/// not have to build a `Tab` per tab to get it. These pin it to the ordering
+/// `tabs(inPane:)` already produces, so the cheap call and the expensive one
+/// can never disagree.
+final class TabIdListingTests: XCTestCase {
+    @MainActor
+    func testTabIdsMatchTabsInOrderAcrossMovesAndCloses() {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(newTabPosition: .end)
+        )
+        let paneId = try! XCTUnwrap(controller.focusedPaneId)
+        let first = try! XCTUnwrap(controller.createTab(title: "First"))
+        let second = try! XCTUnwrap(controller.createTab(title: "Second"))
+
+        XCTAssertEqual(
+            controller.tabIds(inPane: paneId),
+            controller.tabs(inPane: paneId).map(\.id)
+        )
+        XCTAssertEqual(controller.tabIds(inPane: paneId).suffix(2), [first, second])
+
+        XCTAssertTrue(controller.moveTab(second, toPane: paneId, atIndex: 0))
+        XCTAssertEqual(controller.tabIds(inPane: paneId).first, second)
+        XCTAssertEqual(
+            controller.tabIds(inPane: paneId),
+            controller.tabs(inPane: paneId).map(\.id)
+        )
+
+        XCTAssertTrue(controller.closeTab(first))
+        XCTAssertFalse(controller.tabIds(inPane: paneId).contains(first))
+        XCTAssertEqual(
+            controller.tabIds(inPane: paneId),
+            controller.tabs(inPane: paneId).map(\.id)
+        )
+    }
+
+    /// A title write must not reorder or drop anything. The ids are the same
+    /// list before and after, which is the property callers depend on when
+    /// they stop reading titles they never wanted.
+    @MainActor
+    func testRenamingATabLeavesTheIdListingAlone() {
+        let controller = BonsplitController()
+        let paneId = try! XCTUnwrap(controller.focusedPaneId)
+        let tabId = try! XCTUnwrap(controller.createTab(title: "Before"))
+
+        let before = controller.tabIds(inPane: paneId)
+        controller.updateTab(tabId, title: "After")
+
+        XCTAssertEqual(controller.tabIds(inPane: paneId), before)
+        XCTAssertEqual(controller.tab(tabId)?.title, "After")
+    }
+
+    @MainActor
+    func testEmptyAndUnknownPanesListNoTabs() {
+        let controller = BonsplitController()
+        let originalPaneId = try! XCTUnwrap(controller.focusedPaneId)
+        let emptyPaneId = try! XCTUnwrap(
+            controller.splitPane(originalPaneId, orientation: .vertical)
+        )
+
+        XCTAssertEqual(controller.tabIds(inPane: emptyPaneId), [])
+        XCTAssertEqual(controller.tabIds(inPane: PaneID()), [])
+    }
+}


### PR DESCRIPTION
## Summary

Adds `tabIds(inPane:)` for callers that want identity or ordering and nothing else.

`tabs(inPane:)` builds a `Tab` per tab, and `Tab.init(from:)` copies all fourteen `TabItem` properties. A caller asking for tabs so it can read their ids pays for thirteen fields it discards, per tab, on every call. One of those copied fields is the tab title, so a caller reading ids inside a SwiftUI view body ends up observing titles it never looks at, and re-renders whenever one changes.

```swift
public func tabIds(inPane paneId: PaneID) -> [TabID] {
    guard let pane = internalController.paneState(for: paneId) else {
        return []
    }
    return pane.tabs.map { TabID(id: $0.id) }
}
```

## Tests

`TabIdListingTests` pins the new call to the ordering `tabs(inPane:)` already produces, across moves and closes, so the cheap call and the expensive one cannot disagree. An empty or unknown pane returns `[]`, matching `tabs(inPane:)`.

## Why now

cmux's `Workspace.sidebarOrderedPanelIds()` is the caller that motivated it. It asks for tabs purely to collect ids, from inside sidebar view bodies, so an animating tab title invalidates the sidebar for an ordering that never looks at a title. The cmux-side change depends on this method, so this lands first.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791221249&installation_model_id=21920&pr_number=233&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F233&signature=b6c36b6175854fa1073360d702c3e9c664169ec66374b5052fc74b1b9be720aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tabIds(inPane:)` so callers can read tab ordering or identity without building full `Tab` objects. The old `tabs(inPane:)` path copied all fourteen `TabItem` fields per tab, including titles, which caused SwiftUI views that only needed IDs to re-render on title changes they never read.

**New Features**
- `tabIds(inPane:)` returns tab IDs in tab order and reads nothing else.
- Empty or unknown panes return `[]`, matching `tabs(inPane:)`.
- New tests pin the ID ordering to `tabs(inPane:)` across moves, closes, and renames so the cheap call and the expensive one cannot disagree.

<sup>Written for commit 156fc9c0d07791c7c40548db5f88b7a09ca2d856. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public query to retrieve tab identifiers in their pane order.
  - Unknown or empty panes return an empty list.

- **Tests**
  - Added coverage for tab ordering and consistency after creating, moving, closing, and renaming tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->