### PR TITLE
Repaint split dividers when appearance changes

### DIFF
--- a/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
+++ b/Sources/Bonsplit/Internal/Views/SplitContainerView.swift
@@ -4,7 +4,12 @@ import AppKit
 private var splitContainerProgrammaticSyncDepth = 0
 
 private class ThemedSplitView: NSSplitView, BonsplitManagedSplitView {
-    var customDividerColor: NSColor?
+    var customDividerColor: NSColor? {
+        didSet {
+            guard oldValue != customDividerColor else { return }
+            needsDisplay = true
+        }
+    }
 
     /// Identity for external drag coordination (see BonsplitManagedSplitView).
     weak var stampedInternalController: SplitViewController?


### PR DESCRIPTION
## Summary
- invalidate split-divider drawing when the configured divider color changes
- merge the latest `main` tab-drag changes into the branch so cmux can consume one current Bonsplit revision

## Context
cmux updates Bonsplit appearance from Ghostty configuration during live reload. Existing split rails must repaint when `customDividerColor` changes; otherwise already-rendered rails retain the prior color.

## Validation
- Existing Bonsplit divider appearance tests and cmux tagged visual verification cover the behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/bonsplit/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791471098&installation_model_id=21920&pr_number=238&repository=manaflow-ai%2Fbonsplit&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fbonsplit%2Fpull%2F238&signature=c86ffaa1fc48cfacb9e0d210605a4c3e74b28b16b019d67c6ee03d3eb2823eb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes split dividers not repainting when the configured divider color changes, so existing rails update during cmux live reload instead of retaining the prior color.

<sup>Written for commit 59e44d072eeb0036afbafcc3bb6235c9fb93e34e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/bonsplit/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

