### PR TITLE
fix: notify pane targets when native tab drags end

### DIFF
--- a/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
+++ b/Sources/Bonsplit/Internal/Controllers/TabDragSessionSource.swift
@@ -62,7 +62,7 @@ final class TabDragSessionSource: NSObject, NSDraggingSource {
     func finishDrag() {
         guard !didFinish else { return }
         didFinish = true
-        transferRegistry.end(transferRegistration)
+        transferRegistry.endNativeDrag(transferRegistration)
         controller?.nativeTabDragSessionDidEnd(generation: generation)
         sourceView = nil
     }

--- a/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
+++ b/Sources/Bonsplit/Public/TabDragTransferRegistry.swift
@@ -21,9 +21,22 @@ public final class TabDragTransferRegistry {
     }
 
     private var transfers: [UUID: Entry] = [:]
+    private var nativeDragEndObservers: [UUID: () -> Void] = [:]
 
     /// Creates an empty capability registry.
     public init() {}
+
+    /// Registers a callback for the terminal transition of a native drag.
+    @discardableResult
+    public func addNativeDragEndObserver(_ observer: @escaping () -> Void) -> UUID {
+        let observerID = UUID()
+        nativeDragEndObservers[observerID] = observer
+        return observerID
+    }
+
+    public func removeNativeDragEndObserver(_ observerID: UUID) {
+        nativeDragEndObservers[observerID] = nil
+    }
 
     /// Registers metadata and creates an opaque capability lease for a drag source.
     ///
@@ -79,12 +92,24 @@ public final class TabDragTransferRegistry {
         transfers[registration.token] = nil
     }
 
+    /// Ends a native drag and notifies observers after revoking its capability.
+    public func endNativeDrag(_ registration: TabDragTransferRegistration) {
+        end(registration)
+        notifyNativeDragEnded()
+    }
+
     /// Revokes the capability currently written to a completed drag pasteboard.
     ///
     /// - Parameter pasteboard: The pasteboard owned by the completed dragging session.
     public func end(from pasteboard: NSPasteboard) {
         guard let token = token(from: pasteboard) else { return }
         transfers[token] = nil
+    }
+
+    /// Ends a native drag represented by a pasteboard and notifies observers.
+    public func endNativeDrag(from pasteboard: NSPasteboard) {
+        end(from: pasteboard)
+        notifyNativeDragEnded()
     }
 
     /// Revokes routing for the capability represented by an accepted drop.
@@ -163,5 +188,11 @@ public final class TabDragTransferRegistry {
 
     private func compactReleasedRegistrations() {
         transfers = transfers.filter { $0.value.lifetime != nil }
+    }
+
+    private func notifyNativeDragEnded() {
+        for observer in Array(nativeDragEndObservers.values) {
+            observer()
+        }
     }
 }


### PR DESCRIPTION
Fixes the native drag lifecycle signal needed by cmux issue #11156.

- Adds observer registration to the shared transfer registry.
- Distinguishes native drag termination from accepted-drop routing revocation.
- Keeps terminal source completion as the authoritative notification point.

Parent cmux branch: issue-11156-tab-tearout-split

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791293251&installation_model_id=21920&pr_number=234&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F234&signature=336a65300e8863e5e54c1c976b0b03d4b619ff61918a8e8259f95baf93061974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native tab drag termination so pane targets are notified when a drag ends, addressing issue #11156. Adds observer registration to the shared transfer registry and separates native drag termination from accepted-drop routing revocation; terminal source completion remains the authoritative notification point.

<sup>Written for commit b200a59ea24c37c55a0639e006ea5af346b238f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

